### PR TITLE
Add a NuGet.Config to ensure nuget.org feed used

### DIFF
--- a/Maestro/NuGet.Config
+++ b/Maestro/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/Maestro/NuGet.Config
+++ b/Maestro/NuGet.Config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
CI has sometimes been unable to restore packages because it is only looking at local sources. Add a NuGet.Config file to make sure we can acquire the packages, no matter what the machine state is.

See https://github.com/dotnet/versions/pull/157, https://github.com/dotnet/versions/pull/158