### PR TITLE
Remove PGO, IBC, CoreFX, and Core-Setup flow to CoreCLR

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -166,11 +166,8 @@
     // Update dependencies in CoreCLR master
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/corefx/master/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/coreclr/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/PGO/Latest.txt",
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/master/IBC/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
       ],
       "action": "coreclr-general",
       "delay": "00:10:00",


### PR DESCRIPTION
Remove PGO, IBC, CoreFX, and Core-Setup flow to CoreCLR as the now flow using Darc/Maestro++