### PR TITLE
Update aspnetcore from core-setup

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -743,7 +743,7 @@
     // Update dependencies in the aspnetcore repo's release/2.1 branch
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1/packages.semaphore"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1/packages+installers.semaphore"
       ],
       "action": "aspnet-dependency-update",
       "delay": "00:05:00",
@@ -767,7 +767,7 @@
     // Update dependencies in the aspnetcore repo's dev branch
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/master/packages.semaphore"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/master/packages+installers.semaphore"
       ],
       "action": "aspnet-dependency-update",
       "delay": "00:05:00",

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -685,14 +685,59 @@
           "Arguments": [
             "-CleanupDocker",
             "-UpdateDependenciesParams '",
-              "--user dotnet-maestro-bot",
-              "--email dotnet-maestro-bot@microsoft.com",
-              "--password `$(`$Secrets[`'DotNetMaestroBotGitHubToken`'])",
-              "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml",
+            "--user dotnet-maestro-bot",
+            "--email dotnet-maestro-bot@microsoft.com",
+            "--password `$(`$Secrets[`'DotNetMaestroBotGitHubToken`'])",
+            "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml",
             "'"
           ]
         },
         "vsoSourceBranch": "nightly"
+      }
+    },
+    // Update dependencies in the aspnet/aspnet-docker repo's dev branch
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1/packages+installers.semaphore"
+      ],
+      "action": "aspnet-docker-general",
+      "delay": "00:05:00",
+      "actionArguments": {
+        "vsoBuildParameters": {
+          "ScriptFileName": "scripts\\Invoke-UpdateDependencies.ps1",
+          "Arguments": [
+            "-CleanupDocker",
+            "--github-user:dotnet-maestro-bot",
+            "--github-email:dotnet-maestro-bot@microsoft.com",
+            "--github-password:`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
+            "--branch:dev",
+            "--build-info-url:https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml"
+          ]
+        },
+        "vsoSourceBranch": "dev"
+      }
+    },
+    // Update dependencies in the aspnetcore repo's dev branch after core-setup passes
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/master/Latest.txt"
+      ],
+      "action": "aspnet-dependency-update",
+      "delay": "00:05:00",
+      "actionArguments": {
+        "vsoSourceBranch": "dev",
+        "vsoBuildParameters": {
+          "ScriptFileName": "scripts\\UpdateDependencies.ps1",
+          "Arguments": [
+            "-UseCoreFx",
+            "-ConfigVars '",
+            "--GithubUpstreamBranch release/2.1",
+            "--GithubUsername dotnet-maestro-bot",
+            "--GithubEmail dotnet-maestro-bot@microsoft.com",
+            "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
+            "'"
+          ]
+        }
       }
     },
     // Update dependencies in the aspnetcore repo's release/2.1 branch
@@ -710,10 +755,10 @@
             "-BuildXml",
             "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml",
             "-ConfigVars '",
-              "--GithubUpstreamBranch release/2.1",
-              "--GithubUsername dotnet-maestro-bot",
-              "--GithubEmail dotnet-maestro-bot@microsoft.com",
-              "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
+            "--GithubUpstreamBranch release/2.1",
+            "--GithubUsername dotnet-maestro-bot",
+            "--GithubEmail dotnet-maestro-bot@microsoft.com",
+            "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
             "'"
           ]
         }

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -685,10 +685,10 @@
           "Arguments": [
             "-CleanupDocker",
             "-UpdateDependenciesParams '",
-            "--user dotnet-maestro-bot",
-            "--email dotnet-maestro-bot@microsoft.com",
-            "--password `$(`$Secrets[`'DotNetMaestroBotGitHubToken`'])",
-            "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml",
+              "--user dotnet-maestro-bot",
+              "--email dotnet-maestro-bot@microsoft.com",
+              "--password `$(`$Secrets[`'DotNetMaestroBotGitHubToken`'])",
+              "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml",
             "'"
           ]
         },

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -727,15 +727,11 @@
       "actionArguments": {
         "vsoSourceBranch": "dev",
         "vsoBuildParameters": {
-          "ScriptFileName": "scripts\\UpdateDependencies.ps1",
+          "ScriptFileName": "scripts\\UpdateDependenciesCoreFx.ps1",
           "Arguments": [
-            "-UseCoreFx",
-            "-ConfigVars '",
-            "--GithubUpstreamBranch release/2.1",
-            "--GithubUsername dotnet-maestro-bot",
-            "--GithubEmail dotnet-maestro-bot@microsoft.com",
-            "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
-            "'"
+            "-GithubUsername dotnet-maestro-bot",
+            "-GithubEmail dotnet-maestro-bot@microsoft.com",
+            "-GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
           ]
         }
       }
@@ -755,10 +751,10 @@
             "-BuildXml",
             "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml",
             "-ConfigVars '",
-            "--GithubUpstreamBranch release/2.1",
-            "--GithubUsername dotnet-maestro-bot",
-            "--GithubEmail dotnet-maestro-bot@microsoft.com",
-            "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
+              "--GithubUpstreamBranch release/2.1",
+              "--GithubUsername dotnet-maestro-bot",
+              "--GithubEmail dotnet-maestro-bot@microsoft.com",
+              "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
             "'"
           ]
         }
@@ -779,10 +775,10 @@
             "-BuildXml",
             "https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/master/build.xml",
             "-ConfigVars '",
-            "--GithubUpstreamBranch dev",
-            "--GithubUsername dotnet-maestro-bot",
-            "--GithubEmail dotnet-maestro-bot@microsoft.com",
-            "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
+              "--GithubUpstreamBranch dev",
+              "--GithubUsername dotnet-maestro-bot",
+              "--GithubEmail dotnet-maestro-bot@microsoft.com",
+              "--GithubToken=`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
             "'"
           ]
         }

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -695,28 +695,6 @@
         "vsoSourceBranch": "nightly"
       }
     },
-    // Update dependencies in the aspnet/aspnet-docker repo's dev branch
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1/packages+installers.semaphore"
-      ],
-      "action": "aspnet-docker-general",
-      "delay": "00:05:00",
-      "actionArguments": {
-        "vsoBuildParameters": {
-          "ScriptFileName": "scripts\\Invoke-UpdateDependencies.ps1",
-          "Arguments": [
-            "-CleanupDocker",
-            "--github-user:dotnet-maestro-bot",
-            "--github-email:dotnet-maestro-bot@microsoft.com",
-            "--github-password:`$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])",
-            "--branch:dev",
-            "--build-info-url:https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/product/cli/release/2.1/build.xml"
-          ]
-        },
-        "vsoSourceBranch": "dev"
-      }
-    },
     // Update dependencies in the aspnetcore repo's dev branch after core-setup passes
     {
       "triggerPaths": [


### PR DESCRIPTION
This should allow aspnetcore to take new dependencies when core-setup passes instead of waiting for final ProdCon. It depends on aspnet/Universe#1011.