### PR TITLE
Enable per-PR builds of Core-Setup 1.1.0/1.0.0

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -401,6 +401,20 @@
         "https://github.com/dotnet/core-setup/blob/master/**/*"
       ],
       "action": "core-setup-pipebuild-master"
+    },
+    // Trigger official build of core-setup release/1.0.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/core-setup/blob/release/1.0.0/**/*"
+      ],
+      "action": "core-setup-pipebuild-release-1.0.0"
+    },
+    // Trigger official build of core-setup release/1.1.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/core-setup/blob/release/1.1.0/**/*"
+      ],
+      "action": "core-setup-pipebuild-release-1.1.0"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit c3841e616a165c24f2e0b74a4486bb83cbd435f0. (https://github.com/dotnet/versions/pull/125)

@gkhanna79 @wtgodbe 