### PR TITLE
Need LKG file to build 1.0.0 branch in VSO.

### DIFF
--- a/build-info/dotnet/wcf/release/1.0.0/LKG_Packages.txt
+++ b/build-info/dotnet/wcf/release/1.0.0/LKG_Packages.txt
@@ -1,0 +1,6 @@
+System.Private.ServiceModel 4.1.0
+System.ServiceModel.Duplex 4.0.1
+System.ServiceModel.Http 4.1.0
+System.ServiceModel.NetTcp 4.1.0
+System.ServiceModel.Primitives 4.1.0
+System.ServiceModel.Security 4.0.1


### PR DESCRIPTION
In order to build 1.0.0 in VSO buildtools expects an LKG file during the sync step. I assume it pulls down these versions of the WCF packages for build purposes. I haven't gotten there yet but I expect that tests will run against the "just built" packages.