### PR TITLE
Set up maestro insertions for dotnet/core-sdk

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1499,6 +1499,21 @@
         }
       }
     },
+    // Update dependencies in core-sdk master
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/master/Latest_Packages.txt",
+      ],
+      "action": "core-sdk-dependencies",
+      "delay": "00:05:00",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GITHUB_PULL_REQUEST_NOTIFICATIONS": "dotnet/dotnet-cli",
+          "CORESETUP_VERSION_FRAGMENT": "dotnet/core-setup/master"
+        }
+      }
+    },
     // Update dependencies in source-build release/2.1
     {
       "triggerPaths": [

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -72,6 +72,12 @@
       "vsoProject": "DevDiv",
       "buildDefinitionId": 808
     },
+    // A build definition that will update the dependencies of the dotnet/core-sdk repo
+    "core-sdk-dependencies": {
+      "vsoInstance": "devdiv.visualstudio.com",
+      "vsoProject": "DevDiv",
+      "buildDefinitionId": 9749
+    },
     // A build definition capable of running any .ps1 script in the dotnet-docker repo
     "dotnet-docker-general": {
       "vsoInstance": "devdiv.visualstudio.com",
@@ -101,6 +107,12 @@
       "vsoInstance": "devdiv.visualstudio.com",
       "vsoProject": "DevDiv",
       "buildDefinitionId": 7644
+    },
+    // A build definition that will update the dependencies of the dotnet/toolset repo
+    "toolset-dependencies": {
+      "vsoInstance": "devdiv.visualstudio.com",
+      "vsoProject": "DevDiv",
+      "buildDefinitionId": 9750
     },
     // A build definition capable of running any .ps1 script in the WCF repo. By default, the master branch.
     "wcf-general": {


### PR DESCRIPTION
This should enable maestro insertions of .NET Core runtime components into dotnet/core-sdk.

@natemcmaster @mmitche This doesn't currently cover ASP.NET.  What would we need to add to this to get ASP.NET updates via maestro?  I see this for the 2.2.1xx branch:

```json
    {
      "triggerPaths": [
        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.2/packages.semaphore",
      ],
      "action": "cli-dependencies",
      "delay": "00:05:00",
      "actionArguments": {
        "vsoSourceBranch": "release/2.2.1xx",
        "vsoBuildParameters": {
          "GITHUB_PULL_REQUEST_NOTIFICATIONS": "dotnet/dotnet-cli",
          "GITHUB_UPSTREAM_BRANCH": "release/2.2.1xx",
          // Enable once this is done https://github.com/aspnet/Universe/issues/1013.
          // "ASPNET_VERSION_FRAGMENT": "<version fragment>",
          "SDK_VERSION_FRAGMENT": "dotnet/sdk/release/2.2.1xx",
          "TEMPLATING_VERSION_FRAGMENT": "dotnet/templating/release/2.2",
          "WEBSDK_VERSION_FRAGMENT": "dotnet/templating/release/2.2.1xx",
          "CORESETUP_VERSION_FRAGMENT": "dotnet/core-setup/release/2.2"
        }
      }
    },
```

As I understand it, that trigger is for a ProdCon build, which we don't have yet for 3.0.  Is there a trigger that would work for ASP.NET for 3.0 currently?