### PR TITLE
Merge source-build changes across VSTS branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1287,7 +1287,8 @@
         "https://github.com/dotnet/corefx/blob/release/2.0.0",
         "https://github.com/dotnet/coreclr/blob/release/1.0.0",
         "https://github.com/dotnet/coreclr/blob/release/1.1.0",
-        "https://github.com/dotnet/coreclr/blob/release/2.0.0"
+        "https://github.com/dotnet/coreclr/blob/release/2.0.0",
+        "https://github.com/dotnet/source-build/blob/release/**/*"
       ],
       "action": "dotnet-branch-merge-mirror",
       "actionArguments": {


### PR DESCRIPTION
The Core repos list each release branch to exclude the 2.1 one. `release/**/*` is good for source-build (for now).

Example manual trigger: https://devdiv.visualstudio.com/DevDiv/Default/_build/results?buildId=1775772