### PR TITLE
Set GITHUB_UPSTREAM_BRANCH for Docker sdk-1.0.0 subscription

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -348,6 +348,7 @@
             "'GITHUB_USER=dotnet-bot',",
             "'GITHUB_EMAIL=dotnet-bot@microsoft.com',",
             "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])',",
+            "'GITHUB_UPSTREAM_BRANCH=sdk-1.0.0',",
             "'CLI_BRANCH=rel/1.0.0',",
             "'CLI_RELEASE_MONIKER=rc4'"
           ]


### PR DESCRIPTION
Recently added subscription was making the PRs against master when they should be on the sdk-1.0.0 branch.