### PR TITLE
Add subscription to trigger core-setup release builds on commit

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -24,6 +24,12 @@
       "vsoProject": "DevDiv",
       "buildDefinitionId": 3160
     },
+    // A build definition that will trigger an official build of the core-setup repo on release/1.0.0
+    "core-setup-pipebuild-release-1.0.0": {
+      "vsoInstance": "devdiv.visualstudio.com",
+      "vsoProject": "DevDiv",
+      "buildDefinitionId": 4187
+    },
     // A build definition that will trigger an official build of the core-setup repo on release/1.1.0
     "core-setup-pipebuild-release-1.1.0": {
       "vsoInstance": "devdiv.visualstudio.com",
@@ -398,6 +404,20 @@
         "https://github.com/dotnet/core-setup/blob/master/**/*"
       ],
       "action": "core-setup-pipebuild-master"
+    },
+    // Trigger official build of core-setup release/1.0.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/core-setup/blob/release/1.0.0/**/*"
+      ],
+      "action": "core-setup-pipebuild-release-1.0.0"
+    },
+    // Trigger official build of core-setup release/1.1.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/core-setup/blob/release/1.1.0/**/*"
+      ],
+      "action": "core-setup-pipebuild-release-1.1.0"
     }
   ]
 }


### PR DESCRIPTION
Now that core-setup release/1.0.0 and release/1.1.0 produce prereleases, enable automatic builds because they aren't dangerous anymore.

@gkhanna79