### PR TITLE
Manually set Microsoft.Owin.Security.Interop to not ship in 2.2.0

### DIFF
--- a/build-info/dotnet/product/cli/release/2.2.0/build.xml
+++ b/build-info/dotnet/product/cli/release/2.2.0/build.xml
@@ -274,7 +274,7 @@
     <Package Id="Microsoft.NETCore.Platforms" Version="2.2.0" OriginBuildName="corefx" />
     <Package Id="Microsoft.NETCore.Runtime.CoreCLR" Version="2.2.0-rtm-27110-04" OriginBuildName="coreclr" NonShipping="true" />
     <Package Id="Microsoft.NETCore.TestHost" Version="2.2.0-rtm-27110-04" OriginBuildName="coreclr" NonShipping="true" />
-    <Package Id="Microsoft.Owin.Security.Interop" Version="2.2.0" OriginBuildName="aspnet" />
+    <Package Id="Microsoft.Owin.Security.Interop" Version="2.2.0" OriginBuildName="aspnet" NonShipping="true" />
     <Package Id="Microsoft.Private.CoreFx.NETCoreApp" Version="4.5.220-servicing-27110-04" OriginBuildName="corefx" NonShipping="true" />
     <Package Id="Microsoft.Private.PackageBaseline" Version="2.2.0-servicing-27110-04" OriginBuildName="corefx" NonShipping="true" />
     <Package Id="Microsoft.TargetingPack.Private.CoreCLR" Version="2.2.0-rtm-27110-04" OriginBuildName="coreclr" NonShipping="true" />


### PR DESCRIPTION
As discussed with @muratg @blowdart @Tratcher