### PR TITLE
Create triggers for post-build signing validation

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -94,6 +94,12 @@
       "vsoInstance": "devdiv.visualstudio.com",
       "vsoProject": "DevDiv",
       "buildDefinitionId": 8228
+    },
+    // Performs signing validation for an orchestrated build based on its build output manifest on dotnet/versions.
+    "DotNet-Orchestration-Final-Validate-Assets-Signed": {
+      "vsoInstance": "devdiv.visualstudio.com",
+      "vsoProject": "DevDiv",
+      "buildDefinitionId": 8291
     }
   },
   "subscriptions": [
@@ -840,6 +846,18 @@
         }
       }
     },
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/master/build.semaphore"
+      ],
+      "action": "DotNet-Orchestration-Final-Validate-Assets-Signed",
+      "actionArguments": {
+        "vsoBuildParameters": {
+          "PB_TriggerPath": "<trigger-path>",
+          "PB_VersionsRepoRef": "<trigger-commit>"
+        }
+      }
+    },
     // Orchestrated build final publish in release/2.1
     {
       "triggerPaths": [
@@ -862,6 +880,18 @@
       "actionArguments": {
         "vsoBuildParameters": {
           "PB_FinalTargets": "/t:FinalBlobPublish",
+          "PB_TriggerPath": "<trigger-path>",
+          "PB_VersionsRepoRef": "<trigger-commit>"
+        }
+      }
+    },
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1/build.semaphore"
+      ],
+      "action": "DotNet-Orchestration-Final-Validate-Assets-Signed",
+      "actionArguments": {
+        "vsoBuildParameters": {
           "PB_TriggerPath": "<trigger-path>",
           "PB_VersionsRepoRef": "<trigger-commit>"
         }


### PR DESCRIPTION
Right now this is parallel to publish steps: the bits will publish, regardless of signing issues. We can change this in the future (once we at least are confident in the whitelist) so that publish triggers on the validation success semaphore.

https://github.com/dotnet/core-eng/issues/2434