### PR TITLE
Add coreclr->corefx 1.0.0 subscription; clean up unnecessary defs

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -6,23 +6,11 @@
       "vsoProject": "DevDiv",
       "buildDefinitionId": 1084
     },
-    // A build definition capable of running any .ps1 script in the CoreFX repo release/1.0.0 branch
-    "corefx-general-release": {
-      "vsoInstance": "devdiv.visualstudio.com",
-      "vsoProject": "DevDiv",
-      "buildDefinitionId": 1990
-    },
-    // A build definition capable of running any .ps1 script in the CoreCLR repo master branch
+    // A build definition capable of running any .ps1 script in the CoreCLR repo. By default, the master branch.
     "coreclr-general": {
       "vsoInstance": "devdiv.visualstudio.com",
       "vsoProject": "DevDiv",
       "buildDefinitionId": 2249
-    },
-    // A build definition capable of running any .ps1 script in the CoreCLR repo release/1.0.0 branch
-    "coreclr-general-release": {
-      "vsoInstance": "devdiv.visualstudio.com",
-      "vsoProject": "DevDiv",
-      "buildDefinitionId": 2250
     },
     // A build definition capable of running any .ps1 script in the core-setup repo
     "core-setup-general": {
@@ -190,6 +178,27 @@
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-GitHubUpstreamBranch dev/api",
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/master/Latest.txt",
+            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
+            "-DirPropsVersionElements CoreClrExpectedPrerelease"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreCLR release/1.0.0 build into CoreFX release/1.0.0
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.0.0",
+          "ScriptFileName": "UpdateDependencies.ps1",
+          "Arguments": [
+            "-GitHubUser dotnet-bot",
+            "-GitHubEmail dotnet-bot@microsoft.com",
+            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
+            "-GitHubUpstreamBranch release/1.0.0",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements CoreClrExpectedPrerelease"
           ]


### PR DESCRIPTION
Now that `vsoSourceBranch` exists, the extra per-branch definitions aren't needed.

/cc @eerhardt @gkhanna79 