### PR TITLE
Add core-setup master auto-PR trigger

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -241,12 +241,15 @@
     // Update dependencies in core-setup master
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest_Packages.txt",
         // Roslyn 1.0.0
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"
       ],
       "action": "core-setup-general",
+      "delay": "00:10:00",
       "actionArguments": {
+        "vsoSourceBranch": "master",
         "vsoBuildParameters": {
           "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
           "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
@@ -256,7 +259,10 @@
     // Update dependencies in core-setup release/1.0.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/1.0.0/Latest_Packages.txt",
+        // Roslyn 1.0.0
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/netcore1.0/Latest_Packages.txt"
       ],
       "action": "core-setup-general",
       "delay": "00:10:00",


### PR DESCRIPTION
Adds upgrade auto-PR subscriptions for core-setup master branch.

Also fixes the existing release/1.0.0 subscriptions. The subscriptions were assuming that core-setup-general defaults to the master branch, but it actually defaults to release/1.0.0.

@gkhanna79 @brianrob