### PR TITLE
Removing WCF from the automatic PRs for version updates.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -332,33 +332,6 @@
         }
       }
     },
-    // Update dependencies in WCF master
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/master/Latest.txt"
-      ],
-      "action": "wcf-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoBuildParameters": {
-          "ScriptFileName": "build-managed.cmd",
-          "Arguments": [
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
-            "/p:GitHubUser=dotnet-bot",
-            "/p:GitHubEmail=dotnet-bot@microsoft.com",
-            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
-            "/p:ProjectRepoOwner=dotnet",
-            "/p:ProjectRepoName=wcf",
-            "/p:ProjectRepoBranch=master",
-            "/p:NotifyGitHubUsers=dotnet/wcf-contrib",
-            "/verbosity:Normal"
-          ]
-        }
-      }
-    },
     // Update dependencies in cli master
     {
       "triggerPaths": [


### PR DESCRIPTION
* Since WCF cannot move to the latest buildtools until other issues are resolved the PRs being generated cannot be merged and will always fail CI tests.