### PR TITLE
Enable Copy to Latest for 2.1

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -824,7 +824,9 @@
         "vsoBuildParameters": {
           "PB_FinalTargets": "/t:FinalBlobPublish",
           "PB_TriggerPath": "<trigger-path>",
-          "PB_VersionsRepoRef": "<trigger-commit>"
+          "PB_VersionsRepoRef": "<trigger-commit>",
+          "CoreSetupLatestChannel": "master",
+          "CliLatestChannel": "master"
         }
       }
     },

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -867,7 +867,9 @@
           "PB_TriggerPath": "<trigger-path>",
           "PB_VersionsRepoRef": "<trigger-commit>",
           "DotNetCliContainerName": "dotnet",
-          "DotNetCliChecksumsContainerName": "dotnet"
+          "DotNetCliChecksumsContainerName": "dotnet",
+          "CoreSetupLatestChannel": "release/2.1",
+          "CliLatestChannel": "release/2.1"
         }
       }
     },


### PR DESCRIPTION
Start copying 2.1 Core-Setup and CLI builds to the `release/2.1` channel. This gives us the stable links on `dotnetcli`/`dotnetclichecksums` that are used in the Core-Setup and CLI repo readmes. (Those readmes aren't suitable to auto-upgrade, unlike the readme on dotnet/versions.)