### PR TITLE
Add auto-update for CoreFx 3.0

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1083,7 +1083,7 @@
       "action": "core-setup-general",
       "delay": "00:10:00",
       "actionArguments": {
-        "vsoSourceBranch": "release/2.2",
+        "vsoSourceBranch": "release/3.0",
         "vsoBuildParameters": {
           "ScriptFileName": "build.cmd",
           "Arguments": [
@@ -1094,7 +1094,7 @@
             "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
             "/p:ProjectRepoOwner=dotnet",
             "/p:ProjectRepoName=core-setup",
-            "/p:ProjectRepoBranch=release/2.2",
+            "/p:ProjectRepoBranch=release/3.0",
             "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
             "/verbosity:Normal"
           ]

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -717,6 +717,36 @@
         }
       }
     },
+    // Update dependencies in CoreFX release/3.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0/packages.semaphore",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0.1/packages.semaphore",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/3.0.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/2.2/Latest.txt"
+      ],
+      "action": "corefx-general",
+      "delay": "00:10:00",
+      "actionArguments": {
+        "vsoSourceBranch": "release/3.0",
+        "vsoBuildParameters": {
+          "ScriptFileName": "build-managed.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-maestro-bot",
+            "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=corefx",
+            "/p:ProjectRepoBranch=release/3.0",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
+            "/verbosity:Normal"
+          ]
+        }
+      }
+    },
+
     // Mirror github changes to devdiv Azure DevOps
     {
       "triggerPaths": [

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -723,7 +723,7 @@
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0/packages.semaphore",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0.1/packages.semaphore",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/3.0.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/2.2/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
       ],
       "action": "corefx-general",
       "delay": "00:10:00",
@@ -1078,7 +1078,7 @@
       "triggerPaths": [
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0.1/packages.semaphore",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/3.0.0/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/2.2/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
       ],
       "action": "core-setup-general",
       "delay": "00:10:00",

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1073,6 +1073,34 @@
         }
       }
     },
+    // Update dependencies in core-setup release/3.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0.1/packages.semaphore",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/3.0.0/Latest.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/2.2/Latest.txt"
+      ],
+      "action": "core-setup-general",
+      "delay": "00:10:00",
+      "actionArguments": {
+        "vsoSourceBranch": "release/2.2",
+        "vsoBuildParameters": {
+          "ScriptFileName": "build.cmd",
+          "Arguments": [
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-maestro-bot",
+            "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=core-setup",
+            "/p:ProjectRepoBranch=release/2.2",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
+            "/verbosity:Normal"
+          ]
+        }
+      }
+    },
     // Update 2.1 dependencies in the dotnet-docker repo's nightly branch
     {
       "triggerPaths": [

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -416,6 +416,35 @@
         }
       }
     },
+    // Update dependencies in CoreCLR release/3.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/release/3.0/Latest.txt"
+      ],
+      "action": "coreclr-general",
+      "delay": "00:10:00",
+      "actionArguments": {
+        "vsoSourceBranch": "release/3.0",
+        "vsoBuildParameters": {
+          "ScriptFileName": "run.cmd",
+          "Arguments": [
+            "build",
+            "-Project='tests\\build.proj'",
+            "--",
+            "/t:UpdateDependenciesAndSubmitPullRequest",
+            "/p:GitHubUser=dotnet-maestro-bot",
+            "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",
+            "/p:GitHubAuthToken=`$(`$Secrets['DotNetMaestroBotGitHubToken'])",
+            "/p:ProjectRepoOwner=dotnet",
+            "/p:ProjectRepoName=coreclr",
+            "/p:ProjectRepoBranch=release/3.0",
+            "/p:NotifyGitHubUsers=dotnet/maestro-reviewers-core",
+            "/verbosity:Normal"
+          ]
+        }
+      }
+    },
     // Update dependencies in CoreFX master
     {
       "triggerPaths": [

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -720,9 +720,6 @@
     // Update dependencies in CoreFX release/3.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0/packages.semaphore",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0.1/packages.semaphore",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/3.0.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
       ],
       "action": "corefx-general",
@@ -1076,8 +1073,6 @@
     // Update dependencies in core-setup release/3.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/product/cli/release/3.0.1/packages.semaphore",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/standard/release/3.0.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
       ],
       "action": "core-setup-general",

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -754,9 +754,8 @@
       "actionArguments": {
         "vsoSourceBranch": "release/3.0",
         "vsoBuildParameters": {
-          "ScriptFileName": "build-managed.cmd",
+          "ScriptFileName": "eng\\update-dependencies.cmd",
           "Arguments": [
-            "--",
             "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-maestro-bot",
             "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -427,11 +427,9 @@
       "actionArguments": {
         "vsoSourceBranch": "release/3.0",
         "vsoBuildParameters": {
-          "ScriptFileName": "run.cmd",
+          "ScriptFileName": "msbuild.cmd",
           "Arguments": [
-            "build",
-            "-Project='tests\\build.proj'",
-            "--",
+            "tests\\build.proj",
             "/t:UpdateDependenciesAndSubmitPullRequest",
             "/p:GitHubUser=dotnet-maestro-bot",
             "/p:GitHubEmail=dotnet-maestro-bot@microsoft.com",


### PR DESCRIPTION
Please hold off on merging until we confirm what branching will look like for Standard/Buildtools (CC @danmosemsft @leecow - are we planning on branching buildtools to 3.0 as well?)

@dagood @mmitche PTAL

@livarcocc is the versioning correct for the CLI dependency?