### PR TITLE
Temporarily disable core-setup/master auto-update

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -324,23 +324,6 @@
         }
       }
     },
-    // Update dependencies in core-setup master
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest_Packages.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/master/Latest.txt"
-      ],
-      "action": "core-setup-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
-        }
-      }
-    },
     // Update dependencies in core-setup release/1.0.0
     {
       "triggerPaths": [


### PR DESCRIPTION
This will avoid build failure noise until it's working again.

Fix is tracked by https://github.com/dotnet/core-setup/issues/2208--then we can revert this and make whatever changes are needed.

/cc @karajas @eerhardt @weshaggard 