### PR TITLE
Disable projectk-tfs release/1.0.0 (KRel) -> CoreFX release/1.0.0 auto-upgrade

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -174,22 +174,6 @@
     {
       "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
       "handlers": [
-        // This handler will bring the Latest ProjectKRel (projectk-tfs/release/1.0.0) build into CoreFX release/1.0.0
-        {
-          "maestroAction": "corefx-general",
-          "maestroDelay": "00:10:00",
-          "vsoSourceBranch": "release/1.0.0",
-          "ScriptFileName": "UpdateDependencies.ps1",
-          "Arguments": [
-            "-GitHubUser dotnet-bot",
-            "-GitHubEmail dotnet-bot@microsoft.com",
-            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-GitHubUpstreamBranch release/1.0.0",
-            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
-            "-DirPropsVersionElements ExternalExpectedPrerelease"
-          ]
-        },
         // This handler will bring the Latest ProjectKRel (projectk-tfs/release/1.0.0) build into CoreCLR release/1.0.0
         {
           "maestroAction": "coreclr-general",


### PR DESCRIPTION
@gkhanna79 This disables PRs like https://github.com/dotnet/corefx/pull/10663, which are unnecessary right now and fail.

If we start servicing any External packages that need to be referenced in CoreFX, this PR can be reverted.