### PR TITLE
Add Microsoft/clrmd to source mirroring

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -854,14 +854,14 @@
         "https://github.com/dotnet/roslyn/blob/release/**/*",
         "https://github.com/Microsoft/msbuild/blob/master/**/*",
         "https://github.com/Microsoft/msbuild/blob/release/**/*",
+        "https://github.com/Microsoft/clrmd/blob/master/**/*",
+        "https://github.com/Microsoft/clrmd/blob/release/**/*",
         "https://github.com/SignalR/SignalR/blob/master/**/*",
         "https://github.com/SignalR/SignalR/blob/dev/**/*",
         "https://github.com/SignalR/SignalR/blob/release/**/*",
         "https://github.com/dotnet/coreclr/blob/master/**/*",
         "https://github.com/dotnet/coreclr/blob/release/**/*",
-        "https://github.com/dotnet/winforms/blob/master/**/*",
-        "https://github.com/Microsoft/clrmd/blob/master/**/*",
-        "https://github.com/Microsoft/clrmd/blob/release/**/*",
+        "https://github.com/dotnet/winforms/blob/master/**/*"
       ],
       "action": "github-dnceng-vsts-mirror",
       "actionArguments": {

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -859,7 +859,9 @@
         "https://github.com/SignalR/SignalR/blob/release/**/*",
         "https://github.com/dotnet/coreclr/blob/master/**/*",
         "https://github.com/dotnet/coreclr/blob/release/**/*",
-        "https://github.com/dotnet/winforms/blob/master/**/*"
+        "https://github.com/dotnet/winforms/blob/master/**/*",
+        "https://github.com/Microsoft/clrmd/blob/master/**/*",
+        "https://github.com/Microsoft/clrmd/blob/release/**/*",
       ],
       "action": "github-dnceng-vsts-mirror",
       "actionArguments": {


### PR DESCRIPTION
This is to support building Microsoft/clrmd (https://www.nuget.org/packages/Microsoft.Diagnostics.Runtime) in dev.azure.com/dnceng

FYI @leculver - this will be mirroring the `master` branch, as well as any branch that starts `release/` to the internal AzDO tenant (will send an email with a few more details). We'll drive the official build off the mirrored commits.

cc @pakrym @davidfowl