### PR TITLE
Make source branch for queued build explicit

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -655,6 +655,7 @@
       ],
       "action": "github-dotnet-vsts-mirror",
       "actionArguments": {
+        "vsoSourceBranch": "master",
         "vsoBuildParameters": {
           "GithubRepo": "<trigger-repo>",
           "BranchToMirror": "<trigger-branch>"


### PR DESCRIPTION
The dotnet instance appears a little less forgiving, or at least this appears to be related to the error