### PR TITLE
Revert corefx/release/1.1.0 build-info update

### DIFF
--- a/build-info/dotnet/corefx/release/1.1.0/Latest.txt
+++ b/build-info/dotnet/corefx/release/1.1.0/Latest.txt
@@ -1,1 +1,1 @@
-servicing-25021-01
+servicing-25009-02

--- a/build-info/dotnet/corefx/release/1.1.0/Latest_Packages.txt
+++ b/build-info/dotnet/corefx/release/1.1.0/Latest_Packages.txt
@@ -1,2 +1,2 @@
-Microsoft.Private.PackageBaseline 1.0.1-servicing-25021-01
+Microsoft.Private.PackageBaseline 1.0.1-servicing-25009-02
 System.Net.Http 4.3.1


### PR DESCRIPTION
This reverts commits 63eeda89c687d359d42cb6f824c2a2fcaf459fcf and 7a70e49511fdf08fb99b98d92dbdcbd0d75c5952, created when an unintentional corefx 1.1.0 build happened. I put the packages from the earlier build back in place on MyGet, and this PR makes the dotnet/versions repo consistent with the rollback.

See https://github.com/dotnet/coreclr/pull/9708

@gkhanna79 @MattGal 