### PR TITLE
Fix VersionFileUrl parameters to get raw github content

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -98,7 +98,7 @@
             "-GitHubUser dotnet-bot",
             "-GitHubEmail dotnet-bot@microsoft.com",
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-VersionFileUrl https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
             "-GitHubUpstreamBranch 'release/1.0.0'",
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements ExternalExpectedPrerelease"
@@ -113,7 +113,7 @@
             "-GitHubUser dotnet-bot",
             "-GitHubEmail dotnet-bot@microsoft.com",
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-VersionFileUrl https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
             "-GitHubUpstreamBranch 'release/1.0.0'",
             "-GitHubPullRequestNotifications 'dotnet/coreclr-contrib'",
             "-DirPropsVersionElements ExternalExpectedPrerelease"
@@ -133,7 +133,7 @@
             "-GitHubUser dotnet-bot",
             "-GitHubEmail dotnet-bot@microsoft.com",
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-VersionFileUrl https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
             "-GitHubUpstreamBranch 'release/1.0.0'",
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements CoreClrExpectedPrerelease"


### PR DESCRIPTION
With the non-raw GitHub url, the update script was adding random HTML into `dir.props`, which fails the auto-PR build. This only happened for recent release builds because when I made those I copy-pasted the subscription `path` into the `VersionFileUrl` parameter without spotting that critical difference.

Fixes https://github.com/dotnet/versions/issues/24, although we should still stop doing native builds in the auto-update build just because it's unnecessary.

/cc @jhendrixMSFT @eerhardt @joshfree 