### PR TITLE
Adding SNI subscription to Maestro

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -142,7 +142,8 @@
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectk-tfs/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/master/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/master/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/sni/master/Latest.txt"
       ],
       "action": "corefx-general",
       "delay": "00:10:00",


### PR DESCRIPTION
With SNI builds running, there is build-info being generated an published to the dotnet/versions repo.

This change adds the change to subscriptions.json so that SNI versions can be published to .Net Corefx repo.

cc @dagood 