### PR TITLE
Add coreclr and core-setup github-vsts triggers

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -348,7 +348,12 @@
       "triggerPaths": [
         "https://github.com/dotnet/corefx/blob/master/**/*",
         "https://github.com/dotnet/corefx/blob/release/**/*",
-        "https://github.com/dotnet/corefx/blob/dev/defaultintf/**/*"
+        "https://github.com/dotnet/coreclr/blob/master/**/*",
+        "https://github.com/dotnet/coreclr/blob/release/**/*",
+        "https://github.com/dotnet/core-setup/blob/master/**/*",
+        "https://github.com/dotnet/core-setup/blob/release/**/*",
+        "https://github.com/dotnet/standard/blob/master/**/*",
+        "https://github.com/dotnet/standard/blob/release/**/*",
       ],
       "action": "github-vsts-mirror",
       "actionArguments": {
@@ -548,31 +553,6 @@
             "/p:ProjectRepoName=core-setup",
             "/p:ProjectRepoBranch=release/uwp6.0",
             "/p:NotifyGitHubUsers=dotnet/core-setup-contrib",
-            "/verbosity:Normal"
-          ]
-        }
-      }
-    },
-    // Update dependencies in core-setup dev/defaultintf
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/dev/defaultintf/Latest.txt"
-      ],
-      "action": "core-setup-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "dev/defaultintf",
-        "vsoBuildParameters": {
-          "ScriptFileName": "build.cmd",
-          "Arguments": [
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
-            "/p:GitHubUser=dotnet-maestro-bot",
-            "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
-            "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
-            "/p:ProjectRepoOwner=dotnet",
-            "/p:ProjectRepoName=core-setup",
-            "/p:ProjectRepoBranch=dev/defaultintf",
             "/verbosity:Normal"
           ]
         }


### PR DESCRIPTION
c @mmitche @dagood 

This is a follow-up to move to all the core repos to one general definition for mirroring. 

Also removed some defaultinf subs which are no longer needed as the branch is deleted at this point.