### PR TITLE
Adding a trigger to automatically update the master CLI branch

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -625,13 +625,15 @@
     // Update dependencies in cli master
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/master/Latest_Packages.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/master/Latest_Packages.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/roslyn/dev15.7/Latest_Packages.txt"
       ],
       "action": "cli-dependencies",
       "delay": "00:05:00",
       "actionArguments": {
         "vsoBuildParameters": {
-          "GITHUB_PULL_REQUEST_NOTIFICATIONS": "dotnet/dotnet-cli"
+          "GITHUB_PULL_REQUEST_NOTIFICATIONS": "dotnet/dotnet-cli",
+          "ROSLYN_VERSION_FRAGMENT": "dotnet/roslyn/dev15.7"
         }
       }
     },


### PR DESCRIPTION
Adding a trigger to automatically update the master CLI branch when roslyn 15.7 changes.

cc @eerhardt 