### PR TITLE
Copy prodcon 2.1 CLI to release/2.1.3xx channel

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -940,7 +940,7 @@
           "DotNetCliContainerName": "dotnet",
           "DotNetCliChecksumsContainerName": "dotnet",
           "CoreSetupLatestChannel": "release/2.1",
-          "CliLatestChannel": "release/2.1"
+          "CliLatestChannel": "release/2.1.3xx"
         }
       }
     },


### PR DESCRIPTION
Fix the CLI latest channel to match the built branch so the CLI repo's readme works.