### PR TITLE
Update release/uwp6.0 triggers

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -394,8 +394,7 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/uwp6.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/uwp6.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/release/uwp6.0/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/uwp6.0/Latest.txt"
       ],
       "action": "corefx-general",
       "delay": "00:10:00",
@@ -525,33 +524,6 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=core-setup",
             "/p:ProjectRepoBranch=release/2.0.0",
-            "/p:NotifyGitHubUsers=dotnet/core-setup-contrib",
-            "/verbosity:Normal"
-          ]
-        }
-      }
-    },
-    // Update dependencies in core-setup release/2.0.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/uwp6.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/release/uwp6.0/Latest.txt"
-      ],
-      "action": "core-setup-general",
-      "delay": "00:10:00",
-      "actionArguments": {
-        "vsoSourceBranch": "release/uwp6.0",
-        "vsoBuildParameters": {
-          "ScriptFileName": "build.cmd",
-          "Arguments": [
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
-            "/p:GitHubUser=dotnet-maestro-bot",
-            "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
-            "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
-            "/p:ProjectRepoOwner=dotnet",
-            "/p:ProjectRepoName=core-setup",
-            "/p:ProjectRepoBranch=release/uwp6.0",
             "/p:NotifyGitHubUsers=dotnet/core-setup-contrib",
             "/verbosity:Normal"
           ]
@@ -735,9 +707,7 @@
     // Update dependencies in WCF release/uwp6.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/release/uwp6.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/uwp6.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/release/uwp6.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/release/uwp6.0/Latest.txt"
       ],
       "action": "wcf-general",


### PR DESCRIPTION
Remove dependency update for core-setup release/uwp6.0 build. Also remove triggers that track core-setup release/uwp6.0 and projectn-tfs release/uwp6.0.