### PR TITLE
Set core-setup master auto-update branch

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -328,6 +328,7 @@
       "action": "core-setup-general",
       "delay": "00:10:00",
       "actionArguments": {
+        "vsoSourceBranch": "master",
         "vsoBuildParameters": {
           "ScriptFileName": "build.cmd",
           "Arguments": [


### PR DESCRIPTION
The core-setup-general definition defaults to release/1.0.0, so master must be specified.

I didn't think of this when reviewing https://github.com/dotnet/versions/pull/153.

/cc @karajas @chcosta @weshaggard 