### PR TITLE
Prune packages no longer produced in corefx/master

### DIFF
--- a/build-info/dotnet/corefx/master/Latest_Packages.txt
+++ b/build-info/dotnet/corefx/master/Latest_Packages.txt
@@ -6,12 +6,10 @@ Microsoft.VisualBasic 10.2.0-beta-25107-03
 Microsoft.Win32.Registry 4.4.0-beta-25107-03
 Microsoft.Win32.Registry.AccessControl 4.4.0-beta-25107-03
 runtime.alpine.3.4.3-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
-runtime.aot.Microsoft.NETCore.Platforms 2.0.0-beta-25016-03
 runtime.debian.8-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
 runtime.fedora.23-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
 runtime.fedora.24-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
 runtime.linux-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
-runtime.opensuse.13.2-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25006-01
 runtime.opensuse.42.1-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
 runtime.osx.10.10-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
 runtime.rhel.7-x64.Microsoft.Private.CoreFx.NETCoreApp 4.4.0-beta-25107-03
@@ -43,7 +41,6 @@ System.Composition.TypedParts 1.1.0-beta-25107-03
 System.Configuration.ConfigurationManager 4.4.0-beta-25107-03
 System.Data.SqlClient 4.4.0-beta-25107-03
 System.Diagnostics.DiagnosticSource 4.4.0-beta-25107-03
-System.IO.Compression 4.4.0-beta-25022-02
 System.IO.FileSystem.AccessControl 4.4.0-beta-25107-03
 System.IO.Packaging 4.4.0-beta-25107-03
 System.IO.Pipes.AccessControl 4.4.0-beta-25107-03
@@ -65,7 +62,6 @@ System.Security.AccessControl 4.4.0-beta-25107-03
 System.Security.Cryptography.OpenSsl 4.4.0-beta-25107-03
 System.Security.Cryptography.Pkcs 4.4.0-beta-25107-03
 System.Security.Cryptography.ProtectedData 4.4.0-beta-25107-03
-System.Security.Cryptography.Xml 4.4.0-beta-25022-02
 System.Security.Permissions 4.4.0-beta-25107-03
 System.Security.Principal.Windows 4.4.0-beta-25107-03
 System.ServiceProcess.ServiceController 4.4.0-beta-25107-03
@@ -74,5 +70,4 @@ System.Text.Encodings.Web 4.4.0-beta-25107-03
 System.Threading.AccessControl 4.4.0-beta-25107-03
 System.Threading.Tasks.Dataflow 4.8.0-beta-25107-03
 System.Threading.Tasks.Extensions 4.4.0-beta-25107-03
-System.Transactions 4.4.0-beta-25022-02
 System.ValueTuple 4.4.0-beta-25107-03


### PR DESCRIPTION
I noticed some packages weren't updated in https://github.com/dotnet/versions/commit/ca917e7e2e1db8d17e279c045758a1abc62a7210#diff-b64b0edcf4b46fafc86baec415ff9201, indicating that CoreFX no longer builds them. Servicing is the reason to leave packages from old builds in the file, and this is a master build where that doesn't apply.

Is it useful to be able to see when packages stop being produced, @weshaggard, or should master branch builds always remove these old entries?