### PR TITLE
Add a parameter substitution for commit id

### DIFF
--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Controllers/CommitPushedController.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Controllers/CommitPushedController.cs
@@ -38,7 +38,7 @@ namespace Microsoft.DotNet.Maestro.WebApi.Controllers
                         foreach (string changedFilePath in c.GetAllChangedFiles())
                         {
                             ModifiedFileModel modifiedFile;
-                            if (!ModifiedFileModel.TryParse(e.Repository.Full_Name, e.Ref, changedFilePath, out modifiedFile))
+                            if (!ModifiedFileModel.TryParse(e.Repository.Full_Name, e.Ref, changedFilePath, c, out modifiedFile))
                             {
                                 Trace.TraceWarning($"Skipping file '{changedFilePath}'");
                                 continue;

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/Commit.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/Commit.cs
@@ -9,6 +9,8 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
 {
     public class Commit
     {
+        public string id { get; set; }
+
         public string[] added { get; set; }
         public string[] modified { get; set; }
         public string[] removed { get; set; }

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/ModifiedFileModel.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/ModifiedFileModel.cs
@@ -14,7 +14,14 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
 
         public string BranchName { get; set; }
 
-        public static bool TryParse(string repoFullName, string refSpec, string fullPath, out ModifiedFileModel model)
+        public string CommitId { get; set; }
+
+        public static bool TryParse(
+            string repoFullName,
+            string refSpec,
+            string fullPath,
+            Commit commit,
+            out ModifiedFileModel model)
         {
             // the file path goes like the following:
             // https://github.com/<owner>/<repo>/blob/<branch>/<fullPath>
@@ -34,7 +41,8 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
             {
                 RepoName = repoFullName,
                 BranchName = branchName,
-                FullPath = "https://github.com/" + string.Join("/", repoFullName, "blob", branchName, fullPath)
+                FullPath = "https://github.com/" + string.Join("/", repoFullName, "blob", branchName, fullPath),
+                CommitId = commit.id
             };
 
             return true;

--- a/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/SubscriptionsModel.cs
+++ b/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/SubscriptionsModel.cs
@@ -52,14 +52,15 @@ namespace Microsoft.DotNet.Maestro.WebApi.Models
             {
                 try
                 {
-                    Dictionary<string, string> triggerSubs = new Dictionary<string, string>()
+                    var parameterSubstitutions = new Dictionary<string, string>
                     {
                         { "<trigger-repo>", modifiedFile.RepoName},
                         { "<trigger-branch>", modifiedFile.BranchName },
-                        { "<trigger-path>", modifiedFile.FullPath }
+                        { "<trigger-path>", modifiedFile.FullPath },
+                        { "<trigger-commit>", modifiedFile.CommitId }
                     };
 
-                    ISubscriptionHandler subscriptionHandler = resolver.Resolve(subscription, triggerSubs);
+                    ISubscriptionHandler subscriptionHandler = resolver.Resolve(subscription, parameterSubstitutions);
                     subscriptionHandlers.Add(subscriptionHandler);
                 }
                 catch (Exception e)


### PR DESCRIPTION
https://github.com/dotnet/versions/issues/205

Builds on the substitution feature added in https://github.com/dotnet/versions/pull/187

I see `id` defined in real webhook payloads, and also defined here: https://developer.github.com/v3/activity/events/types/#webhook-payload-example-26