### PR TITLE
Update dotnet-docker-nightly build definition reference

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -79,10 +79,10 @@
       "buildDefinitionId": 5543
     },
     // A build definition that will trigger an official build of the dotnet-docker repo's nightly branch
-    "dotnet-docker-nightly-pipebuild": {
+    "dotnet-docker-nightly": {
       "vsoInstance": "devdiv.visualstudio.com",
       "vsoProject": "DevDiv",
-      "buildDefinitionId": 6226
+      "buildDefinitionId": 9035
     },
     // A build definition that will trigger an official build of the dotnet-docker repo's master branch
     "dotnet-docker-pipebuild": {
@@ -740,7 +740,7 @@
         "https://github.com/dotnet/versions/blob/master/build-info/docker/debian/stretch.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/docker/arm32v7/debian/stretch.txt"
       ],
-      "action": "dotnet-docker-nightly-pipebuild",
+      "action": "dotnet-docker-nightly",
       "actionArguments": {
         "vsoSourceBranch": "nightly"
       }


### PR DESCRIPTION
The dotnet-docker-nightly-pipebuild build definition was recently replaced with dotnet-docker-nightly as part of https://github.com/dotnet/dotnet-docker/pull/553.