### PR TITLE
Manually correct the list of latest corefx packages on master

### DIFF
--- a/build-info/dotnet/corefx/master/Latest_Packages.txt
+++ b/build-info/dotnet/corefx/master/Latest_Packages.txt
@@ -5,7 +5,7 @@ Microsoft.IO.Redist 4.6.0-preview.18606.1
 Microsoft.NETCore.Platforms 3.0.0-preview.18606.1
 Microsoft.NETCore.Platforms.Future 3.0.0-preview.18606.1
 Microsoft.NETCore.Targets 3.0.0-preview.18606.1
-Microsoft.NETFramework.Compatibility 2.1.0-preview1-25902-08
+Microsoft.NETFramework.Compatibility 2.1.0-preview1-25718-03
 Microsoft.Private.CoreFx.NETCoreApp 4.6.0-preview.18606.1
 Microsoft.Private.CoreFx.UAP 4.7.0-preview.18606.1
 Microsoft.Private.PackageBaseline 4.6.0-preview.18606.1
@@ -37,7 +37,7 @@ runtime.win-arm.Microsoft.Private.CoreFx.NETCoreApp 4.6.0-preview.18606.1
 runtime.win-arm64.Microsoft.Private.CoreFx.NETCoreApp 4.6.0-preview.18606.1
 runtime.win-x64.Microsoft.Private.CoreFx.NETCoreApp 4.6.0-preview.18606.1
 runtime.win-x86.Microsoft.Private.CoreFx.NETCoreApp 4.6.0-preview.18606.1
-System.Buffers 4.6.0-preview1-26912-03
+System.Buffers 4.5.0
 System.CodeDom 4.6.0-preview.18606.1
 System.Collections.Immutable 1.6.0-preview.18606.1
 System.ComponentModel.Annotations 4.6.0-preview.18606.1
@@ -64,11 +64,11 @@ System.Drawing.Design.Primitives 4.6.0-preview.18563.5
 System.IO.FileSystem.AccessControl 4.6.0-preview.18606.1
 System.IO.Packaging 4.6.0-preview.18606.1
 System.IO.Pipelines 4.6.0-preview.18606.1
-System.IO.Pipes.AccessControl 4.6.0-preview1-26830-01
+System.IO.Pipes.AccessControl 4.5.1
 System.IO.Ports 4.6.0-preview.18606.1
 System.Json 4.6.0-preview.18606.1
 System.Management 4.6.0-preview.18606.1
-System.Memory 4.6.0-preview1-26717-04
+System.Memory 4.5.2-servicing-27114-05
 System.Net.Http.WinHttpHandler 4.6.0-preview.18606.1
 System.Net.WebSockets.WebSocketProtocol 4.6.0-preview.18606.1
 System.Numerics.Tensors 0.2.0-preview.18606.1
@@ -103,5 +103,5 @@ System.Threading.AccessControl 4.6.0-preview.18606.1
 System.Threading.Channels 4.6.0-preview.18606.1
 System.Threading.Tasks.Dataflow 4.10.0-preview.18606.1
 System.Threading.Tasks.Extensions 4.6.0-preview.18606.1
-System.ValueTuple 4.6.0-preview1-26829-04
+System.ValueTuple 4.5.0
 System.Windows.Extensions 4.6.0-preview.18606.1


### PR DESCRIPTION
These packages are apparently no longer produced by the master branch. This messes up our automation everytime we try to update.

cc @sebastianros