### PR TITLE
Revert changes to refactor subscriptions.json

### DIFF
--- a/Maestro/README.md
+++ b/Maestro/README.md
@@ -21,22 +21,21 @@ There may be more "action" types in the future, if the need presents itself.
 This JSON file holds the subscription information of which action to run when a specified file changes. The format
 of the file is as follows:
 
-- actions - An object containing actions that can be referenced in an event subscription. Each action object
-represents a VSO build definition and can have the following properties:
+- actions - A list of actions that can be performed in a build definitions that can be referenced in an event handler. Each object can have the
+following properties:
  - vsoInstance (required) - The domain name where the VSO tenant is hosted.
  - vsoProject (required) - The project the build defintion is contained in.
  - buildDefinitionId (required) - The integer id of the build defintion 
 
-- subscriptions - The array of subscription objects which specify the list of files to watch and the action
-to invoke whenever any of the files is updated. Each subscription object can have the following properties:
-  - triggerPaths (required) - The array of files for which Maestro will trigger the action when any are updated
-  (modified, added, or removed).
-  - action (required) - The name of the action object that will be triggered when any of the files changes.
-  - delay (optional) - The amount of time to wait before triggering the action.
-  - actionArguments (optional) - An object containing properties to be passed to the action. For VSO build actions,
-  the following properties are supported:
-    - vsoSourceBranch (optional) - The source branch for which to queue the build.
-    - vsoBuildParameters (optional) - An object containing properties to be passed as variables to the queued VSO
-    build using the name of the property as the name of the variable and the value of the property as the value of
-    the variable. In order to make the json file more readable, Maestro supports the value of the property to be
-    an array of strings that get appended together to make up one long variable value string.
+- subscriptions - The array of subscription objects which reference the file to watch, and the list of actions or "handlers"
+to invoke whenever that file is updated. Each subscription object can have the following properties:
+ - path (required) - The file that will trigger actions when it is updated.
+ - handlers (required) - The array of subscription handler objects that will be triggered when the files changes.
+ 
+ Each subscription handler can have the following properties:
+ - maestroAction (required) - The name of the Action object which contains the necessary information to
+ queue a new VSO build.
+ - Any other properties defined on the handler will be passed as variables to the queued VSO build using
+ the name of the property as the name of the variable and the value of the property as the value of the variable.
+   - In order to make the json file more readable, Maestro supports the value of the property to be an array of strings that
+   get appended together to make up one long variable value string.

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Microsoft.DotNet.Maestro.WebApi.csproj
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Microsoft.DotNet.Maestro.WebApi.csproj
@@ -99,11 +99,12 @@
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
-    <Compile Include="Models\ActionsList.cs" />
+    <Compile Include="Models\ActionList.cs" />
     <Compile Include="Models\Commit.cs" />
     <Compile Include="Models\ModifiedFileModel.cs" />
     <Compile Include="Models\PushWebHookEvent.cs" />
     <Compile Include="Models\Repository.cs" />
