### PR TITLE
adding a subscription to corefx/master for ProjectN-tfs feed

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -303,6 +303,24 @@
     {
       "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/master/Latest.txt",
       "handlers": [
+        // This handler will bring the Latest ProjectN TFS master build into CoreFX master
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
+            "/verbosity:Normal"
+          ]
+        },
         // This handler will bring the Latest ProjectN TFS master build into CoreFX dev/api
         {
           "maestroAction": "corefx-general",


### PR DESCRIPTION
CoreFx/dev/api has been merged into CoreFX/master and the development will continue on master, rather than dev/api. we need to update the subscription of ProjectN-tfs feed to also update the master branch. 

@dagood , @eerhardt , could you please take a look
