### PR TITLE
Use new update command in coreclr; add corefx, coreclr subscriptions

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -95,6 +95,25 @@
             "/p:ProjectRepoBranch=master",
             "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
           ]
+        },
+        // This handler will bring the Latest CoreFX master build into CoreCLR master
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "run.cmd",
+          "Arguments": [
+            "build",
+            "-Project=tests\\build.proj",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib"
+          ]
         }
       ]
     },
@@ -159,14 +178,19 @@
         {
           "maestroAction": "coreclr-general",
           "maestroDelay": "00:10:00",
-          "ScriptFileName": "UpdateDependencies.ps1",
+          "ScriptFileName": "run.cmd",
           "Arguments": [
-            "-GitHubUser dotnet-bot",
-            "-GitHubEmail dotnet-bot@microsoft.com",
-            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/coreclr-contrib'",
-            "-DirPropsVersionElements ExternalExpectedPrerelease"
+            "build",
+            "-Project=tests\\build.proj",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib"
           ]
         }
       ]
@@ -226,6 +250,25 @@
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/master/Latest.txt",
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements CoreClrExpectedPrerelease"
+          ]
+        },
+        // This handler will bring the Latest CoreCLR master build into CoreCLR master
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "run.cmd",
+          "Arguments": [
+            "build",
+            "-Project=tests\\build.proj",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib"
           ]
         }
       ]


### PR DESCRIPTION
Accompanies https://github.com/dotnet/coreclr/pull/6664, will merge this after.

`run.cmd build -Project=tests\build.proj -- /t:UpdateDependenciesAndSubmitPullRequest ...` is now used to update coreclr dependencies.

Adds back the CoreCLR and CoreFX dependency updates because now they'll update a single PR when possible instead of sending a flood of them.

@gkhanna79 @wtgodbe @eerhardt 

FYI, @jkotas, that these upgrades will start happening. (I thought you might be interested since you raised the concern about the PR flood a while back.)