### PR TITLE
Fix projectk/release/1.0.0 build-info to match stable 1.0.x build

### DIFF
--- a/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt
+++ b/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt
@@ -1,1 +1,1 @@
-servicing-24709-00
+stable

--- a/build-info/dotnet/projectk-tfs/release/1.0.0/Latest_Packages.txt
+++ b/build-info/dotnet/projectk-tfs/release/1.0.0/Latest_Packages.txt
@@ -1,1 +1,1 @@
-runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR 1.0.5-servicing-24709-00
+runtime.win8-arm.Microsoft.NETCore.Runtime.CoreCLR 1.0.5


### PR DESCRIPTION
The auto-publish build successfully pushed the package, but failed to update the versions repo: https://devdiv.visualstudio.com/DevDiv/_build/index?buildId=421214

The versions repo update failure was because auto-publish assumed there would be a prerelease package it could harvest the value from, but there wasn't. I changed the publish script to use `stable` in this case rather than throwing an exception. This matches https://github.com/dotnet/buildtools/pull/1174.

@gkhanna79 @weshaggard 