### PR TITLE
Add maestro subscription for WCF release/uwp6.0

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -470,7 +470,7 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/uwp6.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/uwp6.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/uwp6.0/Latest.txt"
       ],
       "action": "core-setup-general",
       "delay": "00:10:00",
@@ -626,6 +626,34 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=wcf",
             "/p:ProjectRepoBranch=release/2.0.0",
+            "/verbosity:Normal"
+          ]
+        }
+      }
+    },
+    // Update dependencies in WCF release/uwp6.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/release/uwp6.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/uwp6.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/release/uwp6.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/release/uwp6.0/Latest.txt"
+      ],
+      "action": "wcf-general",
+      "delay": "00:10:00",
+      "actionArguments": {
+        "vsoSourceBranch": "release/uwp6.0",
+        "vsoBuildParameters": {
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-maestro-bot",
+            "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=wcf",
+            "/p:ProjectRepoBranch=release/uwp6.0",
             "/verbosity:Normal"
           ]
         }


### PR DESCRIPTION
Please review the trigger paths, comparing to CoreFx's triggers, should I have 'standard' and 'core-setup'?