+    <Compile Include="Models\Subscription.cs" />
     <Compile Include="Models\SubscriptionsModel.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\AzureStorageService.cs" />

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/ActionList.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/ActionList.cs
@@ -3,12 +3,16 @@
 // See the LICENSE file in the project root for more information.
 
 using System.Collections.Generic;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Maestro.WebApi.Models
 {
-    public class ActionsList : Dictionary<string, JToken>
+    public class ActionsList
     {
+        [JsonExtensionData]
+        private IDictionary<string, JToken> ActionNames { get; set; }
+
         public JObject GetAction(string name)
         {
             JObject action = null;
@@ -16,7 +20,7 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
             if (!string.IsNullOrEmpty(name))
             {
                 JToken token;
-                if (TryGetValue(name, out token))
+                if (ActionNames.TryGetValue(name, out token))
                 {
                     action = token as JObject;
                 }

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/Subscription.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/Subscription.cs
@@ -1,0 +1,15 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Generic;
+using Microsoft.DotNet.Maestro.Models;
+
+namespace Microsoft.DotNet.Maestro.WebApi.Models
+{
+    public class Subscription
+    {
+        public string Path { get; set; }
+        public List<HandlerObject> Handlers { get; set; }
+    }
+}

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Services/HandlerResolver.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Services/HandlerResolver.cs
@@ -20,19 +20,24 @@ namespace Microsoft.DotNet.Maestro.WebApi.Services
             _subscriptionsModel = subscriptionsModel;
         }
 
-        public ISubscriptionHandler Resolve(Subscription subscription)
+        public ISubscriptionHandler Resolve(HandlerObject handlerObject)
         {
-            JObject action = _subscriptionsModel.Actions.GetAction(subscription.Action);
-            if (action == null)
+            if (string.IsNullOrEmpty(handlerObject.MaestroAction))
             {
-                throw new Exception($"Could not find a valid action with name '{subscription.Action}'.");
+                throw new Exception("All Subscription Handler objects must contain a 'maestroAction' property.");
             }
 
-            ISubscriptionHandler result = VsoBuildHandler.TryCreate(action, subscription);
+            JObject action = _subscriptionsModel.Actions.GetAction(handlerObject.MaestroAction);
+            if (action == null)
+            {
+                throw new Exception($"Could not find a valid action with name '{handlerObject.MaestroAction}'.");
+            }
+
+            ISubscriptionHandler result = VsoBuildHandler.TryCreate(action, handlerObject);
 
             if (result == null)
             {
-                throw new Exception($"Could not resolve a Handler for Subscription '{JsonConvert.SerializeObject(subscription)}'.");
+                throw new Exception($"Could not resolve a Handler for Subscription '{JsonConvert.SerializeObject(handlerObject)}'.");
             }
             return result;
         }

--- a/Maestro/src/Microsoft.DotNet.Maestro/Microsoft.DotNet.Maestro.csproj
+++ b/Maestro/src/Microsoft.DotNet.Maestro/Microsoft.DotNet.Maestro.csproj
@@ -54,7 +54,7 @@
     <Compile Include="Handlers\ISubscriptionHandler.cs" />
     <Compile Include="Handlers\VsoBuildHandler.cs" />
     <Compile Include="Messages\DelayedMessage.cs" />
-    <Compile Include="Models\Subscription.cs" />
+    <Compile Include="Models\HandlerObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\VsoParameterGenerator.cs" />
     <Compile Include="Services\VsoService.cs" />

--- a/Maestro/src/Microsoft.DotNet.Maestro/Models/HandlerObject.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro/Models/HandlerObject.cs
@@ -9,15 +9,12 @@ using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Maestro.Models
 {
-    public class Subscription
+    public class HandlerObject
     {
-        [JsonProperty(Required = Required.Always)]
-        public List<string> TriggerPaths { get; set; }
+        public string MaestroAction { get; set; }
+        public TimeSpan? MaestroDelay { get; set; }
 
-        [JsonProperty(Required = Required.Always)]
-        public string Action { get; set; }
-
-        public TimeSpan? Delay { get; set; }
-        public IDictionary<string, JToken> ActionArguments { get; set; }
+        [JsonExtensionData]
+        public IDictionary<string, JToken> ExtensionData { get; set; }
     }
 }

--- a/Maestro/src/Microsoft.DotNet.Maestro/Services/VsoParameterGenerator.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro/Services/VsoParameterGenerator.cs
@@ -2,29 +2,31 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json.Linq;
 
 namespace Microsoft.DotNet.Maestro.Services
 {
     public static class VsoParameterGenerator
     {
-        public static string GetParameters(IDictionary<string, JToken> actionArguments)
+        public static string GetParameters(IDictionary<string, JToken> vsoParameters, Func<string, bool> filter)
         {
-            JToken vsoBuildParametersToken = null;
-            actionArguments?.TryGetValue("vsoBuildParameters", out vsoBuildParametersToken);
-
-            if (vsoBuildParametersToken == null)
+            if (vsoParameters == null || !vsoParameters.Any())
             {
                 return null;
             }
 
-            JObject parameterObject = (JObject)vsoBuildParametersToken;
-            foreach (KeyValuePair<string, JToken> parameter in parameterObject)
+            JObject parameterObject = new JObject();
+            foreach (KeyValuePair<string, JToken> parameter in vsoParameters)
             {
-                string value = GetValueString(parameter.Value);
+                if (filter(parameter.Key))
+                {
+                    string value = GetValueString(parameter.Value);
 
-                parameterObject[parameter.Key] = value;
+                    parameterObject[parameter.Key] = value;
+                }
             }
 
             return parameterObject.ToString();

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -56,150 +56,14 @@
     }
   },
   "subscriptions": [
-    // Update dependencies in cli
     {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/release/1.0.0/Latest_Packages.txt"
-      ],
-      "action": "cli-dependencies",
-      "delay": "00:05:00"
-    },
-    // Update dependencies in CoreCLR master
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt"
-      ],
-      "action": "coreclr-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoBuildParameters": {
-          "ScriptFileName": "run.cmd",
-          "Arguments": [
-            "build",
-            "-Project='tests\\build.proj'",
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
-            "/p:GitHubUser=dotnet-bot",
-            "/p:GitHubEmail=dotnet-bot@microsoft.com",
-            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
-            "/p:ProjectRepoOwner=dotnet",
-            "/p:ProjectRepoName=coreclr",
-            "/p:ProjectRepoBranch=master",
-            "/verbosity:Normal"
-          ]
-        }
-      }
-    },
-    // Update ProjectK TFS dependencies in CoreCLR release/1.0.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt"
-      ],
-      "action": "coreclr-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.0.0",
-        "vsoBuildParameters": {
-          "ScriptFileName": "UpdateDependencies.ps1",
-          "Arguments": [
-            "-GitHubUser dotnet-bot",
-            "-GitHubEmail dotnet-bot@microsoft.com",
-            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-GitHubUpstreamBranch release/1.0.0",
-            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
-            "-DirPropsVersionElements ExternalExpectedPrerelease"
-          ]
-        }
-      }
-    },
-    // Update dependencies in CoreCLR release/1.1.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.1.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.1.0/Latest.txt"
-      ],
-      "action": "coreclr-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.1.0",
-        "vsoBuildParameters": {
-          "ScriptFileName": "run.cmd",
-          "Arguments": [
-            "build",
-            "-Project='tests\\build.proj'",
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
-            "/p:GitHubUser=dotnet-bot",
-            "/p:GitHubEmail=dotnet-bot@microsoft.com",
-            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
-            "/p:ProjectRepoOwner=dotnet",
-            "/p:ProjectRepoName=coreclr",
-            "/p:ProjectRepoBranch=release/1.1.0",
-            "/verbosity:Normal"
-          ]
-        }
-      }
-    },
-    // Update dependencies in CoreFX master
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/master/Latest.txt"
-      ],
-      "action": "corefx-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoBuildParameters": {
-          "ScriptFileName": "build-managed.cmd",
-          "Arguments": [
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
-            "/p:GitHubUser=dotnet-bot",
-            "/p:GitHubEmail=dotnet-bot@microsoft.com",
-            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
-            "/p:ProjectRepoOwner=dotnet",
-            "/p:ProjectRepoName=corefx",
-            "/p:ProjectRepoBranch=master",
-            "/verbosity:Normal"
-          ]
-        }
-      }
-    },
-    // Update CoreCLR dependencies in CoreFX release/1.0.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt"
-      ],
-      "action": "corefx-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.0.0",
-        "vsoBuildParameters": {
-          "ScriptFileName": "UpdateDependencies.ps1",
-          "Arguments": [
-            "-GitHubUser dotnet-bot",
-            "-GitHubEmail dotnet-bot@microsoft.com",
-            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
-            "-GitHubUpstreamBranch release/1.0.0",
-            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
-            "-DirPropsVersionElements CoreClrExpectedPrerelease"
-          ]
-        }
-      }
-    },
-    // Update CoreFX dependencies in CoreFX release/1.0.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt"
-      ],
-      "action": "corefx-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.0.0",
-        "vsoBuildParameters": {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreFX release/1.0.0 build into CoreFX release/1.0.0
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.0.0",
           "ScriptFileName": "UpdateDependencies.ps1",
           "Arguments": [
             "-GitHubUser dotnet-bot",
@@ -209,20 +73,41 @@
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest.txt",
             "-DirPropsVersionElements CoreFxExpectedPrerelease"
           ]
+        },
+        // This handler will bring the CoreFX 1.0.0 build into core-setup
+        {
+          "maestroAction": "core-setup-general",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
         }
