### PR TITLE
Properly set source-build update verbosity

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -883,7 +883,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=source-build",
             "/p:ProjectRepoBranch=dev/release/2.1",
-            "/verbosity:Normal"
+            "/clp:v=Normal"
           ]
         }
       }


### PR DESCRIPTION
source-build's build.cmd sets "/clp:v=m", so we need to set "/clp:v=" as well, rather than "/v:".

This makes it so you can see what's happening in Maestro-Source-Build-GeneralExecutor, like the link to the PR that's created.

/cc @crummel @dseefeld 