### PR TITLE
Add dotnet/buildtools auto branch merge PRs

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1848,6 +1848,7 @@
     // Automate opening PRs to merge dotnet org repos' release/2.1 changes into release/2.2 branches
     {
       "triggerPaths": [
+        "https://github.com/dotnet/buildtools/blob/release/2.1/**/*",
         "https://github.com/dotnet/coreclr/blob/release/2.1/**/*",
         "https://github.com/dotnet/corefx/blob/release/2.1/**/*",
         "https://github.com/dotnet/core-setup/blob/release/2.1/**/*",
@@ -1874,6 +1875,7 @@
     // Automate opening PRs to merge dotnet org repos' release/2.2 changes into master branches
     {
       "triggerPaths": [
+        "https://github.com/dotnet/buildtools/blob/release/2.2/**/*",
         "https://github.com/dotnet/source-build/blob/release/2.2/**/*"
       ],
       "action": "dotnet-arcade-general",


### PR DESCRIPTION
2.1 => 2.2 => master

This reduces the manual porting work to get a change in all branches.

There are some conflicts right now for merging 2.2 into master... let me know if I should just skip that one.