### PR TITLE
Add CoreFX subscriptions for ProjectK TFS build

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -59,7 +59,7 @@
     {
       "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
       "handlers": [
-        // This handler will bring the Latest CoreFX master build into CorefX master
+        // This handler will bring the Latest CoreFX master build into CoreFX master
         {
           "maestroAction": "corefx-general",
           "maestroDelay": "00:10:00",
@@ -69,7 +69,55 @@
             "-GitHubEmail dotnet-bot@microsoft.com",
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/master/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'"
+            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
+            "-DirPropsVersionElement 'CoreFxExpectedPrerelease"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest ProjectK TFS master build into CoreFX master for CoreCLR dependencies
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "UpdateDependencies.ps1",
+          "Arguments": [
+            "-GitHubUser dotnet-bot",
+            "-GitHubEmail dotnet-bot@microsoft.com",
+            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
+            "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
+            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
+            "-DirPropsVersionElement 'CoreClrExpectedPrerelease"
+          ]
+        },
+        // This handler will bring the Latest ProjectK TFS master build into CoreFX master for CoreLib targeting pack dependencies
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "UpdateDependencies.ps1",
+          "Arguments": [
+            "-GitHubUser dotnet-bot",
+            "-GitHubEmail dotnet-bot@microsoft.com",
+            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
+            "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
+            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
+            "-DirPropsVersionElement 'CoreLibTargetingPackExpectedPrerelease"
+          ]
+        },
+        // This handler will bring the Latest ProjectK TFS master build into CoreFX master for TFS-side CoreFX dependencies
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "UpdateDependencies.ps1",
+          "Arguments": [
+            "-GitHubUser dotnet-bot",
+            "-GitHubEmail dotnet-bot@microsoft.com",
+            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
+            "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
+            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
+            "-DirPropsVersionElement 'ExternalExpectedPrerelease"
           ]
         }
       ]

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -69,8 +69,8 @@
             "-GitHubEmail dotnet-bot@microsoft.com",
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/master/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
-            "-DirPropsVersionElement 'CoreFxExpectedPrerelease"
+            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
+            "-DirPropsVersionElements CoreFxExpectedPrerelease"
           ]
         }
       ]
@@ -78,7 +78,7 @@
     {
       "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
       "handlers": [
-        // This handler will bring the Latest ProjectK TFS master build into CoreFX master for CoreCLR dependencies
+        // This handler will bring the Latest ProjectK TFS master build into CoreFX master
         {
           "maestroAction": "corefx-general",
           "maestroDelay": "00:10:00",
@@ -88,36 +88,8 @@
             "-GitHubEmail dotnet-bot@microsoft.com",
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
-            "-DirPropsVersionElement 'CoreClrExpectedPrerelease"
-          ]
-        },
-        // This handler will bring the Latest ProjectK TFS master build into CoreFX master for CoreLib targeting pack dependencies
-        {
-          "maestroAction": "corefx-general",
-          "maestroDelay": "00:10:00",
-          "ScriptFileName": "UpdateDependencies.ps1",
-          "Arguments": [
-            "-GitHubUser dotnet-bot",
-            "-GitHubEmail dotnet-bot@microsoft.com",
-            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
-            "-DirPropsVersionElement 'CoreLibTargetingPackExpectedPrerelease"
-          ]
-        },
-        // This handler will bring the Latest ProjectK TFS master build into CoreFX master for TFS-side CoreFX dependencies
-        {
-          "maestroAction": "corefx-general",
-          "maestroDelay": "00:10:00",
-          "ScriptFileName": "UpdateDependencies.ps1",
-          "Arguments": [
-            "-GitHubUser dotnet-bot",
-            "-GitHubEmail dotnet-bot@microsoft.com",
-            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-CoreFxVersionUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib",
-            "-DirPropsVersionElement 'ExternalExpectedPrerelease"
+            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
+            "-DirPropsVersionElements CoreClrExpectedPrerelease, ExternalExpectedPrerelease"
           ]
         }
       ]


### PR DESCRIPTION
Adds a subscription that updates the new dependency version categories that will be created in https://github.com/dotnet/corefx/pull/8999.

~~It's a bit repetitive. `UpdateDependencies.ps1` could be updated to allow for an array of elements to update, but doing it this way makes it easier to split them off later.~~ (Added array support.)

/cc @eerhardt @weshaggard