-      }
+      ]
     },
-    // Update dependencies in CoreFX release/1.1.0
     {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.1.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.1.0/Latest.txt"
-      ],
-      "action": "corefx-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.1.0",
-        "vsoBuildParameters": {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt",
+      "handlers": [
+        // This handler will bring the Roslyn 1.0.0 build into core-setup
+        {
+          "maestroAction": "core-setup-general",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
+        },
+        // This handler will bring the Latest Roslyn 1.0.0 build into core-setup release/1.1.0
+        {
+          "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreFX master build into CoreFX master
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
           "ScriptFileName": "build-managed.cmd",
           "Arguments": [
             "--",
@@ -232,85 +117,33 @@
             "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
-            "/p:ProjectRepoBranch=release/1.1.0",
+            "/p:ProjectRepoBranch=master",
             "/verbosity:Normal"
           ]
-        }
-      }
-    },
-    // Update dependencies in core-setup master
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt",
-        // Roslyn 1.0.0
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"
-      ],
-      "action": "core-setup-general",
-      "actionArguments": {
-        "vsoBuildParameters": {
-          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
-        }
-      }
-    },
-    // Update dependencies in core-setup release/1.0.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt"
-      ],
-      "action": "core-setup-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.0.0",
-        "vsoBuildParameters": {
-          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
-        }
-      }
-    },
-    // Update dependencies in core-setup release/1.1.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.1.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.1.0/Latest.txt",
-        // Roslyn 1.0.0
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"
-      ],
-      "action": "core-setup-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.1.0",
-        "vsoBuildParameters": {
-          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
-        }
-      }
-    },
-    // Update dependencies in dotnet-docker-nightly master
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/rel/1.0.0/Latest_Packages.txt"
-      ],
-      "action": "dotnet-docker-nightly-general",
-      "delay": "00:05:00",
-      "actionArguments": {
-        "vsoBuildParameters": {
-          "ScriptFileName": "update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0'"
-        }
-      }
-    },
-    // Update dependencies in WCF master
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/master/Latest.txt"
-      ],
-      "action": "wcf-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoBuildParameters": {
+        },
+        // This handler will bring the Latest CoreFX master build into CoreCLR master
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "run.cmd",
+          "Arguments": [
+            "build",
+            "-Project='tests\\build.proj'",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=master",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreFX master build into WCF master
+        {
+          "maestroAction": "wcf-general",
+          "maestroDelay": "00:10:00",
           "ScriptFileName": "build-managed.cmd",
           "Arguments": [
             "--",
@@ -325,28 +158,332 @@
             "/verbosity:Normal"
           ]
         }
-      }
+      ]
     },
