### PR TITLE
Point release/2.1 publish at real locations

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -852,7 +852,9 @@
         "vsoBuildParameters": {
           "PB_FinalTargets": "/t:FinalPackagePublish",
           "PB_TriggerPath": "<trigger-path>",
-          "PB_VersionsRepoRef": "<trigger-commit>"
+          "PB_VersionsRepoRef": "<trigger-commit>",
+          "PB_MyGetBaseEndpoint": "https://dotnet.myget.org/F/dotnet-core",
+          "PB_CentralBlobFeedUrl": "https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json"
         }
       }
     },
@@ -865,7 +867,9 @@
         "vsoBuildParameters": {
           "PB_FinalTargets": "/t:FinalBlobPublish",
           "PB_TriggerPath": "<trigger-path>",
-          "PB_VersionsRepoRef": "<trigger-commit>"
+          "PB_VersionsRepoRef": "<trigger-commit>",
+          "DotNetCliContainerName": "dotnet",
+          "DotNetCliChecksumsContainerName": "dotnet"
         }
       }
     },


### PR DESCRIPTION
Moves publish away from the `-test` locations.

We shouldn't merge this until we know the manifests are ok and won't overwrite blobs built by `master`. aspnet requires some build-to-build overwriting because it includes its "latest" files in the manifest, so we can't just disable overwrites.