### PR TITLE
Use UpdateDependencies.ps1 for CoreCLR 1.1.x

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -198,12 +198,8 @@
       "actionArguments": {
         "vsoSourceBranch": "release/1.1.0",
         "vsoBuildParameters": {
-          "ScriptFileName": "run.cmd",
+          "ScriptFileName": "UpdateDependencies.ps1",
           "Arguments": [
-            "build",
-            "-Project='tests\\build.proj'",
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-maestro-bot",
             "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
             "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",


### PR DESCRIPTION
Uses new script added in https://github.com/dotnet/coreclr/pull/16868.

@wtgodbe, do you think you can port this to CoreFX release/1.1.0, and the other fix to CoreFX release/1.0.0? (No dotnet/versions change needed for the 1.0.0 one.)