### PR TITLE
Add notifications for CoreFx Auto-update PRs

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -444,6 +444,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=master",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -470,6 +471,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=feature/utf8string",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -492,7 +494,8 @@
             "-GitHubPassword `$(`$Secrets['DotNetMaestroBotGitHubToken'])",
             "-GitHubUpstreamBranch release/1.0.0",
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/coreclr/release/1.0.0/Latest.txt",
-            "-DirPropsVersionElements CoreClrExpectedPrerelease"
+            "-DirPropsVersionElements CoreClrExpectedPrerelease",
+            "-GitHubPullRequestNotifications dotnet/maestro-reviewers-core"
           ]
         }
       }
@@ -514,7 +517,8 @@
             "-GitHubPassword `$(`$Secrets['DotNetMaestroBotGitHubToken'])",
             "-GitHubUpstreamBranch release/1.0.0",
             "-VersionFileUrl https://raw.githubusercontent.com/dotnet/versions/master/build-info/dotnet/corefx/release/1.0.0/Latest.txt",
-            "-DirPropsVersionElements CoreFxExpectedPrerelease"
+            "-DirPropsVersionElements CoreFxExpectedPrerelease",
+            "-GitHubPullRequestNotifications dotnet/maestro-reviewers-core"
           ]
         }
       }
@@ -538,6 +542,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/1.1.0",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -565,6 +570,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/2.0.0",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -591,6 +597,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/uwp6.0",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -617,6 +624,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/uwp6.1",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -647,6 +655,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/uwp6.2",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -675,6 +684,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/2.1",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }
@@ -703,6 +713,7 @@
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=corefx",
             "/p:ProjectRepoBranch=release/2.2",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]
         }


### PR DESCRIPTION
This will send notifications to the members of `dotnet/maestro-reviewers-core` (currently just me) when a Maestro auto-update PR goes into any CoreFx branch. We already have such notifications for Core-Setup & CoreClr.

@dagood PTAL

CC @danmosemsft @karelz 