### PR TITLE
Update Docker subscriptions to specify the CLI_RELEASE_MONIKER

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -296,7 +296,14 @@
       "actionArguments": {
         "vsoBuildParameters": {
           "ScriptFileName": "update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0','CLI_RELEASE_MONIKER=preview3'"
+          "Arguments": [
+            "-EnvVars",
+            "'GITHUB_USER=dotnet-bot',",
+            "'GITHUB_EMAIL=dotnet-bot@microsoft.com',",
+            "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])',",
+            "'CLI_BRANCH=rel/1.0.0',",
+            "'CLI_RELEASE_MONIKER=preview3'"
+          ] 
         }
       }
     },
@@ -310,7 +317,14 @@
       "actionArguments": {
         "vsoBuildParameters": {
           "ScriptFileName": "update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0-preview2.1','CLI_RELEASE_MONIKER=preview2.1'"
+          "Arguments": [
+            "-EnvVars",
+            "'GITHUB_USER=dotnet-bot',",
+            "'GITHUB_EMAIL=dotnet-bot@microsoft.com',",
+            "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])',",
+            "'CLI_BRANCH=rel/1.0.0-preview2.1',",
+            "'CLI_RELEASE_MONIKER=preview2.1'"
+          ]
         }
       }
     },

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -323,7 +323,7 @@
             "'GITHUB_EMAIL=dotnet-bot@microsoft.com',",
             "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])',",
             "'CLI_BRANCH=rel/1.0.0-preview2.1',",
-            "'CLI_RELEASE_MONIKER=preview2.1'"
+            "'CLI_RELEASE_MONIKER=preview2-1'"
           ]
         }
       }

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -296,7 +296,7 @@
       "actionArguments": {
         "vsoBuildParameters": {
           "ScriptFileName": "update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0'"
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0','CLI_RELEASE_MONIKER=preview3'"
         }
       }
     },
@@ -310,7 +310,7 @@
       "actionArguments": {
         "vsoBuildParameters": {
           "ScriptFileName": "update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0-preview2.1'"
+          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','CLI_BRANCH=rel/1.0.0-preview2.1','CLI_RELEASE_MONIKER=preview2.1'"
         }
       }
     },


### PR DESCRIPTION
This change is need for https://github.com/dotnet/dotnet-docker-nightly/pull/103

@dagood 