### PR TITLE
Add support for passing trigger information to the handlers

### DIFF
--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/ModifiedFileModel.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/ModifiedFileModel.cs
@@ -10,6 +10,10 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
     {
         public string FullPath { get; set; }
 
+        public string RepoName { get; set; }
+
+        public string BranchName { get; set; }
+
         public static bool TryParse(string repoFullName, string refSpec, string fullPath, out ModifiedFileModel model)
         {
             // the file path goes like the following:
@@ -28,6 +32,8 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
 
             model = new ModifiedFileModel()
             {
+                RepoName = repoFullName,
+                BranchName = branchName,
                 FullPath = "https://github.com/" + string.Join("/", repoFullName, "blob", branchName, fullPath)
             };
 

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/SubscriptionsModel.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/SubscriptionsModel.cs
@@ -52,7 +52,14 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
             {
                 try
                 {
-                    ISubscriptionHandler subscriptionHandler = resolver.Resolve(subscription);
+                    Dictionary<string, string> triggerSubs = new Dictionary<string, string>()
+                    {
+                        { "<trigger-repo>", modifiedFile.RepoName},
+                        { "<trigger-branch>", modifiedFile.BranchName },
+                        { "<trigger-path>", modifiedFile.FullPath }
+                    };
+
+                    ISubscriptionHandler subscriptionHandler = resolver.Resolve(subscription, triggerSubs);
                     subscriptionHandlers.Add(subscriptionHandler);
                 }
                 catch (Exception e)

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Services/HandlerResolver.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Services/HandlerResolver.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Maestro.Models;
 using Microsoft.DotNet.Maestro.WebApi.Models;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Maestro.WebApi.Services
 {
@@ -20,7 +21,7 @@ namespace Microsoft.DotNet.Maestro.WebApi.Services
             _subscriptionsModel = subscriptionsModel;
         }
 
-        public ISubscriptionHandler Resolve(Subscription subscription)
+        public ISubscriptionHandler Resolve(Subscription subscription, IDictionary<string, string> parameterSubstitutions = null)
         {
             JObject action = _subscriptionsModel.Actions.GetAction(subscription.Action);
             if (action == null)
@@ -28,7 +29,7 @@ namespace Microsoft.DotNet.Maestro.WebApi.Services
                 throw new Exception($"Could not find a valid action with name '{subscription.Action}'.");
             }
 
-            ISubscriptionHandler result = VsoBuildHandler.TryCreate(action, subscription);
+            ISubscriptionHandler result = VsoBuildHandler.TryCreate(action, subscription, parameterSubstitutions);
 
             if (result == null)
             {

--- a/Maestro/src/Microsoft.DotNet.Maestro/Handlers/VsoBuildHandler.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro/Handlers/VsoBuildHandler.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.DotNet.Maestro.Models;
 using Microsoft.DotNet.Maestro.Services;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Microsoft.DotNet.Maestro.Handlers
 {
@@ -25,7 +26,7 @@ namespace Microsoft.DotNet.Maestro.Handlers
         public string SourceBranch { get; set; }
         public string VsoParameters { get; set; }
 
-        public static ISubscriptionHandler TryCreate(JObject action, Subscription subscription)
+        public static ISubscriptionHandler TryCreate(JObject action, Subscription subscription, IDictionary<string, string> parameterSubstitutions)
         {
             if (action.Property("vsoInstance") != null)
             {
@@ -37,7 +38,7 @@ namespace Microsoft.DotNet.Maestro.Handlers
                     VsoProject = action["vsoProject"].ToString(),
                     BuildDefinitionId = action["buildDefinitionId"].Value<int>(),
                     SourceBranch = GetSourceBranch(subscription),
-                    VsoParameters = VsoParameterGenerator.GetParameters(subscription.ActionArguments)
+                    VsoParameters = VsoParameterGenerator.GetParameters(subscription.ActionArguments, parameterSubstitutions)
                 };
             }
 

--- a/Maestro/src/Microsoft.DotNet.Maestro/Services/VsoParameterGenerator.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro/Services/VsoParameterGenerator.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Maestro.Services
 {
     public static class VsoParameterGenerator
     {
-        public static string GetParameters(IDictionary<string, JToken> actionArguments)
+        public static string GetParameters(IDictionary<string, JToken> actionArguments, IDictionary<string, string> parameterSubstitutions)
         {
             JToken vsoBuildParametersToken = null;
             actionArguments?.TryGetValue("vsoBuildParameters", out vsoBuildParametersToken);
@@ -23,6 +23,14 @@ namespace Microsoft.DotNet.Maestro.Services
             foreach (KeyValuePair<string, JToken> parameter in parameterObject)
             {
                 string value = GetValueString(parameter.Value);
+
+                if (parameterSubstitutions != null)
+                {
+                    foreach (var sub in parameterSubstitutions)
+                    {
+                        value = value.Replace(sub.Key, sub.Value);
+                    }
+                }
 
                 parameterObject[parameter.Key] = value;
             }


### PR DESCRIPTION
PTAL @eerhardt @dagood 

This will add some well known arguments `<trigger-repo>`, etc to get information about what triggered the run. I brought this together yesterday while it was top of mind but I will likely finish it after the current servicing releases. 