### PR TITLE
Remove quotes from NotifyGitHubUsers to avoid excessive escaping

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -93,7 +93,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=`\"dotnet/corefx-contrib`\""
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
           ]
         }
       ]
@@ -136,7 +136,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=`\"dotnet/corefx-contrib`\""
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
           ]
         },
         // This handler will bring the Latest ProjectK TFS master build into CoreFX dev/api
@@ -209,7 +209,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=`\"dotnet/corefx-contrib`\""
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
           ]
         },
         // This handler will bring the Latest CoreCLR master build into CoreFX dev/api


### PR DESCRIPTION
There's no need to notify multiple users, so this removes my earlier attempt to escape `"`'s to make it possible. If we want to notify multiple users later, it can be done in the `dir.props` of the respective repo along with the upgrade config. It could be done with a bunch of escaping but it's overly confusing.

See https://github.com/dotnet/versions/pull/50 for details about the escaping problem. (cc @eerhardt @jaredpar)