### PR TITLE
Switch to new eng/update-dependencies.cmd script to update dependencies

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -212,7 +212,7 @@
           ]
         }
       }
-    },    
+    },
     // Update ProjectK TFS dependencies in CoreCLR release/1.0.0
     {
       "triggerPaths": [
@@ -427,9 +427,8 @@
       "actionArguments": {
         "vsoSourceBranch": "master",
         "vsoBuildParameters": {
-          "ScriptFileName": "build-managed.cmd",
+          "ScriptFileName": "eng\\update-dependencies.cmd",
           "Arguments": [
-            "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-maestro-bot",
             "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
@@ -454,9 +453,8 @@
       "actionArguments": {
         "vsoSourceBranch": "feature/utf8string",
         "vsoBuildParameters": {
-          "ScriptFileName": "build-managed.cmd",
+          "ScriptFileName": "eng\\update-dependencies.cmd",
           "Arguments": [
-            "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-maestro-bot",
             "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
@@ -468,7 +466,7 @@
           ]
         }
       }
-    },    
+    },
     // Update CoreCLR dependencies in CoreFX release/1.0.0
     {
       "triggerPaths": [
@@ -854,7 +852,7 @@
         "https://github.com/dotnet/sdk/blob/release/**/*",
         "https://github.com/dotnet/dotnet-cli-archiver/blob/master/**/*",
         "https://github.com/dotnet/cli-migrate/blob/master/**/*",
-        "https://github.com/dotnet/clicommandlineparser/blob/master/**/*",       
+        "https://github.com/dotnet/clicommandlineparser/blob/master/**/*",
         "https://github.com/dotnet/project-system/blob/master/**/*",
         "https://github.com/dotnet/project-system/blob/release/**/*",
         "https://github.com/dotnet/source-build/blob/master/**/*",


### PR DESCRIPTION
cc @dagood @MattGal @mmitche 

I created a wrapper update-dependencies script in corefx to deal with the build changes caused by the move to arcade. see https://github.com/dotnet/corefx/pull/32896