### PR TITLE
Align 2.2 branches between aspnet and core-setup

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -830,7 +830,7 @@
     // Update dependencies in the aspnetcore repo's dev branch after core-setup passes
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/master/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/release/2.2/Latest.txt"
       ],
       "action": "aspnet-dependency-update",
       "delay": "00:05:00",


### PR DESCRIPTION
The latest maestro PR to aspnet attempted to move aspnet ahead from 2.2 to 3.0. On aspnet, our dev branches are still appointed for 2.2 work (for now), so I'm updating the maestro trigger to only run for 2.2 changes.

@weshaggard do you have plans to enable publishing for the release/2.2 branches? I don't actually see anything for 2.2 under https://github.com/dotnet/versions/tree/master/build-info/dotnet/core-setup/release.


