### PR TITLE
Switch WCF release/2.0.0 to use dotnet-maestro-bot

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -873,9 +873,9 @@
           "Arguments": [
             "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",
-            "/p:GitHubUser=dotnet-bot",
-            "/p:GitHubEmail=dotnet-bot@microsoft.com",
-            "/p:GitHubAuthToken=`$(`$Secrets['DotNetBotGitHubPassword'])",
+            "/p:GitHubUser=dotnet-maestro-bot",
+            "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=wcf",
             "/p:ProjectRepoBranch=release/2.0.0",


### PR DESCRIPTION
This is the only place `dotnet-bot` is used in a subscription. Moving to the preferred `dotnet-maestro-bot` account lets us simplify the definitions and reduce the permissions that auto-PR generation code has access to.

The only visible change will be that WCF release/2.0.0 auto-PRs start coming from @dotnet-maestro-bot, like they do for the other WCF branches already.

Related to https://github.com/dotnet/core-eng/issues/2382

FYI @StephenBonikowsky 
