### PR TITLE
Update CoreFx mirror triggers to mirror all release branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -340,61 +340,13 @@
     // Mirror corefx changes into VSO
     {
       "triggerPaths": [
-        "https://github.com/dotnet/corefx/blob/master/**/*"
-      ],
-      "action": "corefx-mirror",
-      "actionArguments": {
-        "vsoSourceBranch": "master"
-      }
-    },
-    // Mirror corefx changes into VSO
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/corefx/blob/release/1.0.0/**/*"
-      ],
-      "action": "corefx-mirror",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.0.0"
-      }
-    },
-    // Mirror corefx changes into VSO
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/corefx/blob/release/1.1.0/**/*"
-      ],
-      "action": "corefx-mirror",
-      "actionArguments": {
-        "vsoSourceBranch": "release/1.1.0"
-      }
-    },
-    // Mirror corefx changes into VSO
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/corefx/blob/release/2.0.0/**/*"
-      ],
-      "action": "corefx-mirror",
-      "actionArguments": {
-        "vsoSourceBranch": "release/2.0.0"
-      }
-    },
-    // Mirror corefx changes into VSO
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/corefx/blob/release/uwp6.0/**/*"
-      ],
-      "action": "corefx-mirror",
-      "actionArguments": {
-        "vsoSourceBranch": "release/uwp6.0"
-      }
-    },
-    // Mirror corefx changes into VSO
-    {
-      "triggerPaths": [
+        "https://github.com/dotnet/corefx/blob/master/**/*",
+        "https://github.com/dotnet/corefx/blob/release/**/*",
         "https://github.com/dotnet/corefx/blob/dev/defaultintf/**/*"
       ],
       "action": "corefx-mirror",
       "actionArguments": {
-        "vsoSourceBranch": "dev/defaultintf"
+        "vsoSourceBranch": "<trigger-branch>"
       }
     },
     // Update dependencies in CoreFX release/2.0.0


### PR DESCRIPTION
cc @mmitche @dagood 

Corefx is the only one that uses this trigger type for the mirror. We should enable this for all the repo's and create one common mirror definition and pass the repo and branch.