### PR TITLE
Update Docker subscriptions for cli 2.0.0

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -306,7 +306,7 @@
             "'GITHUB_EMAIL=dotnet-bot@microsoft.com',",
             "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])',",
             "'CLI_BRANCH=master',",
-            "'CLI_RELEASE_MONIKER=alpha'"
+            "'CLI_RELEASE_PREFIX=2.0.0'"
           ]
         }
       }
@@ -327,29 +327,6 @@
             "'GITHUB_EMAIL=dotnet-bot@microsoft.com',",
             "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])',",
             "'CLI_BRANCH=rel/1.0.1',",
-            "'CLI_RELEASE_MONIKER=rc4'"
-          ]
-        }
-      }
-    },
-    // Update cli rel/1.0.0 dependencies in dotnet-docker-nightly sdk-1.0.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/rel/1.0.0/Latest_Packages.txt"
-      ],
-      "action": "dotnet-docker-nightly-general",
-      "delay": "00:05:00",
-      "actionArguments": {
-        "vsoSourceBranch": "sdk-1.0.0",
-        "vsoBuildParameters": {
-          "ScriptFileName": "update-dependencies\\update-dependencies.ps1",
-          "Arguments": [
-            "-EnvVars",
-            "'GITHUB_USER=dotnet-bot',",
-            "'GITHUB_EMAIL=dotnet-bot@microsoft.com',",
-            "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])',",
-            "'GITHUB_UPSTREAM_BRANCH=sdk-1.0.0',",
-            "'CLI_BRANCH=rel/1.0.0',",
             "'CLI_RELEASE_MONIKER=rc4'"
           ]
         }


### PR DESCRIPTION
- Making use of the CLI_RELEASE_PREFIX added with https://github.com/dotnet/dotnet-docker-nightly/pull/226.
- Cleaning up obsolete sdk-1.0.0 subscription.
