### PR TITLE
Add subscription to trigger dotnet-docker build on base image change

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -66,11 +66,17 @@
       "vsoProject": "DevDiv",
       "buildDefinitionId": 6226
     },
+    // A build definition that will trigger an official build of the dotnet-docker repo
+    "dotnet-docker-pipebuild": {
+      "vsoInstance": "devdiv.visualstudio.com",
+      "vsoProject": "DevDiv",
+      "buildDefinitionId": 6226
+    },
     // A build definition capable of running any .ps1 script in the WCF repo. By default, the master branch.
     "wcf-general": {
       "vsoInstance": "devdiv.visualstudio.com",
       "vsoProject": "DevDiv",
-      "buildDefinitionId": 4226
+      "buildDefinitionId": 6412
     }
   },
   "subscriptions": [
@@ -663,6 +669,20 @@
         "https://github.com/dotnet/versions/blob/master/build-info/docker/arm32v7/debian/stretch.txt"
       ],
       "action": "dotnet-docker-nightly-pipebuild",
+      "actionArguments": {
+        "vsoSourceBranch": "master"
+      }
+    },
+    // Trigger official build of the dotnet-docker repo when a base image is changed
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/docker/buildpack-deps/jessie-scm.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/docker/buildpack-deps/stretch-scm.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/docker/debian/jessie.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/docker/debian/stretch.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/docker/arm32v7/debian/stretch.txt"
+      ],
+      "action": "dotnet-docker-pipebuild",
       "actionArguments": {
         "vsoSourceBranch": "master"
       }


### PR DESCRIPTION
This new subscription will trigger official builds of the dotnet-docker repo whenever an image it depends on changes.