### PR TITLE
Verify payload signatures from webhooks

### DIFF
--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Controllers/CommitPushedController.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Controllers/CommitPushedController.cs
@@ -20,6 +20,7 @@ namespace Microsoft.DotNet.Maestro.WebApi.Controllers
         private EventRegistrationTable _eventService = new EventRegistrationTable();
         private AzureStorageService _storageService = new AzureStorageService();
 
+        [VerifyPayloadSignature]
         public async Task Post(PushWebHookEvent e)
         {
             Trace.TraceInformation($"CommitPushed Started: {e}");

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Microsoft.DotNet.Maestro.WebApi.csproj
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Microsoft.DotNet.Maestro.WebApi.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\AzureStorageService.cs" />
     <Compile Include="Services\EventRegistrationTable.cs" />
+    <Compile Include="Services\VerifyPayloadSignatureAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Global.asax" />

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Services/VerifyPayloadSignatureAttribute.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Services/VerifyPayloadSignatureAttribute.cs
@@ -1,0 +1,128 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+
+namespace Microsoft.DotNet.Maestro.WebApi.Services
+{
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true)]
+    public class VerifyPayloadSignatureAttribute : FilterAttribute, IAuthorizationFilter
+    {
+        private const string SignatureHeaderName = "X-Hub-Signature";
+
+        public async Task<HttpResponseMessage> ExecuteAuthorizationFilterAsync(
+            HttpActionContext actionContext,
+            CancellationToken cancellationToken,
+            Func<Task<HttpResponseMessage>> continuation)
+        {
+            using (Task<byte[]> getRequestContentTask = actionContext.Request.Content.ReadAsByteArrayAsync())
+            {
+                try
+                {
+                    string payloadSignature = GetPayloadSignature(actionContext.Request);
+                    string computedHash = ComputeHashHexDigest(await getRequestContentTask);
+
+                    if (!CryptographicEquals(payloadSignature, computedHash))
+                    {
+                        Trace.TraceWarning("Signature validation failed.  Payload signature: " +
+                            $"{payloadSignature}; computed hash: {computedHash}");
+
+                        throw new Exception($"The payload signature specified by the {SignatureHeaderName} " +
+                            "header does not match the hash computed from the request.  This could indicate " +
+                            "that the repo's Maestro webhook has an incorrect Secret, the request came from " +
+                            "an unauthorized source, or the request was corrupted.");
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Trace.TraceError(ex.Message);
+
+                    actionContext.Response = actionContext.Request.CreateErrorResponse(
+                        HttpStatusCode.Unauthorized,
+                        ex.Message);
+                }
+            }
+
+            if (actionContext.Response != null)
+            {
+                return actionContext.Response;
+            }
+            else
+            {
+                return await continuation();
+            }
+        }
+
+        private string GetPayloadSignature(HttpRequestMessage request)
+        {
+            IEnumerable<string> headerValues;
+            string requestXHubSignature = string.Empty;
+            if (request.Headers.TryGetValues(SignatureHeaderName, out headerValues))
+            {
+                requestXHubSignature = headerValues.FirstOrDefault();
+            }
+
+            if (string.IsNullOrWhiteSpace(requestXHubSignature) || !requestXHubSignature.StartsWith("sha1="))
+            {
+                throw new Exception($"The HTTP request does not contain a valid {SignatureHeaderName} " +
+                    "header.  Verify that the repo's Maestro webhook is configured with a Secret.");
+            }
+
+            return requestXHubSignature.Substring(5).ToUpper();
+        }
+
+        private string ComputeHashHexDigest(byte[] requestContent)
+        {
+            byte[] hmacKey = Encoding.UTF8.GetBytes(Config.Instance.WebhookSecretToken);
+
+            using (HMACSHA1 hmac = new HMACSHA1(hmacKey))
+            {
+                byte[] computedHash = hmac.ComputeHash(requestContent);
+                return BitConverter.ToString(computedHash).Replace("-", string.Empty);
+            }
+        }
+
+        // Test two strings for equality using a constant-time algorithm such that the execution time varies
+        // only on the length of the data, not the contents thereof, to prevent timing attacks. This method
+        // assumes that the strings are indexable (as all ASCII strings are).
+        [MethodImpl(MethodImplOptions.NoInlining | MethodImplOptions.NoOptimization)]
+        private static bool CryptographicEquals(string a, string b)
+        {
+            int result = 0;
+
+            // Short cut if the lengths are not identical
+            if (a.Length != b.Length)
+            {
+                return false;
+            }
+
+            unchecked
+            {
+                // Normally this caching doesn't matter, but with the optimizer off, this nets a non-trivial
+                // speedup.
+                int aLength = a.Length;
+
+                for (int i = 0; i < aLength; i++)
+                    // We use subtraction here instead of XOR because the XOR algorithm gets ever so slightly
+                    // faster as more and more differences pile up. This cannot overflow because the output
+                    // of subtracting two chars is an int.
+                    result = result | (a[i] - b[i]);
+            }
+
+            return (0 == result);
+        }
+    }
+}

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Web.config
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Web.config
@@ -5,6 +5,7 @@
   -->
 <configuration>
   <appSettings>
+    <add key="WebhookSecretToken" value=""/>
     <add key="VsoUser" value=""/>
     <add key="VsoPassword" value=""/>
     <add key="SubscriptionsUrl" value="https://raw.githubusercontent.com/dotnet/versions/master/Maestro/subscriptions.json"/>

--- a/Maestro/src/Microsoft.DotNet.Maestro/Config.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro/Config.cs
@@ -14,6 +14,7 @@ namespace Microsoft.DotNet.Maestro
     {
         public static Config Instance { get; } = new Config();
 
+        private Lazy<string> _webhookSecretToken = new Lazy<string>(() => ConfigurationManager.AppSettings[nameof(WebhookSecretToken)]);
         private Lazy<string> _vsoUser = new Lazy<string>(() => ConfigurationManager.AppSettings[nameof(VSoUser)]);
         private Lazy<string> _vsoPassword = new Lazy<string>(() => ConfigurationManager.AppSettings[nameof(VSoPassword)]);
         private Lazy<string> _subscriptionsUrl = new Lazy<string>(() => ConfigurationManager.AppSettings[nameof(SubscriptionsUrl)]);
@@ -21,6 +22,11 @@ namespace Microsoft.DotNet.Maestro
 
         private Config()
         {
+        }
+
+        public string WebhookSecretToken
+        {
+            get { return _webhookSecretToken.Value; }
         }
 
         public string VSoUser


### PR DESCRIPTION
When Maestro receives an HTTP request, verify that it's from an
authorized source and wasn't corrupted by comparing the payload
signature to the HMAC calculated from the HTTP request's content with
the webhook's secret token as the key.

cc: @eerhardt @bartonjs 