### PR TITLE
Correcting the Trigger Paths for the new subscriptions

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1564,12 +1564,12 @@
     },
     {
       "triggerPaths": [
-        "https://github.com/dotnet/corefx/tree/master/src/Common/src/CoreLib/**/*",
-        "https://github.com/dotnet/corefx/tree/release/2.1/src/Common/src/CoreLib/**/*",
-        "https://github.com/dotnet/coreclr/tree/master/src/System.Private.CoreLib/shared/**/*",
-        "https://github.com/dotnet/coreclr/tree/release/2.1/src/System.Private.CoreLib/shared/**/*",
-        "https://github.com/dotnet/corert/tree/master/src/System.Private.CoreLib/shared/**/*",
-        "https://github.com/dotnet/corert/tree/release/2.1/src/System.Private.CoreLib/shared/**/*"
+        "https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/**/*",
+        "https://github.com/dotnet/corefx/blob/release/2.1/src/Common/src/CoreLib/**/*",
+        "https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/**/*",
+        "https://github.com/dotnet/coreclr/blob/release/2.1/src/System.Private.CoreLib/shared/**/*",
+        "https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/**/*",
+        "https://github.com/dotnet/corert/blob/release/2.1/src/System.Private.CoreLib/shared/**/*"
       ],
       "action": "DotNet-GitSync-CommitManager",
       "actionArguments": {


### PR DESCRIPTION
We construct the fullpath https://github.com/dotnet/versions/blob/482b2c2718d3e9d75da3f944f459f0863c315ebb/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/ModifiedFileModel.cs#L49 here to match with triggerPaths


we use blob rather than tree while constructing the build path.

cc @safern @dagood 