### PR TITLE
Updating build-info/dotnet/cli/release/2.0.0 for preview2-006467

### DIFF
--- a/build-info/dotnet/cli/release/2.0.0/Last_Build_Packages.txt
+++ b/build-info/dotnet/cli/release/2.0.0/Last_Build_Packages.txt
@@ -1,3 +1,3 @@
-Microsoft.DotNet.Cli.Utils 2.0.0-preview2-006215
-VS.Redist.Common.Net.Core.SDK.MSBuildExtensions 2.0.0-preview2-006215
-VS.Redist.Common.Net.Core.SDK.x64 2.0.0-preview2-006215
+Microsoft.DotNet.Cli.Utils 2.0.0-preview2-006467
+VS.Redist.Common.Net.Core.SDK.MSBuildExtensions 2.0.0-preview2-006467
+VS.Redist.Common.Net.Core.SDK.x64 2.0.0-preview2-006467

--- a/build-info/dotnet/cli/release/2.0.0/Latest.txt
+++ b/build-info/dotnet/cli/release/2.0.0/Latest.txt
@@ -1,1 +1,1 @@
-preview2-006215
+preview2-006467

--- a/build-info/dotnet/cli/release/2.0.0/Latest_Packages.txt
+++ b/build-info/dotnet/cli/release/2.0.0/Latest_Packages.txt
@@ -1,4 +1,4 @@
-Microsoft.DotNet.Cli.Utils 2.0.0-preview2-006215
-VS.Redist.Common.Net.Core.SDK.MSBuildExtensions 2.0.0-preview2-006215
-VS.Redist.Common.Net.Core.SDK.x64 2.0.0-preview2-006215
-VS.Redist.Common.Net.Core.SDK.x86 2.0.0-preview2-006206
+Microsoft.DotNet.Cli.Utils 2.0.0-preview2-006467
+VS.Redist.Common.Net.Core.SDK.MSBuildExtensions 2.0.0-preview2-006467
+VS.Redist.Common.Net.Core.SDK.x64 2.0.0-preview2-006467
+VS.Redist.Common.Net.Core.SDK.x86 2.0.0-preview2-006467


### PR DESCRIPTION
Automatic updates of CLI are currently paused, waiting on https://github.com/dotnet/buildtools/pull/1556.

This updates the CLI info for dotnet-CLI to the last known good build of dotnet/cli/release/2.0.0

cc @dagood @livarcocc 