### PR TITLE
Fix release/2.1 cli product build README

### DIFF
--- a/build-info/dotnet/product/cli/release/2.1/README.md
+++ b/build-info/dotnet/product/cli/release/2.1/README.md
@@ -43,25 +43,25 @@
 [sdk-alpine-3.6-targz-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Sdk/2.1.300-preview1-008009/dotnet-sdk-2.1.300-preview1-008009-alpine.3.6-x64.tar.gz.sha
 
 
-### Runtime Installers and Binaries
+### .NET Core Runtime Installers and Binaries
 
 | Platform | Build |
 |---------|:----------:|
-| **Windows (x64)**                      | [Installer][win-x64-installer] ([Checksum][win-x64-installer-checksum])<br>[zip][win-x64-zip] ([Checksum][win-x64-zip-checksum])<br>[Symbols (zip)][win-x64-symbols-zip] |
-| **Windows (x86)**                      | [Installer][win-x86-installer] ([Checksum][win-x86-installer-checksum])<br>[zip][win-x86-zip] ([Checksum][win-x86-zip-checksum])<br>[Symbols (zip)][win-x86-symbols-zip] |
-| **Windows (arm32)**                    | [zip][win-arm-zip] ([Checksum][win-arm-zip-checksum])<br>[Symbols (zip)][win-arm-symbols-zip] |
-| **Windows (arm64)**                    | [zip][win-arm64-zip] ([Checksum][win-arm64-zip-checksum])<br>[Symbols (zip)][win-arm64-symbols-zip] |
-| **Mac OS X (x64)**                     | [Installer][osx-installer] ([Checksum][osx-installer-checksum])<br>[tar.gz][osx-targz] ([Checksum][osx-targz-checksum])<br>[Symbols (tar.gz)][osx-symbols-targz] |
-| **Linux (x64)** (for glibc based OS)   | [tar.gz][linux-x64-targz] ([Checksum][linux-x64-targz-checksum])<br>[Symbols (tar.gz)][linux-x64-symbols-targz] |
-| **Linux (armhf)** (for glibc based OS) | [tar.gz][linux-arm-targz] ([Checksum][linux-arm-targz-checksum])<br>[Symbols (tar.gz)][linux-arm-symbols-targz] |
-| **Ubuntu 14.04 (x64)**                 | [Runtime-Deps][ubuntu-14.04-runtime-deps] ([Checksum][ubuntu-14.04-runtime-deps-checksum])<br>[Host][ubuntu-14.04-host] ([Checksum][ubuntu-14.04-host-checksum])<br>[Host FX Resolver][ubuntu-14.04-hostfxr] ([Checksum][ubuntu-14.04-hostfxr-checksum])<br>[Shared Framework][ubuntu-14.04-sharedfx] ([Checksum][ubuntu-14.04-sharedfx-checksum])<br> |
-| **Ubuntu 16.04 (x64)**                 | [Runtime-Deps][ubuntu-16.04-runtime-deps] ([Checksum][ubuntu-16.04-runtime-deps-checksum])<br>[Host][ubuntu-16.04-host] ([Checksum][ubuntu-16.04-host-checksum])<br>[Host FX Resolver][ubuntu-16.04-hostfxr] ([Checksum][ubuntu-16.04-hostfxr-checksum])<br>[Shared Framework][ubuntu-16.04-sharedfx] ([Checksum][ubuntu-16.04-sharedfx-checksum])<br> |
-| **Ubuntu 17.04 (x64)**                 | [Runtime-Deps][ubuntu-17.04-runtime-deps] ([Checksum][ubuntu-17.04-runtime-deps-checksum])<br>[Host][ubuntu-17.04-host] ([Checksum][ubuntu-17.04-host-checksum])<br>[Host FX Resolver][ubuntu-17.04-hostfxr] ([Checksum][ubuntu-17.04-hostfxr-checksum])<br>[Shared Framework][ubuntu-17.04-sharedfx] ([Checksum][ubuntu-17.04-sharedfx-checksum])<br> |
-| **Ubuntu 17.10 (x64)**                 | [Runtime-Deps][ubuntu-17.10-runtime-deps] ([Checksum][ubuntu-17.10-runtime-deps-checksum])<br>[Host][ubuntu-17.10-host] ([Checksum][ubuntu-17.10-host-checksum])<br>[Host FX Resolver][ubuntu-17.10-hostfxr] ([Checksum][ubuntu-17.10-hostfxr-checksum])<br>[Shared Framework][ubuntu-17.10-sharedfx] ([Checksum][ubuntu-17.10-sharedfx-checksum])<br> |
-| **Debian 8.2 (x64)**                   | [Runtime-Deps][debian-8.2-runtime-deps] ([Checksum][debian-8.2-runtime-deps-checksum])<br>[Host][debian-8.2-host] ([Checksum][debian-8.2-host-checksum])<br>[Host FX Resolver][debian-8.2-hostfxr] ([Checksum][debian-8.2-hostfxr-checksum])<br>[Shared Framework][debian-8.2-sharedfx] ([Checksum][debian-8.2-sharedfx-checksum])<br> |
-| **Debian 9 (x64)**                     | [Runtime-Deps][debian-9-runtime-deps] ([Checksum][debian-9-runtime-deps-checksum])<br>[Host][debian-9-host] ([Checksum][debian-9-host-checksum])<br>[Host FX Resolver][debian-9-hostfxr] ([Checksum][debian-9-hostfxr-checksum])<br>[Shared Framework][debian-9-sharedfx] ([Checksum][debian-9-sharedfx-checksum])<br> |
-| **RHEL 7.2 (x64)**                     | [Host][rhel7-host] ([Checksum][rhel7-host-checksum])<br>[Host FX Resolver][rhel7-hostfxr] ([Checksum][rhel7-hostfxr-checksum])<br>[Shared Framework][rhel7-sharedfx] ([Checksum][rhel7-sharedfx-checksum])<br> |
-| **OpenSUSE 42.1 (x64)**                | [Host][OpenSUSE-42-host] ([Checksum][OpenSUSE-42-host-checksum])<br>[Host FX Resolver][OpenSUSE-42-hostfxr] ([Checksum][OpenSUSE-42-hostfxr-checksum])<br>[Shared Framework][OpenSUSE-42-sharedfx] ([Checksum][OpenSUSE-42-sharedfx-checksum])<br> |
+| **Windows (x64)**                      | [Installer][win-x64-installer] <br>[zip][win-x64-zip] <br>[Symbols (zip)][win-x64-symbols-zip] |
+| **Windows (x86)**                      | [Installer][win-x86-installer] <br>[zip][win-x86-zip] <br>[Symbols (zip)][win-x86-symbols-zip] |
+| **Windows (arm32)**                    | [zip][win-arm-zip] <br>[Symbols (zip)][win-arm-symbols-zip] |
+| **Windows (arm64)**                    | [zip][win-arm64-zip] <br>[Symbols (zip)][win-arm64-symbols-zip] |
+| **Mac OS X (x64)**                     | [Installer][osx-installer] <br>[tar.gz][osx-targz] <br>[Symbols (tar.gz)][osx-symbols-targz] |
+| **Linux (x64)** (for glibc based OS)   | [tar.gz][linux-x64-targz] <br>[Symbols (tar.gz)][linux-x64-symbols-targz] |
+| **Linux (armhf)** (for glibc based OS) | [tar.gz][linux-arm-targz] <br>[Symbols (tar.gz)][linux-arm-symbols-targz] |
+| **Ubuntu 14.04 (x64)**                 | [Runtime-Deps][ubuntu-14.04-runtime-deps] <br>[Host][deb-package-host] <br>[Host FX Resolver][deb-package-hostfxr] <br>[Shared Framework][deb-package-sharedfx] <br> |
+| **Ubuntu 16.04 (x64)**                 | [Runtime-Deps][ubuntu-16.04-runtime-deps] <br>[Host][deb-package-host] <br>[Host FX Resolver][deb-package-hostfxr] <br>[Shared Framework][deb-package-sharedfx] <br> |
+| **Ubuntu 17.04 (x64)**                 | [Runtime-Deps][ubuntu-17.04-runtime-deps] <br>[Host][deb-package-host] <br>[Host FX Resolver][deb-package-hostfxr] <br>[Shared Framework][deb-package-sharedfx] <br> |
+| **Ubuntu 17.10 (x64)**                 | [Runtime-Deps][ubuntu-17.10-runtime-deps] <br>[Host][deb-package-host] <br>[Host FX Resolver][deb-package-hostfxr] <br>[Shared Framework][deb-package-sharedfx] <br> |
+| **Debian 8.2 (x64)**                   | [Runtime-Deps][debian-8.2-runtime-deps] <br>[Host][deb-package-host] <br>[Host FX Resolver][deb-package-hostfxr] <br>[Shared Framework][deb-package-sharedfx] <br> |
+| **Debian 9 (x64)**                     | [Runtime-Deps][debian-9-runtime-deps] <br>[Host][deb-package-host] <br>[Host FX Resolver][deb-package-hostfxr] <br>[Shared Framework][deb-package-sharedfx] <br> |
+| **RHEL 7.2 (x64)**                     | [Host][rhel7-host] <br>[Host FX Resolver][rhel7-hostfxr] <br>[Shared Framework][rhel7-sharedfx] <br> |
+| **OpenSUSE 42.1 (x64)**                | [Host][OpenSUSE-42-host] <br>[Host FX Resolver][OpenSUSE-42-hostfxr] <br>[Shared Framework][OpenSUSE-42-sharedfx] <br> |
 | **RHEL 6**                             | [tar.gz][rhel-6-targz] |
 
 [win-x64-installer]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-x64.exe
@@ -69,90 +69,95 @@
 [win-x64-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-x64.zip
 [win-x64-zip-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-x64.zip.sha512
 [win-x64-symbols-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-symbols-2.1.0-preview1-26126-02-win-x64.zip
+
 [win-x86-installer]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-x86.exe
 [win-x86-installer-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-x86.exe.sha512
 [win-x86-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-x86.zip
 [win-x86-zip-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-x86.zip.sha512
 [win-x86-symbols-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-symbols-2.1.0-preview1-26126-02-win-x86.zip
+
 [win-arm-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-arm.zip
 [win-arm-zip-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-arm.zip.sha512
 [win-arm-symbols-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-symbols-2.1.0-preview1-26126-02-win-arm.zip
+
 [win-arm64-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-arm64.zip
 [win-arm64-zip-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-win-arm64.zip.sha512
 [win-arm64-symbols-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-symbols-2.1.0-preview1-26126-02-win-arm64.zip
+
 [osx-installer]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-osx-x64.pkg
 [osx-installer-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-osx-x64.pkg.sha512
 [osx-targz]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-osx-x64.tar.gz
 [osx-targz-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-osx-x64.tar.gz.sha512
 [osx-symbols-targz]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-symbols-2.1.0-preview1-26126-02-osx-x64.tar.gz
+
 [linux-x64-targz]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-linux-x64.tar.gz
 [linux-x64-targz-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-linux-x64tar.gz.sha512
 [linux-x64-symbols-targz]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-symbols-2.1.0-preview1-26126-02-linux-x64.tar.gz
 [linux-arm-targz]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-linux-arm.tar.gz
 [linux-arm-targz-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-linux-arm.tar.gz.sha512
 [linux-arm-symbols-targz]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-symbols-2.1.0-preview1-26126-02-linux-arm.tar.gz
+
 [ubuntu-14.04-runtime-deps]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb
 [ubuntu-14.04-runtime-deps-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb.sha512
-[ubuntu-14.04-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb
-[ubuntu-14.04-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb.sha512
-[ubuntu-14.04-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb
-[ubuntu-14.04-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb.sha512
-[ubuntu-14.04-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb
-[ubuntu-14.04-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.14.04-x64.deb.sha512
-[ubuntu-16.04-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb
+
 [ubuntu-16.04-runtime-deps]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb
 [ubuntu-16.04-runtime-deps-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb.sha512
-[ubuntu-16.04-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb.sha512
-[ubuntu-16.04-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb
-[ubuntu-16.04-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb.sha512
-[ubuntu-16.04-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb
-[ubuntu-16.04-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.16.04-x64.deb.sha512
+
 [ubuntu-17.04-runtime-deps]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb
 [ubuntu-17.04-runtime-deps-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb.sha512
-[ubuntu-17.04-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb
-[ubuntu-17.04-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb.sha512
-[ubuntu-17.04-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb
-[ubuntu-17.04-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb.sha512
-[ubuntu-17.04-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb
-[ubuntu-17.04-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.17.04-x64.deb.sha512
+
 [ubuntu-17.10-runtime-deps]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb
 [ubuntu-17.10-runtime-deps-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb.sha512
-[ubuntu-17.10-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb
-[ubuntu-17.10-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb.sha512
-[ubuntu-17.10-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb
-[ubuntu-17.10-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb.sha512
-[ubuntu-17.10-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb
-[ubuntu-17.10-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-ubuntu.17.10-x64.deb.sha512
+
 [debian-8.2-runtime-deps]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-debian.8-x64.deb
 [debian-8.2-runtime-deps-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-debian.8-x64.deb.sha512
-[debian-8.2-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-debian.8-x64.deb
-[debian-8.2-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-debian.8-x64.deb.sha512
-[debian-8.2-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-debian.8-x64.deb
-[debian-8.2-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-debian.8-x64.deb.sha512
-[debian-8.2-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-debian.8-x64.deb
-[debian-8.2-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-debian.8-x64.deb.sha512
+
 [debian-9-runtime-deps]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-debian.9-x64.deb
 [debian-9-runtime-deps-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-deps-2.1.0-preview1-26126-02-debian.9-x64.deb.sha512
-[debian-9-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-debian.9-x64.deb
-[debian-9-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-debian.9-x64.deb.sha512
-[debian-9-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-debian.9-x64.deb
-[debian-9-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-debian.9-x64.deb.sha512
-[debian-9-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-debian.9-x64.deb
-[debian-9-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-debian.9-x64.deb.sha512
+
+[deb-package-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-x64.deb
+[deb-package-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-x64.deb.sha512
+[deb-package-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-x64.deb
+[deb-package-hostfxr-checksum]:https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-x64.deb.sha512
+[deb-package-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-x64.deb
+[deb-package-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-x64.deb.sha512
+
 [rhel7-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-rhel.7-x64.rpm
 [rhel7-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-rhel.7-x64.rpm.sha512
 [rhel7-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-rhel.7-x64.rpm
 [rhel7-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-rhel.7-x64.rpm.sha512
 [rhel7-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-rhel.7-x64.rpm
 [rhel7-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-rhel.7-x64.rpm.sha512
+
 [OpenSUSE-42-host]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-opensuse.42-x64.rpm
 [OpenSUSE-42-host-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-host-2.1.0-preview1-26126-02-opensuse.42-x64.rpm.sha512
 [OpenSUSE-42-hostfxr]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-opensuse.42-x64.rpm
 [OpenSUSE-42-hostfxr-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-hostfxr-2.1.0-preview1-26126-02-opensuse.42-x64.rpm.sha512
 [OpenSUSE-42-sharedfx]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-opensuse.42-x64.rpm
 [OpenSUSE-42-sharedfx-checksum]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-opensuse.42-x64.rpm.sha512
+
 [rhel-6-targz]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-26126-02/dotnet-runtime-2.1.0-preview1-26126-02-rhel.6-x64.tar.gz
 
+
+### ASP.NET Core Runtime Installers and Binaries
+
+Platform              | Build
+----------------------|---------------------
+Windows (x64)         | [Installer (exe)][aspnetcore-win-x64-exe]<br>[Archive (zip)][aspnetcore-win-x64-zip]
+Windows (x86)         | [Installer (exe)][aspnetcore-win-x86-exe]<br>[Archive (zip)][aspnetcore-win-x86-zip]
+macOS (x64)           | [Archive (tar.gz)][aspnetcore-osx-x64-tar]
+Linux (x64)           | [Archive (tar.gz)][aspnetcore-linux-x64-tar]
+Debian/Ubuntu (x64)   | [Installer (deb)][aspnetcore-debian-x64-deb]
+RedHat/Fedora (x64)   | [Installer (rpm)][aspnetcore-redhat-x64-rpm]
+
+[aspnetcore-win-x64-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-win-x64.zip
+[aspnetcore-win-x64-exe]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-win-x64.exe
+[aspnetcore-win-x86-zip]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-win-x86.zip
+[aspnetcore-win-x86-exe]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-win-x86.exe
+[aspnetcore-linux-x64-tar]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-linux-x64.tar.gz
+[aspnetcore-osx-x64-tar]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-osx-x64.tar.gz
+[aspnetcore-debian-x64-deb]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-x64.deb
+[aspnetcore-redhat-x64-rpm]: https://dotnetfeed.blob.core.windows.net/orchestrated-release-2-1/20180126-01/final/assets/Runtime/2.1.0-preview1-28181/aspnetcore-runtime-2.1.0-preview1-28181-rhel.7-x64.rpm
 
 ### Built Repositories
  * cli '2.1.300-preview1-008009' on 'master' (dddf53509f0caf30982a9442d9a8aabeffe40118)


### PR DESCRIPTION
 * Add ASP.NET Core Runtime section.
 * Fix Core-Setup links. Remove not-yet-available checksum links (https://github.com/dotnet/core-eng/issues/2437) and use distro-agnostic artifacts.

I've already changed the generation process to create the readme like this in the future. I figure reviewing this is a good idea anyway, to make sure it will have what everyone needs.

 @natemcmaster @wli3 @johnbeisner PTAL

cc @weshaggard @shawnro 