### PR TITLE
Remove CoreCLR master auto-update from ProjectK

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -68,8 +68,7 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/master/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt"
       ],
       "action": "coreclr-general",
       "delay": "00:10:00",


### PR DESCRIPTION
This dependency no longer exists with https://github.com/dotnet/coreclr/pull/7714 merged.

@gkhanna79 