### PR TITLE
Fix parameters to actually be vsoBuildParameters

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -352,8 +352,10 @@
       ],
       "action": "github-vsts-mirror",
       "actionArguments": {
-        "GithubRepo": "<trigger-repo>",
-        "BranchToMirror": "<trigger-branch>"
+        "vsoBuildParameters": {
+          "GithubRepo": "<trigger-repo>",
+          "BranchToMirror": "<trigger-branch>"
+        }
       }
     },
     // Update dependencies in CoreFX release/2.0.0
@@ -815,8 +817,10 @@
       ],
       "action": "dotnet-branch-merge-mirror",
       "actionArguments": {
-        "GithubRepo": "<trigger-repo>",
-        "BranchToMirror": "<trigger-branch>"
+        "vsoBuildParameters": {
+          "GithubRepo": "<trigger-repo>",
+          "BranchToMirror": "<trigger-branch>"
+        }
       }
     },
     // Orchestrated build final publish in master


### PR DESCRIPTION
cc @dagood @safern 

Trying to figure out why the branch information wasn't correctly being passed to the mirror I finally figured out we didn't actually pass them as vsobuildparameters. This should fix that.