### PR TITLE
Fix Core-Setup release/2.0.0 auto-update trigger

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -394,8 +394,19 @@
       "actionArguments": {
         "vsoSourceBranch": "release/2.0.0",
         "vsoBuildParameters": {
-          "ScriptFileName": "build_projects\\update-dependencies\\update-dependencies.ps1",
-          "Arguments": "-EnvVars 'GITHUB_USER=dotnet-bot','GITHUB_EMAIL=dotnet-bot@microsoft.com','GITHUB_PASSWORD=`$(`$Secrets[`'DotNetBotGitHubPassword`'])','GITHUB_PULL_REQUEST_NOTIFICATIONS=dotnet/core-setup-contrib'"
+          "ScriptFileName": "build.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-bot",
+            "/p:GitHubEmail=dotnet-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=core-setup",
+            "/p:ProjectRepoBranch=release/2.0.0",
+            "/p:NotifyGitHubUsers=dotnet/core-setup-contrib",
+            "/verbosity:Normal"
+          ]
         }
       }
     },


### PR DESCRIPTION
Since Core-Setup master was merged into release/2.0.0, the auto-update call needs to be changed to match the BuildTools bringup that happened in master. `build_projects\update-dependencies\update-dependencies.ps1` no longer exists.

I copied the subscription from Core-Setup master to release/2.0.0 and changed the branch.