### PR TITLE
Have the subscription for WCF 2.0.0 use the new UpdateDep script.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -869,7 +869,7 @@
       "actionArguments": {
         "vsoSourceBranch": "release/2.0.0",
         "vsoBuildParameters": {
-          "ScriptFileName": "build-managed.cmd",
+          "ScriptFileName": "UpdateDependencies.ps1",
           "Arguments": [
             "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -871,8 +871,6 @@
         "vsoBuildParameters": {
           "ScriptFileName": "UpdateDependencies.ps1",
           "Arguments": [
-            "--",
-            "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-maestro-bot",
             "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
             "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",


### PR DESCRIPTION
The WCF branch 2.0.0 does not use buildtools v2 so using the workaround that was used for 1.1.0 regarding the TLS 1.2 requirement.
Related to dotnet/wcf#2676