### PR TITLE
Remove notifications of coreclr/corefx-contrib groups

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -71,7 +71,6 @@
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-GitHubUpstreamBranch release/1.0.0",
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements CoreFxExpectedPrerelease"
           ]
         },
@@ -119,7 +118,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -139,7 +137,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -181,7 +178,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/1.1.0",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -202,7 +198,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=release/1.1.0",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -233,7 +228,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -253,7 +247,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
             "/verbosity:Normal"
           ]
         }
@@ -276,7 +269,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
             "/verbosity:Normal"
           ]
         }
@@ -297,7 +289,6 @@
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-GitHubUpstreamBranch release/1.0.0",
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/coreclr-contrib'",
             "-DirPropsVersionElements ExternalExpectedPrerelease"
           ]
         }
@@ -320,7 +311,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -340,7 +330,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -402,7 +391,6 @@
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-GitHubUpstreamBranch release/1.0.0",
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
-            "-GitHubPullRequestNotifications 'dotnet/corefx-contrib'",
             "-DirPropsVersionElements CoreClrExpectedPrerelease"
           ]
         },
@@ -434,7 +422,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/1.1.0",
-            "/p:NotifyGitHubUsers=dotnet/corefx-contrib",
             "/verbosity:Normal"
           ]
         },
@@ -455,7 +442,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=release/1.1.0",
-            "/p:NotifyGitHubUsers=dotnet/coreclr-contrib",
             "/verbosity:Normal"
           ]
         },


### PR DESCRIPTION
Remove notifications of coreclr/corefx-contrib groups because of they are not useful