### PR TITLE
add subscription for dotnet/fsharp

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -831,6 +831,8 @@
         "https://github.com/dotnet/docker-tools/blob/master/**/*",
         "https://github.com/dotnet/dotnet-docker/blob/master/**/*",
         "https://github.com/dotnet/dotnet-docker/blob/nightly/**/*",
+	"https://github.com/dotnet/fsharp/blob/master/**/*",
+	"https://github.com/dotnet/fsharp/blob/release/**/*",
         "https://github.com/dotnet/iot/blob/master/**/*",
         "https://github.com/dotnet/msbuild-language-service/blob/master/**/*",
         "https://github.com/dotnet/msbuild-language-service/blob/release/**/*",


### PR DESCRIPTION
`Microsoft/visualfsharp` was recently renamed to `dotnet/fsharp`.

@mmitche for review.