### PR TITLE
Move Core-Setup executor from MSEng to DevDiv

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -14,9 +14,9 @@
     },
     // A build definition capable of running any .ps1 script in the core-setup repo
     "core-setup-general": {
-      "vsoInstance": "mseng.visualstudio.com",
-      "vsoProject": "dotnetcore",
-      "buildDefinitionId": 3571
+      "vsoInstance": "devdiv.visualstudio.com",
+      "vsoProject": "DevDiv",
+      "buildDefinitionId": 5610
     },
     // A build definition that will trigger an official build of the core-setup repo on master
     "core-setup-pipebuild-master": {


### PR DESCRIPTION
I cloned an executor definition in DevDiv and set it up for Core-Setup. With this change, all triggered builds exist on DevDiv.

Core-Setup auto-updates should flow after this, but I'll run a dotnet/standard build (<10 min build time) and look closely at the results to make sure.

/cc @ericstj @gkhanna79 @dleeapho 