### PR TITLE
Fix CLI trigger path

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -410,7 +410,7 @@
     // Update dependencies in cli master
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/tree/master/build-info/dotnet/core-setup/master/Latest_Packages.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/master/Latest_Packages.txt"
       ],
       "action": "cli-dependencies",
       "delay": "00:05:00",


### PR DESCRIPTION
I had an incorrect URL for the trigger path in the CLI subscription.

@MichaelSimons @dagood @naamunds 