### PR TITLE
Updating WCF subscriptions.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1597,8 +1597,6 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/2.0.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/2.0.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/release/2.0.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/release/2.0.0/Latest.txt"
       ],
       "action": "wcf-general",
@@ -1622,7 +1620,6 @@
     // Update dependencies in WCF release/uwp6.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/release/uwp6.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/release/uwp6.0/Latest.txt"
       ],
       "action": "wcf-general",
@@ -1674,11 +1671,10 @@
     // Update dependencies in WCF Master
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/projectn-tfs/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/core-setup/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.2/packages.semaphore",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/2.0.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/release/master/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/2.1/Latest.txt"
       ],
       "action": "wcf-general",
       "delay": "00:10:00",
@@ -1704,8 +1700,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/2.1/packages.semaphore",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/release/2.1.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/2.0.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/wcf/release/2.1.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/2.1/Latest.txt"
       ],
       "action": "wcf-general",


### PR DESCRIPTION
* We prefer not to update our CoreFx dependency in servicing branches unless specifically desired or required.
* Our Master branch is comparable to the CoreFx release/2.2 branch for now for purposes of dependencies and auto-updates.