### PR TITLE
Fix trigger paths for 2.1->2.2 mirror

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1197,7 +1197,7 @@
         "vsoBuildParameters": {
           "GITHUB_PULL_REQUEST_NOTIFICATIONS": "dotnet/dotnet-cli",
           "GITHUB_UPSTREAM_BRANCH": "release/2.1.401",
-          // Enable once this is done https://github.com/aspnet/Universe/issues/1013.  
+          // Enable once this is done https://github.com/aspnet/Universe/issues/1013.
           // "ASPNET_VERSION_FRAGMENT": "<version fragment>",
           "SDK_VERSION_FRAGMENT": "dotnet/sdk/release/2.1.4xx",
           "CORESETUP_VERSION_FRAGMENT": "dotnet/core-setup/release/2.1"
@@ -1524,9 +1524,9 @@
     // Automate opening PRs to merge core repo's release/2.1 changes into release/2.2 branches
     {
       "triggerPaths": [
-        "https://github.com/dotnet/coreclr/release/2.1/**/*",
-        "https://github.com/dotnet/corefx/release/2.1/**/*",
-        "https://github.com/dotnet/core-setup/release/2.1/**/*"
+        "https://github.com/dotnet/coreclr/blob/release/2.1/**/*",
+        "https://github.com/dotnet/corefx/blob/release/2.1/**/*",
+        "https://github.com/dotnet/core-setup/blob/release/2.1/**/*"
       ],
       "action": "aspnet-buildtools-general",
       "actionArguments": {


### PR DESCRIPTION
cc @dagood @natemcmaster 

Fix the trigger paths for the subs I setup in https://github.com/dotnet/versions/pull/329. 