### PR TITLE
Add auto-merge from Master into Release/3.0

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1857,7 +1857,7 @@
       "triggerPaths": [
         "https://github.com/dotnet/coreclr/blob/master/**/*",
         "https://github.com/dotnet/corefx/blob/master/**/*",
-        "https://github.com/dotnet/core-setup/blob/master**/*",
+        "https://github.com/dotnet/core-setup/blob/master/**/*",
       ],
       "action": "dotnet-arcade-general",
       "actionArguments": {

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1852,6 +1852,31 @@
         }
       }
     },
+    // Automate opening PRs to merge dotnet org repos' master changes into release/3.0 branches
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/coreclr/blob/master/**/*",
+        "https://github.com/dotnet/corefx/blob/master/**/*",
+        "https://github.com/dotnet/core-setup/blob/master**/*",
+      ],
+      "action": "dotnet-arcade-general",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepo": "<trigger-repo>",
+          "ScriptFileName": "scripts\\GitHubMergeBranches.ps1",
+          "Arguments":[
+            "-Fork",
+            "-Username dotnet-maestro-bot",
+            "-HeadBranch master",
+            "-BaseBranch release/3.0",
+            "-RepoOwner dotnet",
+            "-RepoName $(GithubRepo)",
+            "-AuthToken `$(`$Secrets[`'BotAccount-dotnet-maestro-bot-PAT`'])"
+          ]
+        }
+      }
+    },
     // Automate opening PRs to merge dotnet org repos' release/2.2 changes into master branches
     {
       "triggerPaths": [


### PR DESCRIPTION
Please don't merge this until the release/3.0 branches are open for Preview4 (I'll poke at this PR once that's the case)

Adds auto-merges from master into release/3.0 for CoreClr, CoreFx, and Core-Setup.

@mmitche @dagood PTAL

CC @danmosemsft 