### PR TITLE
Update Roslyn versions

### DIFF
--- a/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt
+++ b/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt
@@ -1,4 +1,5 @@
 Microsoft.CodeAnalysis.Common 1.3.0-beta1-20160602-01
+Microsoft.CodeAnalysis.Workspaces.Common 1.3.0-beta1-20160602-01
 Microsoft.CodeAnalysis.CSharp 1.3.0-beta1-20160602-01
 Microsoft.CodeAnalysis.CSharp.Workspaces 1.3.0-beta1-20160602-01
 Microsoft.CodeAnalysis.VisualBasic 1.3.0-beta1-20160602-01

--- a/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt
+++ b/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt
@@ -1,4 +1,7 @@
-Microsoft.CodeAnalysis.CSharp 1.3.0-beta1-20160525-03
-Microsoft.CodeAnalysis.CSharp.Workspaces 1.3.0-beta1-20160525-03
-Microsoft.CodeAnalysis.VisualBasic 1.3.0-beta1-20160525-03
-Microsoft.Net.Compilers.netcore 1.3.0-beta1-20160525-03
+Microsoft.CodeAnalysis.Common 1.3.0-beta1-20160602-01
+Microsoft.CodeAnalysis.CSharp 1.3.0-beta1-20160602-01
+Microsoft.CodeAnalysis.CSharp.Workspaces 1.3.0-beta1-20160602-01
+Microsoft.CodeAnalysis.VisualBasic 1.3.0-beta1-20160602-01
+Microsoft.CodeAnalysis.VisualBasic.Workspaces 1.3.0-beta1-20160602-01
+Microsoft.CodeAnalysis.Compilers 1.3.0-beta1-20160602-01
+Microsoft.Net.Compilers.netcore 1.3.0-beta1-20160602-01


### PR DESCRIPTION
Update Roslyn NuGet versions to 1.3.0-beta1-20160602-01.