### PR TITLE
Keep projectk-tfs -> coreclr auto-updates enabled

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -138,6 +138,20 @@
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements ExternalExpectedPrerelease"
           ]
+        },
+        // This handler will bring the Latest ProjectK TFS master build into CoreCLR master
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "UpdateDependencies.ps1",
+          "Arguments": [
+            "-GitHubUser dotnet-bot",
+            "-GitHubEmail dotnet-bot@microsoft.com",
+            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
+            "-GitHubPullRequestNotifications 'dotnet/coreclr-contrib'",
+            "-DirPropsVersionElements ExternalExpectedPrerelease"
+          ]
         }
       ]
     },


### PR DESCRIPTION
Reverts the projectk-tfs part of https://github.com/dotnet/versions/pull/43 to keep coreclr updated.

/cc @eerhardt @gkhanna79 