### PR TITLE
Split image info file for dotnet-docker nightly

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
@@ -1,0 +1,1058 @@
+[
+  {
+    "repo": "dotnet/core-nightly/aspnet",
+    "images": {
+      "2.1/aspnet/alpine3.7/amd64": {
+        "simpleTags": [
+          "2.1-alpine3.7",
+          "2.1.12-alpine3.7"
+        ]
+      },
+      "2.1/aspnet/alpine3.9/amd64": {
+        "simpleTags": [
+          "2.1-alpine",
+          "2.1-alpine3.9",
+          "2.1.12-alpine",
+          "2.1.12-alpine3.9"
+        ]
+      },
+      "2.1/aspnet/bionic/amd64": {
+        "simpleTags": [
+          "2.1-bionic",
+          "2.1.12-bionic"
+        ]
+      },
+      "2.1/aspnet/bionic/arm32v7": {
+        "simpleTags": [
+          "2.1-bionic-arm32v7",
+          "2.1.12-bionic-arm32v7"
+        ]
+      },
+      "2.1/aspnet/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1803",
+          "2.1.12-nanoserver-1803"
+        ]
+      },
+      "2.1/aspnet/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1809",
+          "2.1.12-nanoserver-1809"
+        ]
+      },
+      "2.1/aspnet/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1903",
+          "2.1.12-nanoserver-1903"
+        ]
+      },
+      "2.1/aspnet/stretch-slim/amd64": {
+        "simpleTags": [
+          "2.1-stretch-slim",
+          "2.1.12-stretch-slim"
+        ]
+      },
+      "2.1/aspnet/stretch-slim/arm32v7": {
+        "simpleTags": [
+          "2.1-stretch-slim-arm32v7",
+          "2.1.12-stretch-slim-arm32v7"
+        ]
+      },
+      "2.2/aspnet/alpine3.8/amd64": {
+        "simpleTags": [
+          "2.2-alpine3.8",
+          "2.2.6-alpine3.8"
+        ]
+      },
+      "2.2/aspnet/alpine3.9/amd64": {
+        "simpleTags": [
+          "2.2-alpine",
+          "2.2-alpine3.9",
+          "2.2.6-alpine",
+          "2.2.6-alpine3.9"
+        ]
+      },
+      "2.2/aspnet/bionic/amd64": {
+        "simpleTags": [
+          "2.2-bionic",
+          "2.2.6-bionic"
+        ]
+      },
+      "2.2/aspnet/bionic/arm32v7": {
+        "simpleTags": [
+          "2.2-bionic-arm32v7",
+          "2.2.6-bionic-arm32v7"
+        ]
+      },
+      "2.2/aspnet/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1803",
+          "2.2.6-nanoserver-1803"
+        ]
+      },
+      "2.2/aspnet/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1809",
+          "2.2.6-nanoserver-1809"
+        ]
+      },
+      "2.2/aspnet/nanoserver-1809/arm32v7": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:b18061af61fc812243bda9fd8d8ba1d360593df8bdb5bec7e7fe9ba61779ee62"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1809-arm32",
+          "2.2-nanoserver-1809-arm32v7",
+          "2.2.6-nanoserver-1809-arm32v7"
+        ]
+      },
+      "2.2/aspnet/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1903",
+          "2.2.6-nanoserver-1903"
+        ]
+      },
+      "2.2/aspnet/stretch-slim/amd64": {
+        "simpleTags": [
+          "2.2-stretch-slim",
+          "2.2.6-stretch-slim"
+        ]
+      },
+      "2.2/aspnet/stretch-slim/arm32v7": {
+        "simpleTags": [
+          "2.2-stretch-slim-arm32v7",
+          "2.2.6-stretch-slim-arm32v7"
+        ]
+      },
+      "3.0/aspnet/alpine3.9/amd64": {
+        "simpleTags": [
+          "3.0-alpine",
+          "3.0-alpine3.9",
+          "3.0.0-preview8-alpine",
+          "3.0.0-preview8-alpine3.9"
+        ]
+      },
+      "3.0/aspnet/alpine3.9/arm64v8": {
+        "simpleTags": [
+          "3.0-alpine-arm64v8",
+          "3.0-alpine3.9-arm64v8",
+          "3.0.0-preview8-alpine-arm64v8",
+          "3.0.0-preview8-alpine3.9-arm64v8"
+        ]
+      },
+      "3.0/aspnet/bionic/amd64": {
+        "simpleTags": [
+          "3.0-bionic",
+          "3.0.0-preview8-bionic"
+        ]
+      },
+      "3.0/aspnet/bionic/arm32v7": {
+        "simpleTags": [
+          "3.0-bionic-arm32v7",
+          "3.0.0-preview8-bionic-arm32v7"
+        ]
+      },
+      "3.0/aspnet/bionic/arm64v8": {
+        "simpleTags": [
+          "3.0-bionic-arm64v8",
+          "3.0.0-preview8-bionic-arm64v8"
+        ]
+      },
+      "3.0/aspnet/buster-slim/amd64": {
+        "simpleTags": [
+          "3.0-buster-slim",
+          "3.0.0-preview8-buster-slim"
+        ]
+      },
+      "3.0/aspnet/buster-slim/arm32v7": {
+        "simpleTags": [
+          "3.0-buster-slim-arm32v7",
+          "3.0.0-preview8-buster-slim-arm32v7"
+        ]
+      },
+      "3.0/aspnet/buster-slim/arm64v8": {
+        "simpleTags": [
+          "3.0-buster-slim-arm64v8",
+          "3.0.0-preview8-buster-slim-arm64v8"
+        ]
+      },
+      "3.0/aspnet/disco/amd64": {
+        "simpleTags": [
+          "3.0-disco",
+          "3.0.0-preview8-disco"
+        ]
+      },
+      "3.0/aspnet/disco/arm32v7": {
+        "simpleTags": [
+          "3.0-disco-arm32v7",
+          "3.0.0-preview8-disco-arm32v7"
+        ]
+      },
+      "3.0/aspnet/disco/arm64v8": {
+        "simpleTags": [
+          "3.0-disco-arm64v8",
+          "3.0.0-preview8-disco-arm64v8"
+        ]
+      },
+      "3.0/aspnet/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1803",
+          "3.0.0-preview8-nanoserver-1803"
+        ]
+      },
+      "3.0/aspnet/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1809",
+          "3.0.0-preview8-nanoserver-1809"
+        ]
+      },
+      "3.0/aspnet/nanoserver-1809/arm32v7": {
+        "simpleTags": [
+          "3.0-nanoserver-1809-arm32v7",
+          "3.0.0-preview8-nanoserver-1809-arm32v7"
+        ]
+      },
+      "3.0/aspnet/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1903",
+          "3.0.0-preview8-nanoserver-1903"
+        ]
+      }
+    }
+  },
+  {
+    "repo": "dotnet/core-nightly/runtime",
+    "images": {
+      "1.0/runtime/jessie/amd64": {
+        "simpleTags": []
+      },
+      "1.0/runtime/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
+        },
+        "simpleTags": []
+      },
+      "1.1/runtime/jessie/amd64": {
+        "simpleTags": []
+      },
+      "1.1/runtime/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
+        },
+        "simpleTags": []
+      },
+      "1.1/runtime/stretch/amd64": {
+        "simpleTags": []
+      },
+      "2.1/runtime/alpine3.7/amd64": {
+        "simpleTags": [
+          "2.1-alpine3.7",
+          "2.1.12-alpine3.7"
+        ]
+      },
+      "2.1/runtime/alpine3.9/amd64": {
+        "simpleTags": [
+          "2.1-alpine",
+          "2.1-alpine3.9",
+          "2.1.12-alpine",
+          "2.1.12-alpine3.9"
+        ]
+      },
+      "2.1/runtime/bionic/amd64": {
+        "simpleTags": [
+          "2.1-bionic",
+          "2.1.12-bionic"
+        ]
+      },
+      "2.1/runtime/bionic/arm32v7": {
+        "simpleTags": [
+          "2.1-bionic-arm32v7",
+          "2.1.12-bionic-arm32v7"
+        ]
+      },
+      "2.1/runtime/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1803",
+          "2.1.12-nanoserver-1803"
+        ]
+      },
+      "2.1/runtime/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1809",
+          "2.1.12-nanoserver-1809"
+        ]
+      },
+      "2.1/runtime/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1903",
+          "2.1.12-nanoserver-1903"
+        ]
+      },
+      "2.1/runtime/stretch-slim/amd64": {
+        "simpleTags": [
+          "2.1-stretch-slim",
+          "2.1.12-stretch-slim"
+        ]
+      },
+      "2.1/runtime/stretch-slim/arm32v7": {
+        "simpleTags": [
+          "2.1-stretch-slim-arm32v7",
+          "2.1.12-stretch-slim-arm32v7"
+        ]
+      },
+      "2.2/runtime/alpine3.8/amd64": {
+        "simpleTags": [
+          "2.2-alpine3.8",
+          "2.2.6-alpine3.8"
+        ]
+      },
+      "2.2/runtime/alpine3.9/amd64": {
+        "simpleTags": [
+          "2.2-alpine",
+          "2.2-alpine3.9",
+          "2.2.6-alpine",
+          "2.2.6-alpine3.9"
+        ]
+      },
+      "2.2/runtime/bionic/amd64": {
+        "simpleTags": [
+          "2.2-bionic",
+          "2.2.6-bionic"
+        ]
+      },
+      "2.2/runtime/bionic/arm32v7": {
+        "simpleTags": [
+          "2.2-bionic-arm32v7",
+          "2.2.6-bionic-arm32v7"
+        ]
+      },
+      "2.2/runtime/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1803",
+          "2.2.6-nanoserver-1803"
+        ]
+      },
+      "2.2/runtime/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1809",
+          "2.2.6-nanoserver-1809"
+        ]
+      },
+      "2.2/runtime/nanoserver-1809/arm32v7": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:b18061af61fc812243bda9fd8d8ba1d360593df8bdb5bec7e7fe9ba61779ee62"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1809-arm32",
+          "2.2-nanoserver-1809-arm32v7",
+          "2.2.6-nanoserver-1809-arm32v7"
+        ]
+      },
+      "2.2/runtime/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1903",
+          "2.2.6-nanoserver-1903"
+        ]
+      },
+      "2.2/runtime/stretch-slim/amd64": {
+        "simpleTags": [
+          "2.2-stretch-slim",
+          "2.2.6-stretch-slim"
+        ]
+      },
+      "2.2/runtime/stretch-slim/arm32v7": {
+        "simpleTags": [
+          "2.2-stretch-slim-arm32v7",
+          "2.2.6-stretch-slim-arm32v7"
+        ]
+      },
+      "3.0/runtime/alpine3.9/amd64": {
+        "simpleTags": [
+          "3.0-alpine",
+          "3.0-alpine3.9",
+          "3.0.0-preview8-alpine",
+          "3.0.0-preview8-alpine3.9"
+        ]
+      },
+      "3.0/runtime/alpine3.9/arm64v8": {
+        "simpleTags": [
+          "3.0-alpine-arm64v8",
+          "3.0-alpine3.9-arm64v8",
+          "3.0.0-preview8-alpine-arm64v8",
+          "3.0.0-preview8-alpine3.9-arm64v8"
+        ]
+      },
+      "3.0/runtime/bionic/amd64": {
+        "simpleTags": [
+          "3.0-bionic",
+          "3.0.0-preview8-bionic"
+        ]
+      },
+      "3.0/runtime/bionic/arm32v7": {
+        "simpleTags": [
+          "3.0-bionic-arm32v7",
+          "3.0.0-preview8-bionic-arm32v7"
+        ]
+      },
+      "3.0/runtime/bionic/arm64v8": {
+        "simpleTags": [
+          "3.0-bionic-arm64v8",
+          "3.0.0-preview8-bionic-arm64v8"
+        ]
+      },
+      "3.0/runtime/buster-slim/amd64": {
+        "simpleTags": [
+          "3.0-buster-slim",
+          "3.0.0-preview8-buster-slim"
+        ]
+      },
+      "3.0/runtime/buster-slim/arm32v7": {
+        "simpleTags": [
+          "3.0-buster-slim-arm32v7",
+          "3.0.0-preview8-buster-slim-arm32v7"
+        ]
+      },
+      "3.0/runtime/buster-slim/arm64v8": {
+        "simpleTags": [
+          "3.0-buster-slim-arm64v8",
+          "3.0.0-preview8-buster-slim-arm64v8"
+        ]
+      },
+      "3.0/runtime/disco/amd64": {
+        "simpleTags": [
+          "3.0-disco",
+          "3.0.0-preview8-disco"
+        ]
+      },
+      "3.0/runtime/disco/arm32v7": {
+        "simpleTags": [
+          "3.0-disco-arm32v7",
+          "3.0.0-preview8-disco-arm32v7"
+        ]
+      },
+      "3.0/runtime/disco/arm64v8": {
+        "simpleTags": [
+          "3.0-disco-arm64v8",
+          "3.0.0-preview8-disco-arm64v8"
+        ]
+      },
+      "3.0/runtime/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1803",
+          "3.0.0-preview8-nanoserver-1803"
+        ]
+      },
+      "3.0/runtime/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1809",
+          "3.0.0-preview8-nanoserver-1809"
+        ]
+      },
+      "3.0/runtime/nanoserver-1809/arm32v7": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:b18061af61fc812243bda9fd8d8ba1d360593df8bdb5bec7e7fe9ba61779ee62"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1809-arm32v7",
+          "3.0.0-preview8-nanoserver-1809-arm32v7"
+        ]
+      },
+      "3.0/runtime/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1903",
+          "3.0.0-preview8-nanoserver-1903"
+        ]
+      }
+    }
+  },
+  {
+    "repo": "dotnet/core-nightly/runtime-deps",
+    "images": {
+      "1.0/runtime-deps/jessie/amd64": {
+        "baseImages": {
+          "debian:jessie": "debian@sha256:6b95a104400bb99ad60b47a48e37d5d1eb71a3f9ec8e86854e0cf64ecc5fd0e8"
+        },
+        "simpleTags": []
+      },
+      "1.1/runtime-deps/stretch/amd64": {
+        "baseImages": {
+          "debian:stretch": "debian@sha256:2b20d1b80dbcdef98ff4e747109c39d2b91539f7f12d7873fdd452306eddb04d"
+        },
+        "simpleTags": []
+      },
+      "2.1/runtime-deps/alpine3.7/amd64": {
+        "baseImages": {
+          "alpine:3.7": "alpine@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10"
+        },
+        "simpleTags": [
+          "2.1-alpine3.7",
+          "2.1.12-alpine3.7"
+        ]
+      },
+      "2.1/runtime-deps/alpine3.9/amd64": {
+        "baseImages": {
+          "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
+        },
+        "simpleTags": [
+          "2.1-alpine",
+          "2.1-alpine3.9",
+          "2.1.12-alpine",
+          "2.1.12-alpine3.9",
+          "2.2-alpine",
+          "2.2-alpine3.9",
+          "2.2.6-alpine",
+          "2.2.6-alpine3.9"
+        ]
+      },
+      "2.1/runtime-deps/bionic/amd64": {
+        "baseImages": {
+          "ubuntu:bionic": "ubuntu@sha256:c303f19cfe9ee92badbbbd7567bc1ca47789f79303ddcef56f77687d4744cd7a"
+        },
+        "simpleTags": [
+          "2.1-bionic",
+          "2.1.12-bionic",
+          "2.2-bionic",
+          "2.2.6-bionic"
+        ]
+      },
+      "2.1/runtime-deps/bionic/arm32v7": {
+        "baseImages": {
+          "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:46fe74f7b605368593fd21ff9db45429d9faa86550ad13f7eefb2c995c69b271"
+        },
+        "simpleTags": [
+          "2.1-bionic-arm32v7",
+          "2.1.12-bionic-arm32v7",
+          "2.2-bionic-arm32v7",
+          "2.2.6-bionic-arm32v7"
+        ]
+      },
+      "2.1/runtime-deps/stretch-slim/amd64": {
+        "baseImages": {
+          "debian:stretch-slim": "debian@sha256:0c04edb9ae10feb7ac03a659dd41e16c79e04fdb2b10cf93c3cbcef1fd6cc1d5"
+        },
+        "simpleTags": [
+          "2.1-stretch-slim",
+          "2.1.12-stretch-slim",
+          "2.2-stretch-slim",
+          "2.2.6-stretch-slim"
+        ]
+      },
+      "2.1/runtime-deps/stretch-slim/arm32v7": {
+        "baseImages": {
+          "arm32v7/debian:stretch-slim": "arm32v7/debian@sha256:f241a8a18e6b3544c6cef738c1df10c3de5617e1cf433973b700df1ae1134ad1"
+        },
+        "simpleTags": [
+          "2.1-stretch-slim-arm32v7",
+          "2.1.12-stretch-slim-arm32v7",
+          "2.2-stretch-slim-arm32v7",
+          "2.2.6-stretch-slim-arm32v7"
+        ]
+      },
+      "2.2/runtime-deps/alpine3.8/amd64": {
+        "baseImages": {
+          "alpine:3.8": "alpine@sha256:04696b491e0cc3c58a75bace8941c14c924b9f313b03ce5029ebbc040ed9dcd9"
+        },
+        "simpleTags": [
+          "2.2-alpine3.8",
+          "2.2.6-alpine3.8"
+        ]
+      },
+      "3.0/runtime-deps/alpine3.9/amd64": {
+        "baseImages": {
+          "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
+        },
+        "simpleTags": [
+          "3.0-alpine",
+          "3.0-alpine3.9",
+          "3.0.0-preview8-alpine",
+          "3.0.0-preview8-alpine3.9"
+        ]
+      },
+      "3.0/runtime-deps/alpine3.9/arm64v8": {
+        "baseImages": {
+          "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
+        },
+        "simpleTags": [
+          "3.0-alpine-arm64v8",
+          "3.0-alpine3.9-arm64v8",
+          "3.0.0-preview8-alpine-arm64v8",
+          "3.0.0-preview8-alpine3.9-arm64v8"
+        ]
+      },
+      "3.0/runtime-deps/bionic/amd64": {
+        "baseImages": {
+          "ubuntu:bionic": "ubuntu@sha256:c303f19cfe9ee92badbbbd7567bc1ca47789f79303ddcef56f77687d4744cd7a"
+        },
+        "simpleTags": [
+          "3.0-bionic",
+          "3.0.0-preview8-bionic"
+        ]
+      },
+      "3.0/runtime-deps/bionic/arm32v7": {
+        "baseImages": {
+          "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:46fe74f7b605368593fd21ff9db45429d9faa86550ad13f7eefb2c995c69b271"
+        },
+        "simpleTags": [
+          "3.0-bionic-arm32v7",
+          "3.0.0-preview8-bionic-arm32v7"
+        ]
+      },
+      "3.0/runtime-deps/bionic/arm64v8": {
+        "baseImages": {
+          "arm64v8/ubuntu:bionic": "arm64v8/ubuntu@sha256:be2ef80501adc5a13c4a58a8045923d4e64b691aaa7e6e470c14e88a45845d0d"
+        },
+        "simpleTags": [
+          "3.0-bionic-arm64v8",
+          "3.0.0-preview8-bionic-arm64v8"
+        ]
+      },
+      "3.0/runtime-deps/buster-slim/amd64": {
+        "baseImages": {
+          "debian:buster-slim": "debian@sha256:0cee610aaf530adfbddf9ce6e679d57c67882f37b6aeaac1ce027e1e13dad4d5"
+        },
+        "simpleTags": [
+          "3.0-buster-slim",
+          "3.0.0-preview8-buster-slim"
+        ]
+      },
+      "3.0/runtime-deps/buster-slim/arm32v7": {
+        "baseImages": {
+          "arm32v7/debian:buster-slim": "arm32v7/debian@sha256:37839cc0c95dc3b60e20ff2af0d2643c62428de12aed6f5c9b09752a789d8cd1"
+        },
+        "simpleTags": [
+          "3.0-buster-slim-arm32v7",
+          "3.0.0-preview8-buster-slim-arm32v7"
+        ]
+      },
+      "3.0/runtime-deps/buster-slim/arm64v8": {
+        "baseImages": {
+          "arm64v8/debian:buster-slim": "arm64v8/debian@sha256:335f7ea18a52e674b3440cb10e1fd2eb53ed9758e5a9a6226354412358f6339b"
+        },
+        "simpleTags": [
+          "3.0-buster-slim-arm64v8",
+          "3.0.0-preview8-buster-slim-arm64v8"
+        ]
+      },
+      "3.0/runtime-deps/disco/amd64": {
+        "baseImages": {
+          "ubuntu:disco": "ubuntu@sha256:8ab57098989838230963dd6a42f93b501af4742c3e30279e060c27b25b937c1c"
+        },
+        "simpleTags": [
+          "3.0-disco",
+          "3.0.0-preview8-disco"
+        ]
+      },
+      "3.0/runtime-deps/disco/arm32v7": {
+        "baseImages": {
+          "arm32v7/ubuntu:disco": "arm32v7/ubuntu@sha256:33c695388c275d95326d8fa4b685672dba9d48293c21a7207c3dfa121371b96d"
+        },
+        "simpleTags": [
+          "3.0-disco-arm32v7",
+          "3.0.0-preview8-disco-arm32v7"
+        ]
+      },
+      "3.0/runtime-deps/disco/arm64v8": {
+        "baseImages": {
+          "arm64v8/ubuntu:disco": "arm64v8/ubuntu@sha256:388ce49c120568ed0d39f5b2773217093e92715260f263bd896ff9483cd1562b"
+        },
+        "simpleTags": [
+          "3.0-disco-arm64v8",
+          "3.0.0-preview8-disco-arm64v8"
+        ]
+      }
+    }
+  },
+  {
+    "repo": "dotnet/core-nightly/sdk",
+    "images": {
+      "1.1/sdk/jessie/amd64": {
+        "baseImages": {
+          "buildpack-deps:jessie-scm": "buildpack-deps@sha256:44d0d909383bb6976c231000af4bcf7988a84afff293270b3df8fdc8af0d3483"
+        },
+        "simpleTags": []
+      },
+      "1.1/sdk/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
+        },
+        "simpleTags": []
+      },
+      "1.1/sdk/stretch/amd64": {
+        "baseImages": {
+          "buildpack-deps:stretch-scm": "buildpack-deps@sha256:0c69a4523a91a858e7e49d8818c97a467edda24553eafae8d409e3b04953226a"
+        },
+        "simpleTags": []
+      },
+      "2.1/sdk/alpine3.7/amd64": {
+        "simpleTags": [
+          "2.1-alpine3.7",
+          "2.1.801-alpine3.7"
+        ]
+      },
+      "2.1/sdk/alpine3.9/amd64": {
+        "simpleTags": [
+          "2.1-alpine",
+          "2.1-alpine3.9",
+          "2.1.801-alpine",
+          "2.1.801-alpine3.9"
+        ]
+      },
+      "2.1/sdk/bionic/amd64": {
+        "baseImages": {
+          "buildpack-deps:bionic-scm": "buildpack-deps@sha256:ac9e8e5c1ac4c11949af7f53c3babf3cd9341bcbf84dd2e02bb9dfae9058015b"
+        },
+        "simpleTags": [
+          "2.1-bionic",
+          "2.1.801-bionic"
+        ]
+      },
+      "2.1/sdk/bionic/arm32v7": {
+        "baseImages": {
+          "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:549c3b62814c4b8f8157515cd14792bd65dc4b85254e0d3838b96df62c85dbe0"
+        },
+        "simpleTags": [
+          "2.1-bionic-arm32v7",
+          "2.1.801-bionic-arm32v7"
+        ]
+      },
+      "2.1/sdk/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1803",
+          "2.1.801-nanoserver-1803"
+        ]
+      },
+      "2.1/sdk/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1809",
+          "2.1.801-nanoserver-1809"
+        ]
+      },
+      "2.1/sdk/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "2.1-nanoserver-1903",
+          "2.1.801-nanoserver-1903"
+        ]
+      },
+      "2.1/sdk/stretch/amd64": {
+        "baseImages": {
+          "buildpack-deps:stretch-scm": "buildpack-deps@sha256:6b66c77db01bc4bf4babf2b563cdde18dbd5acf092e22cddbcec51c9fd2bbade"
+        },
+        "simpleTags": [
+          "2.1-stretch",
+          "2.1.801-stretch"
+        ]
+      },
+      "2.1/sdk/stretch/arm32v7": {
+        "baseImages": {
+          "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:6b882f4ce4f2a8d2d3f0ece63ccf210793e5ec0878c5715d9695fd857564efc6"
+        },
+        "simpleTags": [
+          "2.1-stretch-arm32v7",
+          "2.1.801-stretch-arm32v7"
+        ]
+      },
+      "2.2/sdk/alpine3.8/amd64": {
+        "simpleTags": [
+          "2.2-alpine3.8",
+          "2.2.401-alpine3.8"
+        ]
+      },
+      "2.2/sdk/alpine3.9/amd64": {
+        "simpleTags": [
+          "2.2-alpine",
+          "2.2-alpine3.9",
+          "2.2.401-alpine",
+          "2.2.401-alpine3.9"
+        ]
+      },
+      "2.2/sdk/bionic/amd64": {
+        "baseImages": {
+          "buildpack-deps:bionic-scm": "buildpack-deps@sha256:ac9e8e5c1ac4c11949af7f53c3babf3cd9341bcbf84dd2e02bb9dfae9058015b"
+        },
+        "simpleTags": [
+          "2.2-bionic",
+          "2.2.401-bionic"
+        ]
+      },
+      "2.2/sdk/bionic/arm32v7": {
+        "baseImages": {
+          "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:549c3b62814c4b8f8157515cd14792bd65dc4b85254e0d3838b96df62c85dbe0"
+        },
+        "simpleTags": [
+          "2.2-bionic-arm32v7",
+          "2.2.401-bionic-arm32v7"
+        ]
+      },
+      "2.2/sdk/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1803",
+          "2.2.401-nanoserver-1803"
+        ]
+      },
+      "2.2/sdk/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1809",
+          "2.2.401-nanoserver-1809"
+        ]
+      },
+      "2.2/sdk/nanoserver-1809/arm32v7": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:b18061af61fc812243bda9fd8d8ba1d360593df8bdb5bec7e7fe9ba61779ee62"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1809-arm32",
+          "2.2-nanoserver-1809-arm32v7",
+          "2.2.401-nanoserver-1809-arm32v7"
+        ]
+      },
+      "2.2/sdk/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "2.2-nanoserver-1903",
+          "2.2.401-nanoserver-1903"
+        ]
+      },
+      "2.2/sdk/stretch/amd64": {
+        "baseImages": {
+          "buildpack-deps:stretch-scm": "buildpack-deps@sha256:6b66c77db01bc4bf4babf2b563cdde18dbd5acf092e22cddbcec51c9fd2bbade"
+        },
+        "simpleTags": [
+          "2.2-stretch",
+          "2.2.401-stretch"
+        ]
+      },
+      "2.2/sdk/stretch/arm32v7": {
+        "baseImages": {
+          "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:6b882f4ce4f2a8d2d3f0ece63ccf210793e5ec0878c5715d9695fd857564efc6"
+        },
+        "simpleTags": [
+          "2.2-stretch-arm32v7",
+          "2.2.401-stretch-arm32v7"
+        ]
+      },
+      "3.0/sdk/alpine3.9/amd64": {
+        "simpleTags": [
+          "3.0-alpine",
+          "3.0-alpine3.9",
+          "3.0.100-preview8-alpine",
+          "3.0.100-preview8-alpine3.9"
+        ]
+      },
+      "3.0/sdk/bionic/amd64": {
+        "baseImages": {
+          "buildpack-deps:bionic-scm": "buildpack-deps@sha256:ac9e8e5c1ac4c11949af7f53c3babf3cd9341bcbf84dd2e02bb9dfae9058015b"
+        },
+        "simpleTags": [
+          "3.0-bionic",
+          "3.0.100-preview8-bionic"
+        ]
+      },
+      "3.0/sdk/bionic/arm32v7": {
+        "baseImages": {
+          "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:549c3b62814c4b8f8157515cd14792bd65dc4b85254e0d3838b96df62c85dbe0"
+        },
+        "simpleTags": [
+          "3.0-bionic-arm32v7",
+          "3.0.100-preview8-bionic-arm32v7"
+        ]
+      },
+      "3.0/sdk/bionic/arm64v8": {
+        "baseImages": {
+          "arm64v8/buildpack-deps:bionic-scm": "arm64v8/buildpack-deps@sha256:7c317e26a7150428555a7438d6c7c3f7a562ba759157fcf1912fac02cc0862e7"
+        },
+        "simpleTags": [
+          "3.0-bionic-arm64v8",
+          "3.0.100-preview8-bionic-arm64v8"
+        ]
+      },
+      "3.0/sdk/buster/amd64": {
+        "baseImages": {
+          "buildpack-deps:buster-scm": "buildpack-deps@sha256:b0da50fc3f46feb4998539e965f8fb957bf35b42e932d98e2fe918dabb99f5e0"
+        },
+        "simpleTags": [
+          "3.0-buster",
+          "3.0.100-preview8-buster"
+        ]
+      },
+      "3.0/sdk/buster/arm32v7": {
+        "baseImages": {
+          "arm32v7/buildpack-deps:buster-scm": "arm32v7/buildpack-deps@sha256:d99b6cb74021ec1a36abdf3499e14506fda03f2984d82752d681d680a21d6f11"
+        },
+        "simpleTags": [
+          "3.0-buster-arm32v7",
+          "3.0.100-preview8-buster-arm32v7"
+        ]
+      },
+      "3.0/sdk/buster/arm64v8": {
+        "baseImages": {
+          "arm64v8/buildpack-deps:buster-scm": "arm64v8/buildpack-deps@sha256:4dcca5233cb69e6879f87c33e82f266f1fe4bd578d7c351fd0ae414f7fac56df"
+        },
+        "simpleTags": [
+          "3.0-buster-arm64v8",
+          "3.0.100-preview8-buster-arm64v8"
+        ]
+      },
+      "3.0/sdk/disco/amd64": {
+        "baseImages": {
+          "buildpack-deps:disco-scm": "buildpack-deps@sha256:86bd1854a9e227f7a8e3782672cb3fe2f5a2a98b65779e20a2c2c0daecb2693b"
+        },
+        "simpleTags": [
+          "3.0-disco",
+          "3.0.100-preview8-disco"
+        ]
+      },
+      "3.0/sdk/disco/arm32v7": {
+        "baseImages": {
+          "arm32v7/buildpack-deps:disco-scm": "arm32v7/buildpack-deps@sha256:de5884b74dd8dd74b2ab3a6a5db0a5007d2a3909e67e8cb7a75305f78c939c83"
+        },
+        "simpleTags": [
+          "3.0-disco-arm32v7",
+          "3.0.100-preview8-disco-arm32v7"
+        ]
+      },
+      "3.0/sdk/disco/arm64v8": {
+        "baseImages": {
+          "arm64v8/buildpack-deps:disco-scm": "arm64v8/buildpack-deps@sha256:b7b50f99b1f2f09fd7437b69c538d7e59d65d824d3f73eca9cdcde297f9fd8aa"
+        },
+        "simpleTags": [
+          "3.0-disco-arm64v8",
+          "3.0.100-preview8-disco-arm64v8"
+        ]
+      },
+      "3.0/sdk/nanoserver-1803/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:bc5c1878a69c4538d55bc74e50b7dbafafff1a373120e624e8bad646a0a505dc",
+          "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:4374dbc78737bfec459fe6e2047466faa7c21a03aec362ce61735692ed54e598"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1803",
+          "3.0.100-preview8-nanoserver-1803"
+        ]
+      },
+      "3.0/sdk/nanoserver-1809/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:f4e90ea2a4fa220edd3db4ab1e22b287c3a7bd9ee2d07c71f92f126b42161634",
+          "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:0193dba5d3c7f3c0e23ea956a62f77122585ddb2295435895ecc214122f47475"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1809",
+          "3.0.100-preview8-nanoserver-1809"
+        ]
+      },
+      "3.0/sdk/nanoserver-1809/arm32v7": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:b18061af61fc812243bda9fd8d8ba1d360593df8bdb5bec7e7fe9ba61779ee62"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1809-arm32v7",
+          "3.0.100-preview8-nanoserver-1809-arm32v7"
+        ]
+      },
+      "3.0/sdk/nanoserver-1903/amd64": {
+        "baseImages": {
+          "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:b899bcae24668edfe1a46a1ef38db6d93b0dbface0a0ac4ecbfc85a4ed773992",
+          "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:c62a91ab9f3a1478041dbf2c97fb437074a9f49492d3aa400d2d660f0d8891e7"
+        },
+        "simpleTags": [
+          "3.0-nanoserver-1903",
+          "3.0.100-preview8-nanoserver-1903"
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
This just copies the image info file content related to the dotnet-docker repos' nightly branch into its own file.  This is related to https://github.com/dotnet/dotnet-docker/pull/1262.