### PR TITLE
Add tracking for IBC package

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -157,7 +157,8 @@
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/PGO/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/PGO/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/IBC/Latest.txt"
       ],
       "action": "coreclr-general",
       "delay": "00:10:00",


### PR DESCRIPTION
I removed this as we were not producing IBC pacakges at the time, but
now that we have IBC data being regularly updated we should switch this
trigger back on.