### PR TITLE
Revert "Disable CI triggers for core-setup 1.0.0 and 1.1.0"

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -469,6 +469,20 @@
           "CORESETUP_VERSION_FRAGMENT": "dotnet/core-setup/release/2.0.0"
         }
       }
+    },
+    // Trigger official build of core-setup release/1.0.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/core-setup/blob/release/1.0.0/**/*"
+      ],
+      "action": "core-setup-pipebuild-release-1.0.0"
+    },
+    // Trigger official build of core-setup release/1.1.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/core-setup/blob/release/1.1.0/**/*"
+      ],
+      "action": "core-setup-pipebuild-release-1.1.0"
     }
   ]
 }


### PR DESCRIPTION
This reverts commit 447f6edaa62fdad75bcc785979e4990651197fc7. (https://github.com/dotnet/versions/pull/144)

Core-Setup 1.1.0 and 1.0.0 servicing branches are ready for new builds.

/cc @gkhanna79 @weshaggard @eerhardt @leecow @wtgodbe 