### PR TITLE
Update to trigger paths to the corefx/coreclr repos

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -823,8 +823,8 @@
     // Merge mirrored branches
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/**/*",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/**/*",
+        "https://github.com/dotnet/corefx/blob/release/**/*",
+        "https://github.com/dotnet/coreclr/blob/release/**/*"
       ],
       "action": "dotnet-branch-merge-mirror",
       "actionArguments": {


### PR DESCRIPTION
Accidentally pointed the triggers as the versions repo when it
should be pointed at the individual source repos.

cc @eerhardt @safern 