### PR TITLE
Update trigger paths for optimization repo

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -157,7 +157,8 @@
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/PGO/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/IBC/Latest.txt"
       ],
       "action": "coreclr-general",
       "delay": "00:10:00",


### PR DESCRIPTION
Since we have split out the IBC training from the PGO training we need
to monitor both locations for updates. This will track with
https://github.com/dotnet/optimization/pull/139 as that is the change to
how we write out the tracking files for the optimization repo.