### PR TITLE
Notify dotnet/core-setup-contrib on master auto-PR

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -340,6 +340,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=core-setup",
             "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/core-setup-contrib",
             "/verbosity:Normal"
           ]
         }


### PR DESCRIPTION
@dotnet/core-setup-contrib 

For CoreCLR there are separate `dotnet/coreclr-contrib` and `dotnet/coreclr-auto-update-notify` groups. We could do that for core-setup as well. Let me know and I can create a `dotnet/core-setup-auto-update-notify` team.