### PR TITLE
Use UpdateDependencies target for corefx dev/api subscriptions

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -109,7 +109,7 @@
           "ScriptFileName": "build-managed.cmd",
           "Arguments": [
             "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/t:UpdateDependencies",
             "/p:GitHubUser=dotnet-bot",
             "/p:GitHubEmail=dotnet-bot@microsoft.com",
             "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
@@ -149,7 +149,7 @@
           "ScriptFileName": "build-managed.cmd",
           "Arguments": [
             "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/t:UpdateDependencies",
             "/p:GitHubUser=dotnet-bot",
             "/p:GitHubEmail=dotnet-bot@microsoft.com",
             "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
@@ -224,7 +224,7 @@
           "ScriptFileName": "build-managed.cmd",
           "Arguments": [
             "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/t:UpdateDependencies",
             "/p:GitHubUser=dotnet-bot",
             "/p:GitHubEmail=dotnet-bot@microsoft.com",
             "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",


### PR DESCRIPTION
`UpdateDependencies` is the name of the target in the BuildTools version dev/api is using. It later got renamed `UpdateDependenciesAndSubmitPullRequest`, and I'd assumed dev/api took that version.

/cc @weshaggard @joperezr 