### PR TITLE
Update Core* repos from buildtools 3.0 rather than master

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -421,7 +421,7 @@
     // Update dependencies in CoreCLR release/3.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master.txt",
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/3.0/Latest.txt",
         "https://github.com/dotnet/versions/blob/master/build-info/dotnet/optimization/release/3.0/Latest.txt"
       ],
       "action": "coreclr-general",
@@ -749,7 +749,7 @@
     // Update dependencies in CoreFX release/3.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/3.0/Latest.txt"
       ],
       "action": "corefx-general",
       "delay": "00:10:00",
@@ -1117,7 +1117,7 @@
     // Update dependencies in core-setup release/3.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/master/Latest.txt"
+        "https://github.com/dotnet/versions/blob/master/build-info/dotnet/buildtools/release/3.0/Latest.txt"
       ],
       "action": "core-setup-general",
       "delay": "00:10:00",


### PR DESCRIPTION
I've just branched buildtools to release/3.0 (as per discussions on Friday), so we should update Core* dependencies from there rather than from master. https://github.com/dotnet/buildtools/commit/2912fd36eaffe4e998073044d0be9319ff5213dd

CC @danmosemsft @leecow @mmitche @dagood 