### PR TITLE
Split image info file for buildtools-prereqs

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -1,0 +1,145 @@
+[
+  {
+    "repo": "dotnet-buildtools/prereqs",
+    "images": {
+      "src/debian/10/helix/amd64": {
+        "baseImages": {
+          "debian:buster": "debian@sha256:903779f30a7ee46937bfb21406f125d5fdace4178074e1cc71c49039ebf7f48f"
+        },
+        "simpleTags": [
+          "debian-10-helix-amd64-6b166d8-20190807161114"
+        ]
+      },
+      "src/debian/10/helix/arm32v7": {
+        "baseImages": {
+          "arm32v7/debian:buster": "arm32v7/debian@sha256:2dc27b0362abdf8e47f6090c7f5f855efbfc870cb0d03ad990021ff2d9bf9541"
+        },
+        "simpleTags": [
+          "debian-10-helix-arm32v7-6b166d8-20190807161034"
+        ]
+      },
+      "src/debian/10/helix/arm64v8": {
+        "baseImages": {
+          "arm64v8/debian:buster": "arm64v8/debian@sha256:d5d8c18489f86d65c77cb7e9f2b4f7fc438a0c4cc9ac563e290524ce2d2f11c2"
+        },
+        "simpleTags": [
+          "debian-10-helix-arm64v8-6b166d8-20190807161035"
+        ]
+      },
+      "src/debian/9/arm32v7": {
+        "baseImages": {
+          "arm32v7/debian:9": "arm32v7/debian@sha256:205a3d2b05453df39a6bf7339dfd81878f9828985f8dcc1b7fa5c6fdbb94fd4a"
+        },
+        "simpleTags": [
+          "debian-9-arm32v7-0dbbad8-20190807161034"
+        ]
+      },
+      "src/debian/9/arm64v8": {
+        "baseImages": {
+          "arm64v8/debian:9": "arm64v8/debian@sha256:e8f82c8a38bc474644ccd16911793ad4a676fd6f5c0508555ca5fc7e12be06ec"
+        },
+        "simpleTags": [
+          "debian-9-arm64v8-3e800f1-20190807161037"
+        ]
+      },
+      "src/debian/9/helix/arm32v7": {
+        "baseImages": {
+          "arm32v7/debian:9": "arm32v7/debian@sha256:205a3d2b05453df39a6bf7339dfd81878f9828985f8dcc1b7fa5c6fdbb94fd4a"
+        },
+        "simpleTags": [
+          "debian-9-helix-arm32v7-6b166d8-20190807161035"
+        ]
+      },
+      "src/debian/9/helix/arm64v8": {
+        "baseImages": {
+          "arm64v8/debian:9": "arm64v8/debian@sha256:e8f82c8a38bc474644ccd16911793ad4a676fd6f5c0508555ca5fc7e12be06ec"
+        },
+        "simpleTags": [
+          "debian-9-helix-arm64v8-a12566d-20190807161036"
+        ]
+      },
+      "src/debian/iot/arm32v7": {
+        "baseImages": {
+          "arm32v7/debian:latest": "arm32v7/debian@sha256:2dc27b0362abdf8e47f6090c7f5f855efbfc870cb0d03ad990021ff2d9bf9541"
+        },
+        "simpleTags": [
+          "debian-iot-arm32v7-be5b37d-20190807161037"
+        ]
+      },
+      "src/debian/jessie": {
+        "simpleTags": [
+          "debian-jessie-3e800f1-20190807161116"
+        ]
+      },
+      "src/debian/jessie/coredeps": {
+        "baseImages": {
+          "debian:jessie": "debian@sha256:a8ae3c5129fb2e10a62b5c059a24308831508c44018c24ccda2e4fc6fd7cdda7"
+        },
+        "simpleTags": [
+          "debian-jessie-coredeps-3e800f1-20190807161116"
+        ]
+      },
+      "src/debian/jessie/corert": {
+        "simpleTags": [
+          "debian-jessie-corert-58e4974-20190807161116"
+        ]
+      },
+      "src/debian/jessie/debpkg": {
+        "simpleTags": [
+          "debian-jessie-debpkg-58e4974-20190807161116"
+        ]
+      },
+      "src/debian/stretch-slim/docker-testrunner": {
+        "baseImages": {
+          "debian:stretch-slim": "debian@sha256:0c04edb9ae10feb7ac03a659dd41e16c79e04fdb2b10cf93c3cbcef1fd6cc1d5"
+        },
+        "simpleTags": [
+          "debian-stretch-slim-docker-testrunner-d61254f-20190807161111"
+        ]
+      },
+      "src/debian/stretch/": {
+        "baseImages": {
+          "debian:stretch": "debian@sha256:397b2157a9ea8d7f16c613aded70284292106e8b813fb1ed5de8a8785310a26a"
+        },
+        "simpleTags": [
+          "debian-stretch-d61254f-20190807161114"
+        ]
+      },
+      "src/fedora/29": {
+        "baseImages": {
+          "fedora:29": "fedora@sha256:2c20e5bb324735427f8a659e36f4fe14d6955c74c7baa25067418dddbb71d67a"
+        },
+        "simpleTags": [
+          "fedora-29-a12566d-20190806171712"
+        ]
+      },
+      "src/fedora/29/helix/amd64": {
+        "simpleTags": [
+          "fedora-29-helix-a12566d-20190806171712"
+        ]
+      },
+      "src/fedora/30/amd64": {
+        "baseImages": {
+          "fedora:30": "fedora@sha256:d39a02a0f13c1df3bbcb0ccea4021c53b8e0bfd87f701a5115e18ec089814e70"
+        },
+        "simpleTags": [
+          "fedora-30-39ec319-20190806171718"
+        ]
+      },
+      "src/fedora/30/helix/amd64": {
+        "simpleTags": [
+          "fedora-30-helix-2e197e0-20190806171718"
+        ]
+      },
+      "src/ubuntu/19.04/helix/amd64": {
+        "baseImages": {
+          "ubuntu:19.04": "ubuntu@sha256:8ab57098989838230963dd6a42f93b501af4742c3e30279e060c27b25b937c1c"
+        },
+        "simpleTags": [
+          "ubuntu-19.04-helix-amd64-09ca40b-20190802141739",
+          "ubuntu-19.04-helix-amd64-2e197e0-20190806155103"
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
This just copies the image info file content related to the dotnet-buildtools-prereqs-docker repo's master branch into its own file.  This is related to https://github.com/dotnet/dotnet-docker/pull/1262.

@MichaelSimons 