### PR TITLE
Add coreclr -> core-setup 1.0.0 subscription

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -405,6 +405,14 @@
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements CoreClrExpectedPrerelease"
           ]
+        },
+        // This handler will bring the Latest CoreCLR release/1.0.0 build into core-setup release/1.0.0
+        {
+          "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.0.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
         }
       ]
     },


### PR DESCRIPTION
This will enable auto-PRs on core-setup when a 1.0.0 branch coreclr build completes.

@gkhanna79