### PR TITLE
Adding 3.0 to list of subscriptions in order to mirror these branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -2064,10 +2064,11 @@
       "triggerPaths": [
         "https://github.com/dotnet/corefx/blob/master/src/Common/src/CoreLib/**/*",
         "https://github.com/dotnet/corefx/blob/release/2.1/src/Common/src/CoreLib/**/*",
+        "https://github.com/dotnet/corefx/blob/release/3.0/src/Common/src/CoreLib/**/*",
         "https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/**/*",
         "https://github.com/dotnet/coreclr/blob/release/2.1/src/System.Private.CoreLib/shared/**/*",
-        "https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/**/*",
-        "https://github.com/dotnet/corert/blob/release/2.1/src/System.Private.CoreLib/shared/**/*"
+        "https://github.com/dotnet/coreclr/blob/release/3.0/src/System.Private.CoreLib/shared/**/*",
+        "https://github.com/dotnet/corert/blob/master/src/System.Private.CoreLib/shared/**/*"
       ],
       "action": "DotNet-GitSync-CommitManager",
       "actionArguments": {


### PR DESCRIPTION
Corert does not have any release branches so removing them from the list of subscriptions