### PR TITLE
Remove projectk-tfs NETNative targeting pack: moving to projectn-tfs

### DIFF
--- a/build-info/dotnet/projectk-tfs/master/Latest_Packages.txt
+++ b/build-info/dotnet/projectk-tfs/master/Latest_Packages.txt
@@ -2,7 +2,6 @@ Microsoft.Cci 4.0.0-beta-24430-00
 Microsoft.NETCore.Portable.Compatibility 1.0.3-beta-24430-00
 Microsoft.NETCore.Windows.ApiSets 1.0.2-beta-24430-00
 Microsoft.Private.Intellisense 1.0.0-beta-24430-00
-Microsoft.TargetingPack.Private.NETNative 1.0.1-beta-24430-00
 runtime.win10-arm-aot.runtime.native.System.IO.Compression 4.3.0-beta-24430-00
 runtime.win10-arm64-aot.runtime.native.System.IO.Compression 4.3.0-beta-24430-00
 runtime.win10-arm64.runtime.native.System.Data.SqlClient.sni 4.3.0-beta-24430-00


### PR DESCRIPTION
Remove projectk-tfs version of the NETNative targeting pack. Follows up on https://github.com/dotnet/versions/pull/60. I thought I would want to order this PR later, but it turns out it's more helpful to do it now.

(This package won't be in projectk-tfs in the next build, this manual change just unblocks some PRs.)

/cc @SedarG @eerhardt 