### PR TITLE
Added subscription to trigger building dotnet-preview Docker image

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -24,6 +24,12 @@
       "vsoProject": "DevDiv",
       "buildDefinitionId": 808
     }
+    // A build definition that will trigger the dotnet-preview Docker image build in Docker Hub
+    "build-dotnet-docker-preview": {
+      "vsoInstance": "mseng.visualstudio.com",
+      "vsoProject": "dotnetcore",
+      "buildDefinitionId": 3590
+    }
   },
   "subscriptions": [
     {
@@ -80,6 +86,16 @@
         // This handler will bring the core-setup build into CLI
         {
           "maestroAction": "cli-dependencies",
+          "maestroDelay": "00:05:00"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/rel/1.0.0/Latest_Packages.txt",
+      "handlers": [
+        // This handler will produce a new dotnet-preview Docker image for the latest CLI
+        {
+          "maestroAction": "build-dotnet-docker-preview",
           "maestroDelay": "00:05:00"
         }
       ]


### PR DESCRIPTION
This happens whenever a new CLI build is completed.  The referenced build definition simply makes the appropriate http put request to Docker Hub that will trigger the build.  Maybe at some time in the future Maestro will have support for this type of action rather than needing to use a VSO build definition.

@eerhardt - not sure how to test this change.  Please advise.