### PR TITLE
Update Docker subscription to pickup latest cli 2.2

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -627,7 +627,8 @@
             "'GITHUB_EMAIL=dotnet-maestro-bot@microsoft.com',",
             "'GITHUB_PASSWORD=`$(`$Secrets[`'DotNetMaestroBotGitHubToken`'])',",
             "'CLI_BRANCH=master',",
-            "'CLI_RELEASE_PREFIX=2.1.0'"
+            "'CLI_RELEASE_PREFIX=2.1.0',",
+            "'RUNTIME_RELEASE_PREFIX=2.2.0'"
           ]
         }
       }


### PR DESCRIPTION
This was the source of the following build failure - https://devdiv.visualstudio.com/DevDiv/_build?tracking_data=eyJTb3VyY2UiOiJFbWFpbCIsIlR5cGUiOiJOb3RpZmljYXRpb24iLCJTSUQiOiI1ODI2NCIsIlNUeXBlIjoiUEVSIiwiUmVjaXAiOjEsIl94Y2kiOnsiTklEIjoxNTUwMjEyMiwiTVJlY2lwIjoibTA9MSAiLCJBY3QiOiI2NTJjZjMwNS02ODMyLTRkMTAtYWJlMC1kMTczZGVhNTA5YzUiLCJmZiI6IkNEIn19&buildId=1089929

Related to this change I logged https://github.com/dotnet/dotnet-docker-nightly/issues/476