### PR TITLE
Add release/2.1 trigger for AspNetCore

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -691,6 +691,30 @@
         "vsoSourceBranch": "dev"
       }
     },
+    // Update dependencies in the aspnetcore repo's release/2.1 branch
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1/packages.semaphore"
+      ],
+      "action": "aspnet-dependency-update",
+      "delay": "00:05:00",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "ScriptFileName": "scripts\\UpdateDependencies.ps1",
+          "Arguments": [
+            "-BuildXml",
+            "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml",
+            "-ConfigVars '",
+            "--GithubUpstreamBranch release/2.1",
+            "--GithubUsername dotnet-maestro-bot",
+            "--GithubEmail dotnet-maestro-bot@microsoft.com",
+            "--GithubToken `$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
+            "'"
+          ]
+        }
+      }
+    },
     // Update dependencies in the aspnetcore repo's dev branch
     {
       "triggerPaths": [


### PR DESCRIPTION
Keep release/2.1 up to date in the same way that dev is.

CC @natemcmaster