### PR TITLE
Delay core-setup PRs 10 minutes

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -95,6 +95,7 @@
         // This handler will bring the Latest Roslyn 1.0.0 build into core-setup release/1.1.0
         {
           "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
           "vsoSourceBranch": "release/1.1.0",
           "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
           "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
@@ -208,6 +209,7 @@
         // This handler will bring the Latest CoreFX release/1.1.0 build into core-setup release/1.1.0
         {
           "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
           "vsoSourceBranch": "release/1.1.0",
           "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
           "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
@@ -533,6 +535,7 @@
         // This handler will bring the Latest CoreCLR release/1.1.0 build into core-setup release/1.1.0
         {
           "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
           "vsoSourceBranch": "release/1.1.0",
           "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
           "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"


### PR DESCRIPTION
This lets MyGet get the packages ready: there may be a delay before they can be downloaded which causes restore errors in CI.

The other auto-PRs already do this--I just didn't think to add it when copying over the core-setup auto-PR subscription from master to release/1.1.0. This should fix the restore errors we saw on a few auto-PRs that we worked around by rerunning CI.

@gkhanna79 @wtgodbe 