### PR TITLE
Add coreclr auto-update PR notifications

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -86,6 +86,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/coreclr-auto-update-notify",
             "/verbosity:Normal"
           ]
         }
@@ -108,6 +109,7 @@
             "-GitHubPassword `$(`$Secrets['DotNetBotGitHubPassword'])",
             "-GitHubUpstreamBranch release/1.0.0",
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/projectk-tfs/release/1.0.0/Latest.txt",
+            "-GitHubPullRequestNotifications 'dotnet/coreclr-auto-update-notify'",
             "-DirPropsVersionElements ExternalExpectedPrerelease"
           ]
         }
@@ -136,6 +138,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=coreclr",
             "/p:ProjectRepoBranch=release/1.1.0",
+            "/p:NotifyGitHubUsers=dotnet/coreclr-auto-update-notify",
             "/verbosity:Normal"
           ]
         }


### PR DESCRIPTION
When creating a CoreCLR auto-update PR, notify @dotnet/coreclr-auto-update-notify.

See https://github.com/dotnet/coreclr/pull/8582#issuecomment-267163144.

Partially reverts #91, but uses a new fine-grained group that members are free to leave/join. (https://github.com/orgs/dotnet/teams/coreclr-auto-update-notify)