### PR TITLE
Escape quotes after /p:NotifyGitHubUsers= to avoid powershell arg behavior

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -93,7 +93,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=\"dotnet/corefx-contrib\""
+            "/p:NotifyGitHubUsers=`\"dotnet/corefx-contrib`\""
           ]
         }
       ]
@@ -136,7 +136,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=\"dotnet/corefx-contrib\""
+            "/p:NotifyGitHubUsers=`\"dotnet/corefx-contrib`\""
           ]
         },
         // This handler will bring the Latest ProjectK TFS master build into CoreFX dev/api
@@ -225,7 +225,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=\"dotnet/corefx-contrib\""
+            "/p:NotifyGitHubUsers=`\"dotnet/corefx-contrib`\""
           ]
         },
         // This handler will bring the Latest CoreCLR master build into CoreFX dev/api


### PR DESCRIPTION
Without this it ends up calling:

    [VSTS inline script].ps1 ... -Arguments "-- ... /p:NotifyGitHubUsers="dotnet/corefx-contrib""

This ignores the "extra" stuff after what it sees as the closing `"` after `=`. I'm not sure what powershell is doing with it that makes this not a syntax error. Escaping the `"` makes it not close the string.

Does this look right, @eerhardt?

I want to keep the quotes because this can become a list by adding `;` and I don't want someone else to potentially have to figure it out later.