### PR TITLE
Surround tests\build.proj for coreclr auto-upgrade with single quotes

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -103,7 +103,7 @@
           "ScriptFileName": "run.cmd",
           "Arguments": [
             "build",
-            "-Project=tests\\build.proj",
+            "-Project='tests\\build.proj'",
             "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-bot",
@@ -185,7 +185,7 @@
           "ScriptFileName": "run.cmd",
           "Arguments": [
             "build",
-            "-Project=tests\\build.proj",
+            "-Project='tests\\build.proj'",
             "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-bot",
@@ -265,7 +265,7 @@
           "ScriptFileName": "run.cmd",
           "Arguments": [
             "build",
-            "-Project=tests\\build.proj",
+            "-Project='tests\\build.proj'",
             "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-bot",


### PR DESCRIPTION
This avoids powershell argument parsing behavior where in `-Project=tests\build.proj`, `-Project=tests\build` is considered the argument name and `.proj` is considered a separate argument. The result was a space "appearing" in the list of args when the command is executed.

This behavior is visible in the coloring shown in the powershell console: names are gray and args are white. Quoting seems to make powershell treat the entire `-Project='tests\build.proj'` string as a single argument (white).

Fixes errors like in [this build](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build/index?buildId=301219&_a=summary): "Error: Parameter not recognized: .proj.", and coreclr auto-upgrade should start working.

(This is only a problem when running from powershell, not a cmd terminal. `"` also works, but \` doesn't.)

/cc @eerhardt @weshaggard 