### PR TITLE
Revert "Updating build-info/dotnet/standard/release/2.0.0 for servicing-26522-02"

### DIFF
--- a/build-info/dotnet/standard/release/2.0.0/Last_Build_Packages.txt
+++ b/build-info/dotnet/standard/release/2.0.0/Last_Build_Packages.txt
@@ -1,2 +1,2 @@
-Microsoft.Packaging.Tools.Trimming 1.0.0-servicing-26522-02
-NETStandard.Library 2.0.4-servicing-26522-02
+Microsoft.Packaging.Tools.Trimming 1.0.0-servicing-26419-02
+NETStandard.Library 2.0.3

--- a/build-info/dotnet/standard/release/2.0.0/Latest.txt
+++ b/build-info/dotnet/standard/release/2.0.0/Latest.txt
@@ -1,1 +1,1 @@
-servicing-26522-02
+servicing-26419-02

--- a/build-info/dotnet/standard/release/2.0.0/Latest_Packages.txt
+++ b/build-info/dotnet/standard/release/2.0.0/Latest_Packages.txt
@@ -1,3 +1,3 @@
 Microsoft.Packaging.Tools 1.0.0-preview3-25413-01
-Microsoft.Packaging.Tools.Trimming 1.0.0-servicing-26522-02
-NETStandard.Library 2.0.4-servicing-26522-02
+Microsoft.Packaging.Tools.Trimming 1.0.0-servicing-26419-02
+NETStandard.Library 2.0.3


### PR DESCRIPTION
This reverts commit 7ff3a32a8b6986fe295ff3a8d9f83bc9d399b3ae.

Undo'ing this to move back to the 2.0.3 stable version as we aren't
ready for any newer version of this package yet.

FYI @wtgodbe @mmitche 