### PR TITLE
Updated dotnet-preview Docker handler 

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -148,7 +148,7 @@
       ]
     },
     {
-      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/rel/1.0.0/Latest_Packages.txt",
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/rel/1.0.0-preview2/Latest_Packages.txt",
       "handlers": [
         // This handler will produce a new dotnet-preview Docker image for the latest CLI
         {


### PR DESCRIPTION
Updated dotnet-preview Docker handler to be triggered off of the 1.0.0-preview2 branch

@eerhardt