### PR TITLE
Update the dotnet-docker-general build id

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -82,7 +82,7 @@
     "dotnet-docker-general": {
       "vsoInstance": "devdiv.visualstudio.com",
       "vsoProject": "DevDiv",
-      "buildDefinitionId": 5543
+      "buildDefinitionId": 10293
     },
     // A build definition that will trigger an official build of the dotnet-docker repo's nightly branch
     "dotnet-docker-nightly": {


### PR DESCRIPTION
The dotnet-docker-general build id changed because the build definition moved to yaml.