### PR TITLE
Add release/1.1.0 subscriptions

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -79,6 +79,13 @@
           "maestroAction": "core-setup-general",
           "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
           "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
+        },
+        // This handler will bring the Latest Roslyn 1.0.0 build into core-setup release/1.1.0
+        {
+          "maestroAction": "core-setup-general",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
         }
       ]
     },
@@ -122,6 +129,37 @@
             "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
             "/verbosity:Normal"
           ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.1.0/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreFX release/1.1.0 build into CoreFX release/1.1.0
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=release/1.1.0",
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreFX release/1.1.0 build into core-setup release/1.1.0
+        {
+          "maestroAction": "core-setup-general",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
         }
       ]
     },
@@ -336,6 +374,37 @@
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements CoreClrExpectedPrerelease"
           ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.1.0/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreCLR release/1.1.0 build into CoreFX release/1.1.0
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=release/1.1.0",
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreCLR release/1.1.0 build into core-setup release/1.1.0
+        {
+          "maestroAction": "core-setup-general",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
         }
       ]
     },


### PR DESCRIPTION
Adds corefx and core-setup release/1.1.0 subscriptions:

* corefx, coreclr -> corefx (all release/1.1.0)
* ProjectK TFS (master) -> corefx (release/1.1.0)
* corefx, coreclr -> core-setup (all release/1.1.0)
* roslyn (1.0.0, "netcore1.0") -> core-setup (release/1.1.0)

These are based on what the subscriptions were for the master branch, except for core-setup. The roslyn core-setup subscription is based on 1.0.0 because core-setup doesn't have master branch subscriptions.

Should wait for:
* [x] https://github.com/dotnet/corefx/pull/11533
* ~~https://github.com/dotnet/coreclr/pull/7109~~
* [x] https://github.com/dotnet/core-setup/pull/248
* [x] https://github.com/dotnet/core-setup/pull/249

Otherwise, some auto-PR attempts might be made that result in weird PRs or errors in Maestro executor builds.

@gkhanna79 @weshaggard @eerhardt 