### PR TITLE
Use Latest.txt in corefx release/1.0.0

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -70,9 +70,9 @@
             "-GitHubEmail dotnet-bot@microsoft.com",
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-GitHubUpstreamBranch release/1.0.0",
-            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest.txt",
             "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
-            "-DirPropsVersionElements ExternalExpectedPrerelease"
+            "-DirPropsVersionElements CoreFxExpectedPrerelease"
           ]
         },
         // This handler will bring the CoreFX 1.0.0 build into core-setup


### PR DESCRIPTION
Latest_Packages.txt results in the old auto-update code in corefx release/1.0.0 trying to put the full list of packages into the corefx expected prerelease msbuild property.

I believe the value in the text file is also used in the PR title, causing errors like in https://devdiv.visualstudio.com/DevDiv/_build?buildId=360738 because of the newlines.

Also updates DirPropsVersionElements to `CoreFxExpectedPrerelease` (from `ExternalExpectedPrerelease`), so the correct upgrade happens. It looks like this handler was copy-pasted without enough modifications.