### PR TITLE
Remove core-setup release/1.1.0 commit build trigger

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -368,13 +368,6 @@
         "https://github.com/dotnet/core-setup/blob/master/**/*"
       ],
       "action": "core-setup-pipebuild-master"
-    },
-    // Trigger official build of core-setup release/1.1.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/core-setup/blob/release/1.1.0/**/*"
-      ],
-      "action": "core-setup-pipebuild-release-1.1.0"
     }
   ]
 }


### PR DESCRIPTION
This will make it so builds don't accidentally get triggered while the 1.1.0 branch is in the fragile stable state.

@gkhanna79 