### PR TITLE
Update Docker trigger for CLI 15.5

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -611,10 +611,10 @@
         }
       }
     },
-    // Update cli master dependencies in dotnet-docker-nightly master
+    // Update cli release/15.5 dependencies in dotnet-docker-nightly master
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/master/Latest_Packages.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/cli/release/15.5/Latest_Packages.txt"
       ],
       "action": "dotnet-docker-nightly-general",
       "delay": "00:05:00",
@@ -626,8 +626,8 @@
             "'GITHUB_USER=dotnet-maestro-bot',",
             "'GITHUB_EMAIL=dotnet-maestro-bot@microsoft.com',",
             "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetMaestroBotGitHubToken`'])',",
-            "'CLI_BRANCH=master',",
-            "'CLI_RELEASE_PREFIX=2.1.0'"
+            "'CLI_BRANCH=release/15.5',",
+            "'CLI_RELEASE_PREFIX=2.1.1'"
           ]
         }
       }


### PR DESCRIPTION
This was the source of the following build failure - https://devdiv.visualstudio.com/DevDiv/_build?tracking_data=eyJTb3VyY2UiOiJFbWFpbCIsIlR5cGUiOiJOb3RpZmljYXRpb24iLCJTSUQiOiI1ODI2NCIsIlNUeXBlIjoiUEVSIiwiUmVjaXAiOjEsIl94Y2kiOnsiTklEIjoxNTUwMjEyMiwiTVJlY2lwIjoibTA9MSAiLCJBY3QiOiI2NTJjZjMwNS02ODMyLTRkMTAtYWJlMC1kMTczZGVhNTA5YzUiLCJmZiI6IkNEIn19&buildId=1089929