### PR TITLE
Add subscription to trigger core-setup 1.1.0 builds

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -18,11 +18,17 @@
       "vsoProject": "dotnetcore",
       "buildDefinitionId": 3571
     },
-    // A build definition that will trigger an official build of the core-setup repo
-    "core-setup-pipebuild": {
+    // A build definition that will trigger an official build of the core-setup repo on master
+    "core-setup-pipebuild-master": {
       "vsoInstance": "devdiv.visualstudio.com",
       "vsoProject": "DevDiv",
       "buildDefinitionId": 3160
+    },
+    // A build definition that will trigger an official build of the core-setup repo on release/1.1.0
+    "core-setup-pipebuild-release-1.1.0": {
+      "vsoInstance": "devdiv.visualstudio.com",
+      "vsoProject": "DevDiv",
+      "buildDefinitionId": 4188
     },
     // A build definition that will update the dependencies of the CLI repo
     "cli-dependencies": {
@@ -421,9 +427,18 @@
     {
       "path": "https://github.com/dotnet/core-setup/blob/master/**/*",
       "handlers": [
-        // This handler will trigger an official build of the core-setup repo
+        // This handler will trigger an official build of the core-setup repo on master
         {
-          "maestroAction": "core-setup-pipebuild"
+          "maestroAction": "core-setup-pipebuild-master"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/core-setup/blob/release/1.1.0/**/*",
+      "handlers": [
+        // This handler will trigger an official build of the core-setup repo on release/1.1.0
+        {
+          "maestroAction": "core-setup-pipebuild-release-1.1.0"
         }
       ]
     },


### PR DESCRIPTION
I said earlier that core-setup builds on commit, but I saw merging a PR that it's only for master. This should add a trigger for release/1.1.0.

I don't think leaving core-setup to be manually queued is a good idea because only one build is possible per commit. Automatically triggering will make sure nobody accidentally queues twice on the same one.

@eerhardt There's no extra per-branch setup in the core-setup repo settings, right?

/cc @gkhanna79 @weshaggard @wtgodbe @ianhays 