### PR TITLE
Override Run.cmd verbosity to Normal to see logged messages

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -99,7 +99,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
           ]
         },
         // This handler will bring the Latest CoreFX master build into CoreCLR master
@@ -118,7 +119,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib"
+            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
+            "/verbosity:Normal"
           ]
         }
       ]
@@ -141,7 +143,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=dev/api",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
           ]
         }
       ]
@@ -163,7 +166,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
           ]
         },
         // This handler will bring the Latest ProjectK TFS master build into CoreFX dev/api
@@ -181,7 +185,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=dev/api",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
           ]
         },
         // This handler will bring the Latest ProjectK TFS master build into CoreCLR master
@@ -200,7 +205,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib"
+            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
+            "/verbosity:Normal"
           ]
         }
       ]
@@ -223,7 +229,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=dev/api",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
           ]
         }
       ]
@@ -266,7 +273,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
           ]
         },
         // This handler will bring the Latest CoreCLR master build into CoreFX dev/api
@@ -284,7 +292,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=dev/api",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib"
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
           ]
         },
         // This handler will bring the Latest CoreCLR master build into CoreCLR master
@@ -303,7 +312,8 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib"
+            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
+            "/verbosity:Normal"
           ]
         }
       ]


### PR DESCRIPTION
The default verbosity is Minimal, which hides most messages and makes it hard to debug a failure in a Maestro-triggered build.

/cc @eerhardt @weshaggard 