-    // Trigger official build of cli feature/msbuild
     {
-      "triggerPaths": [
-        "https://github.com/dotnet/cli/blob/feature/msbuild/**/*"
-      ],
-      "action": "cli-pipebuild"
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.1.0/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreFX release/1.1.0 build into CoreFX release/1.1.0
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=release/1.1.0",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreFX release/1.1.0 build into CoreCLR release/1.1.0
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "run.cmd",
+          "Arguments": [
+            "build",
+            "-Project='tests\\build.proj'",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=release/1.1.0",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreFX release/1.1.0 build into core-setup release/1.1.0
+        {
+          "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
+        }
+      ]
     },
-    // Trigger official build of core-setup master
     {
-      "triggerPaths": [
-        "https://github.com/dotnet/core-setup/blob/master/**/*"
-      ],
-      "action": "core-setup-pipebuild-master"
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest ProjectK TFS master build into CoreFX master
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=master",
+            "/verbosity:Normal"
+          ]
+        }
+      ]
     },
-    // Trigger official build of core-setup release/1.1.0
     {
-      "triggerPaths": [
-        "https://github.com/dotnet/core-setup/blob/release/1.1.0/**/*"
-      ],
-      "action": "core-setup-pipebuild-release-1.1.0"
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/master/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest ProjectN TFS master build into CoreFX master
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=master",
+            "/verbosity:Normal"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest ProjectKRel (projectk-tfs/release/1.0.0) build into CoreCLR release/1.0.0
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.0.0",
+          "ScriptFileName": "UpdateDependencies.ps1",
+          "Arguments": [
+            "-GitHubUser dotnet-bot",
+            "-GitHubEmail dotnet-bot@microsoft.com",
+            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
+            "-GitHubUpstreamBranch release/1.0.0",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
+            "-DirPropsVersionElements ExternalExpectedPrerelease"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreCLR master build into CoreFX master
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=master",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreCLR master build into CoreCLR master
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "run.cmd",
+          "Arguments": [
+            "build",
+            "-Project='tests\\build.proj'",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=master",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreCLR master build into WCF master
+        {
+          "maestroAction": "wcf-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=wcf",
+            "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/wcf-contrib",
+            "/verbosity:Normal"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/master/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest WCF master build into WCF master
+        {
+          "maestroAction": "wcf-general",
+          "maestroDelay": "00:10:00",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=wcf",
+            "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/wcf-contrib",
+            "/verbosity:Normal"
+          ]
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreCLR release/1.0.0 build into CoreFX release/1.0.0
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.0.0",
+          "ScriptFileName": "UpdateDependencies.ps1",
+          "Arguments": [
+            "-GitHubUser dotnet-bot",
+            "-GitHubEmail dotnet-bot@microsoft.com",
+            "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
+            "-GitHubUpstreamBranch release/1.0.0",
+            "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
+            "-DirPropsVersionElements CoreClrExpectedPrerelease"
+          ]
+        },
+        // This handler will bring the Latest CoreCLR release/1.0.0 build into core-setup release/1.0.0
+        {
+          "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.0.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.1.0/Latest.txt",
+      "handlers": [
+        // This handler will bring the Latest CoreCLR release/1.1.0 build into CoreFX release/1.1.0
+        {
+          "maestroAction": "corefx-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=release/1.1.0",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreCLR release/1.1.0 build into CoreCLR release/1.1.0
+        {
+          "maestroAction": "coreclr-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "run.cmd",
+          "Arguments": [
+            "build",
+            "-Project='tests\\build.proj'",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=release/1.1.0",
+            "/verbosity:Normal"
+          ]
+        },
+        // This handler will bring the Latest CoreCLR release/1.1.0 build into core-setup release/1.1.0
+        {
+          "maestroAction": "core-setup-general",
+          "maestroDelay": "00:10:00",
+          "vsoSourceBranch": "release/1.1.0",
+          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/release/1.0.0/Latest_Packages.txt",
+      "handlers": [
+        // This handler will bring the core-setup build into CLI
+        {
+          "maestroAction": "cli-dependencies",
+          "maestroDelay": "00:05:00"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/core-setup/blob/master/**/*",
+      "handlers": [
+        // This handler will trigger an official build of the core-setup repo on master
+        {
+          "maestroAction": "core-setup-pipebuild-master"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/core-setup/blob/release/1.1.0/**/*",
+      "handlers": [
+        // This handler will trigger an official build of the core-setup repo on release/1.1.0
+        {
+          "maestroAction": "core-setup-pipebuild-release-1.1.0"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/cli/blob/feature/msbuild/**/*",
+      "handlers": [
+        // This handler will trigger an official build of the CLI repo
+        {
+          "maestroAction": "cli-pipebuild"
+        }
+      ]
+    },
+    {
+      "path": "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/rel/1.0.0/Latest_Packages.txt",
+      "handlers": [
+        // This handler will update the dotnet-docker-nightly Dockerfiles to use the latest CLI
+        {
+          "maestroAction": "dotnet-docker-nightly-general",
+          "maestroDelay": "00:05:00",
+          "ScriptFileName": "update-dependencies\\update-dependencies.ps1",
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0'"
+        }
+      ]
     }
   ]
 }

--- a/Maestro/test/Microsoft.DotNet.Maestro.SubscriptionValidation/SubscriptionValidationTests.cs
+++ b/Maestro/test/Microsoft.DotNet.Maestro.SubscriptionValidation/SubscriptionValidationTests.cs
@@ -20,9 +20,9 @@ namespace Microsoft.DotNet.Maestro.SubscriptionValidation
             SubscriptionsModel subscriptionsModel = InitializeSubscriptionsModel();
             HandlerResolver resolver = new HandlerResolver(subscriptionsModel);
 
-            foreach (Subscription subscription in subscriptionsModel.Subscriptions)
+            foreach (HandlerObject handlerObject in subscriptionsModel.Subscriptions.SelectMany(s => s.Handlers))
             {
-                resolver.Resolve(subscription);
+                resolver.Resolve(handlerObject);
             }
         }
 
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Maestro.SubscriptionValidation
         {
             SubscriptionsModel subscriptionsModel = InitializeSubscriptionsModel();
 
-            foreach (string path in subscriptionsModel.Subscriptions.SelectMany(s => s.TriggerPaths))
+            foreach (string path in subscriptionsModel.Subscriptions.Select(s => s.Path))
             {
                 Assert.True(Uri.IsWellFormedUriString(path, UriKind.Absolute), $"The path '{path}' is not valid.");
             }

--- a/Maestro/test/test-subscriptions.json
+++ b/Maestro/test/test-subscriptions.json
@@ -9,14 +9,12 @@
   },
   "subscriptions": [
     {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/Maestro/test/test-build-info.txt"
-      ],
-      "action": "test-build-definition",
-      "delay": "00:00:30",
-      "actionArguments": {
-        "vsoSourceBranch": "eerhardt-patch-1",
-        "vsoBuildParameters": {
+      "path": "https://github.com/dotnet/versions/blob/master/Maestro/test/test-build-info.txt",
+      "handlers": [
+        {
+          "maestroAction": "test-build-definition",
+          "maestroDelay": "00:00:30",
+          "vsoSourceBranch": "eerhardt-patch-1",
           "SimpleProperty": "simple-value",
           "ArgumentList": [
             "-one one-value",
@@ -24,13 +22,15 @@
             "-three three-value"
           ]
         }
-      }
+      ]
     },
     {
-      "triggerPaths": [
-        "https://github.com/dotnet/cli/blob/feature/msbuild/**/*"
-      ],
-      "action": "test-build-definition"
+      "path": "https://github.com/dotnet/cli/blob/feature/msbuild/**/*",
+      "handlers": [
+        {
+          "maestroAction": "test-build-definition"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This reverts commits a89a6d79, 25f4f7b4, and c99e4841.

The Maestro web app has not been published to Azure since making these
changes, so the published app is out of sync with the
subscriptions.json in this repo.  With eerhardt out, we need to decide
our plan for publishing Maestro; in the meantime, the changes are being
reverted to get it back in sync.

/cc @dagood 