### PR TITLE
Update image info format to include Dockerfile name

### DIFF
--- a/build-info/docker/image-info.Microsoft-dotnet-framework-docker-master.json
+++ b/build-info/docker/image-info.Microsoft-dotnet-framework-docker-master.json
@@ -2,85 +2,85 @@
   {
     "repo": "dotnet/framework/aspnet",
     "images": {
-      "3.5/aspnet/windowsservercore-1803": {
+      "3.5/aspnet/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1803",
           "3.5-windowsservercore-1803"
         ]
       },
-      "3.5/aspnet/windowsservercore-1903": {
+      "3.5/aspnet/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1903",
           "3.5-windowsservercore-1903"
         ]
       },
-      "3.5/aspnet/windowsservercore-ltsc2016": {
+      "3.5/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2016",
           "3.5-windowsservercore-ltsc2016"
         ]
       },
-      "3.5/aspnet/windowsservercore-ltsc2019": {
+      "3.5/aspnet/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2019",
           "3.5-windowsservercore-ltsc2019"
         ]
       },
-      "4.6.2/aspnet/windowsservercore-ltsc2016": {
+      "4.6.2/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.6.2-20190910-windowsservercore-ltsc2016",
           "4.6.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.1/aspnet/windowsservercore-ltsc2016": {
+      "4.7.1/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.1-20190910-windowsservercore-ltsc2016",
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/aspnet/windowsservercore-1803": {
+      "4.7.2/aspnet/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-1803",
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/aspnet/windowsservercore-ltsc2016": {
+      "4.7.2/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2016",
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/aspnet/windowsservercore-ltsc2019": {
+      "4.7.2/aspnet/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2019",
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.7/aspnet/windowsservercore-ltsc2016": {
+      "4.7/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7-20190910-windowsservercore-ltsc2016",
           "4.7-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/aspnet/windowsservercore-1803": {
+      "4.8/aspnet/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1803",
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/aspnet/windowsservercore-1903": {
+      "4.8/aspnet/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1903",
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/aspnet/windowsservercore-ltsc2016": {
+      "4.8/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2016",
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/aspnet/windowsservercore-ltsc2019": {
+      "4.8/aspnet/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2019",
           "4.8-windowsservercore-ltsc2019"
@@ -91,7 +91,7 @@
   {
     "repo": "dotnet/framework/runtime",
     "images": {
-      "3.5/runtime/windowsservercore-1803": {
+      "3.5/runtime/windowsservercore-1803/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -100,7 +100,7 @@
           "3.5-windowsservercore-1803"
         ]
       },
-      "3.5/runtime/windowsservercore-1903": {
+      "3.5/runtime/windowsservercore-1903/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -109,7 +109,7 @@
           "3.5-windowsservercore-1903"
         ]
       },
-      "3.5/runtime/windowsservercore-ltsc2016": {
+      "3.5/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -118,7 +118,7 @@
           "3.5-windowsservercore-ltsc2016"
         ]
       },
-      "3.5/runtime/windowsservercore-ltsc2019": {
+      "3.5/runtime/windowsservercore-ltsc2019/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2019": "mcr.microsoft.com/windows/servercore@sha256:d7e7e3702cbc4d8ea29001a02c1c852d0229a0679d94e017a41c43dbaa01db20"
         },
@@ -127,7 +127,7 @@
           "3.5-windowsservercore-ltsc2019"
         ]
       },
-      "4.6.2/runtime/windowsservercore-ltsc2016": {
+      "4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -136,7 +136,7 @@
           "4.6.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.1/runtime/windowsservercore-ltsc2016": {
+      "4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -145,7 +145,7 @@
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/runtime/windowsservercore-1803": {
+      "4.7.2/runtime/windowsservercore-1803/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -154,7 +154,7 @@
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/runtime/windowsservercore-ltsc2016": {
+      "4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -163,7 +163,7 @@
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/runtime/windowsservercore-ltsc2019": {
+      "4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2019": "mcr.microsoft.com/windows/servercore@sha256:d7e7e3702cbc4d8ea29001a02c1c852d0229a0679d94e017a41c43dbaa01db20"
         },
@@ -172,7 +172,7 @@
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.7/runtime/windowsservercore-ltsc2016": {
+      "4.7/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -181,7 +181,7 @@
           "4.7-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/runtime/windowsservercore-1803": {
+      "4.8/runtime/windowsservercore-1803/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -190,7 +190,7 @@
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/runtime/windowsservercore-1903": {
+      "4.8/runtime/windowsservercore-1903/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -199,7 +199,7 @@
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/runtime/windowsservercore-ltsc2016": {
+      "4.8/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -208,7 +208,7 @@
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/runtime/windowsservercore-ltsc2019": {
+      "4.8/runtime/windowsservercore-ltsc2019/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2019": "mcr.microsoft.com/windows/servercore@sha256:d7e7e3702cbc4d8ea29001a02c1c852d0229a0679d94e017a41c43dbaa01db20"
         },
@@ -222,7 +222,7 @@
   {
     "repo": "dotnet/framework/samples",
     "images": {
-      "samples/aspnetapp": {
+      "samples/aspnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/framework/aspnet:4.8": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:0fd2131bcd54775080b9058d0b38c9dee57f57e4f6ac8ac77ba21786c0b373d7",
           "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220"
@@ -231,7 +231,7 @@
           "aspnetapp-windowsservercore-ltsc2019"
         ]
       },
-      "samples/dotnetapp": {
+      "samples/dotnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/framework/runtime:4.8": "mcr.microsoft.com/dotnet/framework/runtime@sha256:337903387835a83eb65e19f60719f76eae3a71ec8276d2983c20766e6b745a77",
           "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220"
@@ -240,9 +240,17 @@
           "dotnetapp-windowsservercore-ltsc2019"
         ]
       },
-      "samples\\wcfapp": {
+      "samples/wcfapp/Dockerfile.client": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/framework/runtime:4.8": "mcr.microsoft.com/dotnet/framework/runtime@sha256:337903387835a83eb65e19f60719f76eae3a71ec8276d2983c20766e6b745a77",
+          "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220"
+        },
+        "simpleTags": [
+          "wcfclient-windowsservercore-ltsc2019"
+        ]
+      },
+      "samples/wcfapp/Dockerfile.web": {
+        "baseImages": {
           "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220",
           "mcr.microsoft.com/dotnet/framework/wcf:4.8": "mcr.microsoft.com/dotnet/framework/wcf@sha256:61cbbdb6c20a5a988032bafc8244ac28c26cd10599a512a98a17602f1ffb8417"
         },
@@ -255,73 +263,73 @@
   {
     "repo": "dotnet/framework/sdk",
     "images": {
-      "3.5/sdk/windowsservercore-1803": {
+      "3.5/sdk/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1803",
           "3.5-windowsservercore-1803"
         ]
       },
-      "3.5/sdk/windowsservercore-1903": {
+      "3.5/sdk/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1903",
           "3.5-windowsservercore-1903"
         ]
       },
-      "3.5/sdk/windowsservercore-ltsc2016": {
+      "3.5/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2016",
           "3.5-windowsservercore-ltsc2016"
         ]
       },
-      "3.5/sdk/windowsservercore-ltsc2019": {
+      "3.5/sdk/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2019",
           "3.5-windowsservercore-ltsc2019"
         ]
       },
-      "4.7.1/sdk/windowsservercore-ltsc2016": {
+      "4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.1-20190910-windowsservercore-ltsc2016",
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/sdk/windowsservercore-1803": {
+      "4.7.2/sdk/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-1803",
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/sdk/windowsservercore-ltsc2016": {
+      "4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2016",
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/sdk/windowsservercore-ltsc2019": {
+      "4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2019",
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.8/sdk/windowsservercore-1803": {
+      "4.8/sdk/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1803",
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/sdk/windowsservercore-1903": {
+      "4.8/sdk/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1903",
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/sdk/windowsservercore-ltsc2016": {
+      "4.8/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2016",
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/sdk/windowsservercore-ltsc2019": {
+      "4.8/sdk/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2019",
           "4.8-windowsservercore-ltsc2019"
@@ -332,61 +340,61 @@
   {
     "repo": "dotnet/framework/wcf",
     "images": {
-      "4.6.2/wcf/windowsservercore-ltsc2016": {
+      "4.6.2/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.6.2-20190910-windowsservercore-ltsc2016",
           "4.6.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.1/wcf/windowsservercore-ltsc2016": {
+      "4.7.1/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.1-20190910-windowsservercore-ltsc2016",
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/wcf/windowsservercore-1803": {
+      "4.7.2/wcf/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-1803",
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/wcf/windowsservercore-ltsc2016": {
+      "4.7.2/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2016",
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/wcf/windowsservercore-ltsc2019": {
+      "4.7.2/wcf/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2019",
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.7/wcf/windowsservercore-ltsc2016": {
+      "4.7/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7-20190910-windowsservercore-ltsc2016",
           "4.7-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/wcf/windowsservercore-1803": {
+      "4.8/wcf/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1803",
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/wcf/windowsservercore-1903": {
+      "4.8/wcf/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1903",
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/wcf/windowsservercore-ltsc2016": {
+      "4.8/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2016",
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/wcf/windowsservercore-ltsc2019": {
+      "4.8/wcf/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2019",
           "4.8-windowsservercore-ltsc2019"

--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -2,7 +2,7 @@
   {
     "repo": "dotnet-buildtools/prereqs",
     "images": {
-      "src/alpine/3.8/helix/amd64": {
+      "src/alpine/3.8/helix/amd64/Dockerfile": {
         "baseImages": {
           "python:3.7.3-alpine3.8": "python@sha256:3491d1abd29b3f87ca5cb1afd34bc696855a2403df1ff854da55cb6754af1ff8"
         },
@@ -10,7 +10,7 @@
           "alpine-3.8-helix-2e197e0-20190809151301"
         ]
       },
-      "src/alpine/3.8/helix/arm64v8": {
+      "src/alpine/3.8/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.8": "arm64v8/alpine@sha256:360e20fc240529450cf378756935230541da805701e3ff895305b72f37ce4d9c"
         },
@@ -18,7 +18,7 @@
           "alpine-3.8-helix-arm64v8-2e197e0-20190809151315"
         ]
       },
-      "src/alpine/3.9/amd64": {
+      "src/alpine/3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -26,7 +26,7 @@
           "alpine-3.9-44e2650-20190809151252"
         ]
       },
-      "src/alpine/3.9/arm32v7": {
+      "src/alpine/3.9/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/alpine:3.9": "arm32v7/alpine@sha256:f6d15ec5c7cf08079309c59f59ff1e092eb9a678ab891257b1d2b118e7aecc2b"
         },
@@ -34,7 +34,7 @@
           "alpine-3.9-arm32v7-44e2650-20190809151323"
         ]
       },
-      "src/alpine/3.9/arm64v8": {
+      "src/alpine/3.9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
         },
@@ -42,7 +42,7 @@
           "alpine-3.9-arm64v8-44e2650-20190809151317"
         ]
       },
-      "src/alpine/3.9/helix/amd64": {
+      "src/alpine/3.9/helix/amd64/Dockerfile": {
         "baseImages": {
           "python:3.7.3-alpine3.9": "python@sha256:69f4cedf780ea95e7a0591e5ec3db85207142278501dfab6ef483ccfa5340fe2"
         },
@@ -50,12 +50,12 @@
           "alpine-3.9-helix-2e197e0-20190809151254"
         ]
       },
-      "src/alpine/3.9/WithNode/amd64": {
+      "src/alpine/3.9/WithNode/amd64/Dockerfile": {
         "simpleTags": [
           "alpine-3.9-WithNode-0fc54a3-20190809151252"
         ]
       },
-      "src/centos/6": {
+      "src/centos/6/Dockerfile": {
         "baseImages": {
           "centos:6": "centos@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7"
         },
@@ -63,7 +63,7 @@
           "centos-6-3e800f1-20190809151311"
         ]
       },
-      "src/centos/7": {
+      "src/centos/7/Dockerfile": {
         "baseImages": {
           "centos:7": "centos@sha256:a799dd8a2ded4a83484bbae769d97655392b3f86533ceb7dd96bbac929809f3c"
         },
@@ -71,12 +71,12 @@
           "centos-7-3e800f1-20190815164629"
         ]
       },
-      "src/centos/7/mlnet": {
+      "src/centos/7/mlnet/Dockerfile": {
         "simpleTags": [
           "centos-7-mlnet-8bba86b-20190815164629"
         ]
       },
-      "src/debian/10/helix/amd64": {
+      "src/debian/10/helix/amd64/Dockerfile": {
         "baseImages": {
           "debian:buster": "debian@sha256:903779f30a7ee46937bfb21406f125d5fdace4178074e1cc71c49039ebf7f48f"
         },
@@ -84,7 +84,7 @@
           "debian-10-helix-amd64-6b166d8-20190807161114"
         ]
       },
-      "src/debian/10/helix/arm32v7": {
+      "src/debian/10/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:buster": "arm32v7/debian@sha256:2dc27b0362abdf8e47f6090c7f5f855efbfc870cb0d03ad990021ff2d9bf9541"
         },
@@ -92,7 +92,7 @@
           "debian-10-helix-arm32v7-6b166d8-20190807161034"
         ]
       },
-      "src/debian/10/helix/arm64v8": {
+      "src/debian/10/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:buster": "arm64v8/debian@sha256:d5d8c18489f86d65c77cb7e9f2b4f7fc438a0c4cc9ac563e290524ce2d2f11c2"
         },
@@ -100,7 +100,7 @@
           "debian-10-helix-arm64v8-6b166d8-20190807161035"
         ]
       },
-      "src/debian/9/arm32v7": {
+      "src/debian/9/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:9": "arm32v7/debian@sha256:205a3d2b05453df39a6bf7339dfd81878f9828985f8dcc1b7fa5c6fdbb94fd4a"
         },
@@ -108,7 +108,7 @@
           "debian-9-arm32v7-0dbbad8-20190807161034"
         ]
       },
-      "src/debian/9/arm64v8": {
+      "src/debian/9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:9": "arm64v8/debian@sha256:e8f82c8a38bc474644ccd16911793ad4a676fd6f5c0508555ca5fc7e12be06ec"
         },
@@ -116,7 +116,7 @@
           "debian-9-arm64v8-3e800f1-20190807161037"
         ]
       },
-      "src/debian/9/helix/arm32v7": {
+      "src/debian/9/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:9": "arm32v7/debian@sha256:205a3d2b05453df39a6bf7339dfd81878f9828985f8dcc1b7fa5c6fdbb94fd4a"
         },
@@ -124,7 +124,7 @@
           "debian-9-helix-arm32v7-6b166d8-20190807161035"
         ]
       },
-      "src/debian/9/helix/arm64v8": {
+      "src/debian/9/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:9": "arm64v8/debian@sha256:e8f82c8a38bc474644ccd16911793ad4a676fd6f5c0508555ca5fc7e12be06ec"
         },
@@ -132,7 +132,7 @@
           "debian-9-helix-arm64v8-a12566d-20190807161036"
         ]
       },
-      "src/debian/iot/arm32v7": {
+      "src/debian/iot/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:latest": "arm32v7/debian@sha256:2dc27b0362abdf8e47f6090c7f5f855efbfc870cb0d03ad990021ff2d9bf9541"
         },
@@ -140,12 +140,12 @@
           "debian-iot-arm32v7-be5b37d-20190807161037"
         ]
       },
-      "src/debian/jessie": {
+      "src/debian/jessie/Dockerfile": {
         "simpleTags": [
           "debian-jessie-3e800f1-20190807161116"
         ]
       },
-      "src/debian/jessie/coredeps": {
+      "src/debian/jessie/coredeps/Dockerfile": {
         "baseImages": {
           "debian:jessie": "debian@sha256:a8ae3c5129fb2e10a62b5c059a24308831508c44018c24ccda2e4fc6fd7cdda7"
         },
@@ -153,17 +153,17 @@
           "debian-jessie-coredeps-3e800f1-20190807161116"
         ]
       },
-      "src/debian/jessie/corert": {
+      "src/debian/jessie/corert/Dockerfile": {
         "simpleTags": [
           "debian-jessie-corert-58e4974-20190807161116"
         ]
       },
-      "src/debian/jessie/debpkg": {
+      "src/debian/jessie/debpkg/Dockerfile": {
         "simpleTags": [
           "debian-jessie-debpkg-58e4974-20190807161116"
         ]
       },
-      "src/debian/stretch-slim/docker-testrunner": {
+      "src/debian/stretch-slim/docker-testrunner/Dockerfile": {
         "baseImages": {
           "debian:stretch-slim": "debian@sha256:0c04edb9ae10feb7ac03a659dd41e16c79e04fdb2b10cf93c3cbcef1fd6cc1d5"
         },
@@ -171,7 +171,7 @@
           "debian-stretch-slim-docker-testrunner-d61254f-20190807161111"
         ]
       },
-      "src/debian/stretch/": {
+      "src/debian/stretch/Dockerfile": {
         "baseImages": {
           "debian:stretch": "debian@sha256:397b2157a9ea8d7f16c613aded70284292106e8b813fb1ed5de8a8785310a26a"
         },
@@ -179,7 +179,7 @@
           "debian-stretch-d61254f-20190807161114"
         ]
       },
-      "src/fedora/29": {
+      "src/fedora/29/Dockerfile": {
         "baseImages": {
           "fedora:29": "fedora@sha256:2c20e5bb324735427f8a659e36f4fe14d6955c74c7baa25067418dddbb71d67a"
         },
@@ -187,12 +187,12 @@
           "fedora-29-a12566d-20190806171712"
         ]
       },
-      "src/fedora/29/helix/amd64": {
+      "src/fedora/29/helix/amd64/Dockerfile": {
         "simpleTags": [
           "fedora-29-helix-a12566d-20190806171712"
         ]
       },
-      "src/fedora/30/amd64": {
+      "src/fedora/30/amd64/Dockerfile": {
         "baseImages": {
           "fedora:30": "fedora@sha256:d39a02a0f13c1df3bbcb0ccea4021c53b8e0bfd87f701a5115e18ec089814e70"
         },
@@ -200,12 +200,12 @@
           "fedora-30-39ec319-20190806171718"
         ]
       },
-      "src/fedora/30/helix/amd64": {
+      "src/fedora/30/helix/amd64/Dockerfile": {
         "simpleTags": [
           "fedora-30-helix-2e197e0-20190806171718"
         ]
       },
-      "src/nanoserver/1803/helix/amd64": {
+      "src/nanoserver/1803/helix/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/powershell:6.2.0-nanoserver-1803": "mcr.microsoft.com/powershell@sha256:ed8ec196c698713d8814f3c586265a294938d3880943c925cf48d42531bf6675"
         },
@@ -213,7 +213,7 @@
           "nanoserver-1803-helix-amd64-1441ed6-20190815130533"
         ]
       },
-      "src/nanoserver/1809/helix/amd64": {
+      "src/nanoserver/1809/helix/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/powershell:6.2.0-nanoserver-1809": "mcr.microsoft.com/powershell@sha256:8a4e778616607888d88eb64ca72eab4740b2ecef4c93fccf12e1d13cec204646"
         },
@@ -221,7 +221,7 @@
           "nanoserver-1809-helix-amd64-61052b7-20190809151858"
         ]
       },
-      "src/ubuntu/14.04": {
+      "src/ubuntu/14.04/Dockerfile": {
         "baseImages": {
           "ubuntu:14.04": "ubuntu@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90"
         },
@@ -229,7 +229,7 @@
           "ubuntu-14.04-1735d26-20190809151504"
         ]
       },
-      "src/ubuntu/14.04/coredeps": {
+      "src/ubuntu/14.04/coredeps/Dockerfile": {
         "baseImages": {
           "ubuntu:14.04": "ubuntu@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90"
         },
@@ -237,22 +237,22 @@
           "ubuntu-14.04-coredeps-3e800f1-20190809151457"
         ]
       },
-      "src/ubuntu/14.04/cross": {
+      "src/ubuntu/14.04/cross/Dockerfile": {
         "simpleTags": [
           "ubuntu-14.04-cross-1735d26-20190809151457"
         ]
       },
-      "src/ubuntu/14.04/crossdeps": {
+      "src/ubuntu/14.04/crossdeps/Dockerfile": {
         "simpleTags": [
           "ubuntu-14.04-crossdeps-cfdd435-20190809151457"
         ]
       },
-      "src/ubuntu/14.04/debpkg": {
+      "src/ubuntu/14.04/debpkg/Dockerfile": {
         "simpleTags": [
           "ubuntu-14.04-debpkg-cfdd435-20190809151504"
         ]
       },
-      "src/ubuntu/16.04": {
+      "src/ubuntu/16.04/Dockerfile": {
         "baseImages": {
           "ubuntu:16.04": "ubuntu@sha256:97b54e5692c27072234ff958a7442dde4266af21e7b688e7fca5dc5acc8ed7d9"
         },
@@ -260,7 +260,7 @@
           "ubuntu-16.04-30f6673-20190814211612"
         ]
       },
-      "src/ubuntu/16.04/arm32v7": {
+      "src/ubuntu/16.04/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:16.04": "arm32v7/ubuntu@sha256:7826e9ef78e9c2a71388dd08316dcbd94a26a7be5c9ccdeb134d6360665c3d7f"
         },
@@ -268,7 +268,7 @@
           "ubuntu-16.04-arm32v7-0dbbad8-20190814211513"
         ]
       },
-      "src/ubuntu/16.04/arm64v8": {
+      "src/ubuntu/16.04/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:16.04": "arm64v8/ubuntu@sha256:6c6dc3e0c188da27e29edb852d03034e6b7d50a0f10b8ff296220c3a141b703a"
         },
@@ -276,7 +276,7 @@
           "ubuntu-16.04-arm64v8-3e800f1-20190814211510"
         ]
       },
-      "src/ubuntu/16.04/coredeps": {
+      "src/ubuntu/16.04/coredeps/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/powershell:6.2.1-ubuntu-16.04": "mcr.microsoft.com/powershell@sha256:828aaedfbfbf6885800754618a99b7126f5dde4bb51d19a61a22f9a6044f70ee"
         },
@@ -284,17 +284,17 @@
           "ubuntu-16.04-coredeps-d9d81d0-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/cross": {
+      "src/ubuntu/16.04/cross/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-cross-23cacb0-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/cross/14.04": {
+      "src/ubuntu/16.04/cross/14.04/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-cross-14.04-23cacb0-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/cross/arm64": {
+      "src/ubuntu/16.04/cross/arm64/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-cross-arm64-cfdd435-20190814211620"
         ]
@@ -304,17 +304,17 @@
           "ubuntu-16.04-cross-arm64-alpine-406629a-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/crossdeps": {
+      "src/ubuntu/16.04/crossdeps/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-crossdeps-cfdd435-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/debpkg": {
+      "src/ubuntu/16.04/debpkg/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-debpkg-cfdd435-20190814211612"
         ]
       },
-      "src/ubuntu/16.04/helix/arm32v7": {
+      "src/ubuntu/16.04/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:16.04": "arm32v7/ubuntu@sha256:7826e9ef78e9c2a71388dd08316dcbd94a26a7be5c9ccdeb134d6360665c3d7f"
         },
@@ -322,7 +322,7 @@
           "ubuntu-16.04-helix-arm32v7-30f6673-20190814211508"
         ]
       },
-      "src/ubuntu/16.04/helix/arm64v8": {
+      "src/ubuntu/16.04/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:16.04": "arm64v8/ubuntu@sha256:6c6dc3e0c188da27e29edb852d03034e6b7d50a0f10b8ff296220c3a141b703a"
         },
@@ -330,12 +330,12 @@
           "ubuntu-16.04-helix-arm64v8-2e197e0-20190814211515"
         ]
       },
-      "src/ubuntu/16.04/mlnet": {
+      "src/ubuntu/16.04/mlnet/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-mlnet-207e097-20190814211612"
         ]
       },
-      "src/ubuntu/18.04/amd64": {
+      "src/ubuntu/18.04/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:18.04": "ubuntu@sha256:c303f19cfe9ee92badbbbd7567bc1ca47789f79303ddcef56f77687d4744cd7a"
         },
@@ -343,7 +343,7 @@
           "ubuntu-18.04-3e800f1-20190814211606"
         ]
       },
-      "src/ubuntu/18.04/arm32v7": {
+      "src/ubuntu/18.04/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:46fe74f7b605368593fd21ff9db45429d9faa86550ad13f7eefb2c995c69b271"
         },
@@ -351,7 +351,7 @@
           "ubuntu-18.04-arm32v7-3e800f1-20190814211515"
         ]
       },
-      "src/ubuntu/18.04/arm64v8": {
+      "src/ubuntu/18.04/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:be2ef80501adc5a13c4a58a8045923d4e64b691aaa7e6e470c14e88a45845d0d"
         },
@@ -359,12 +359,12 @@
           "ubuntu-18.04-arm64v8-3e800f1-20190814211508"
         ]
       },
-      "src/ubuntu/18.04/debpkg": {
+      "src/ubuntu/18.04/debpkg/Dockerfile": {
         "simpleTags": [
           "ubuntu-18.04-debpkg-cfdd435-20190814211606"
         ]
       },
-      "src/ubuntu/18.04/helix/arm32v7": {
+      "src/ubuntu/18.04/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:46fe74f7b605368593fd21ff9db45429d9faa86550ad13f7eefb2c995c69b271"
         },
@@ -372,7 +372,7 @@
           "ubuntu-18.04-helix-arm32v7-30f6673-20190814211509"
         ]
       },
-      "src/ubuntu/18.04/helix/arm64v8": {
+      "src/ubuntu/18.04/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:be2ef80501adc5a13c4a58a8045923d4e64b691aaa7e6e470c14e88a45845d0d"
         },
@@ -380,7 +380,7 @@
           "ubuntu-18.04-helix-arm64v8-2e197e0-20190814211510"
         ]
       },
-      "src/ubuntu/19.04/helix/amd64": {
+      "src/ubuntu/19.04/helix/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:19.04": "ubuntu@sha256:23f56d855075d7a8ca49b79d61edaab2f28645f4834767abf1b7d3884b969e92"
         },

--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -2,13 +2,13 @@
   {
     "repo": "dotnet/core/aspnet",
     "images": {
-      "2.1/aspnet/alpine3.7/amd64": {
+      "2.1/aspnet/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/aspnet/alpine3.9/amd64": {
+      "2.1/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.9",
@@ -16,19 +16,19 @@
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/aspnet/bionic/amd64": {
+      "2.1/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/aspnet/bionic/arm32v7": {
+      "2.1/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/aspnet/nanoserver-1803/amd64": {
+      "2.1/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -38,7 +38,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/aspnet/nanoserver-1809/amd64": {
+      "2.1/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -48,7 +48,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/aspnet/nanoserver-1903/amd64": {
+      "2.1/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -58,19 +58,19 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/aspnet/stretch-slim/amd64": {
+      "2.1/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/aspnet/stretch-slim/arm32v7": {
+      "2.1/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/aspnet/alpine3.8/amd64": {
+      "2.2/aspnet/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.8",
@@ -78,25 +78,25 @@
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/aspnet/alpine3.9/amd64": {
+      "2.2/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/aspnet/bionic/amd64": {
+      "2.2/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/aspnet/bionic/arm32v7": {
+      "2.2/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1803/amd64": {
+      "2.2/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -106,7 +106,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/amd64": {
+      "2.2/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -116,7 +116,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/arm32v7": {
+      "2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -126,7 +126,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1903/amd64": {
+      "2.2/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -136,19 +136,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/aspnet/stretch-slim/amd64": {
+      "2.2/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/aspnet/stretch-slim/arm32v7": {
+      "2.2/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/alpine3.9/amd64": {
+      "3.0/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -156,7 +156,7 @@
           "3.0.0-preview8-alpine3.9"
         ]
       },
-      "3.0/aspnet/alpine3.9/arm64v8": {
+      "3.0/aspnet/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.9-arm64v8",
@@ -164,61 +164,61 @@
           "3.0.0-preview8-alpine3.9-arm64v8"
         ]
       },
-      "3.0/aspnet/bionic/amd64": {
+      "3.0/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-preview8-bionic"
         ]
       },
-      "3.0/aspnet/bionic/arm32v7": {
+      "3.0/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-preview8-bionic-arm32v7"
         ]
       },
-      "3.0/aspnet/bionic/arm64v8": {
+      "3.0/aspnet/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-preview8-bionic-arm64v8"
         ]
       },
-      "3.0/aspnet/buster-slim/amd64": {
+      "3.0/aspnet/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-preview9-buster-slim"
         ]
       },
-      "3.0/aspnet/buster-slim/arm32v7": {
+      "3.0/aspnet/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-preview8-buster-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/buster-slim/arm64v8": {
+      "3.0/aspnet/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-preview9-buster-slim-arm64v8"
         ]
       },
-      "3.0/aspnet/disco/amd64": {
+      "3.0/aspnet/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-preview8-disco"
         ]
       },
-      "3.0/aspnet/disco/arm32v7": {
+      "3.0/aspnet/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-preview8-disco-arm32v7"
         ]
       },
-      "3.0/aspnet/disco/arm64v8": {
+      "3.0/aspnet/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-preview8-disco-arm64v8"
         ]
       },
-      "3.0/aspnet/nanoserver-1803/amd64": {
+      "3.0/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -227,7 +227,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/amd64": {
+      "3.0/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
         },
@@ -236,13 +236,13 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/arm32v7": {
+      "3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-nanoserver-1809-arm32v7",
           "3.0.0-preview9-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/aspnet/nanoserver-1903/amd64": {
+      "3.0/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -256,36 +256,36 @@
   {
     "repo": "dotnet/core/runtime",
     "images": {
-      "1.0/runtime/jessie/amd64": {
+      "1.0/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.0/runtime/nanoserver-1809/amd64": {
+      "1.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/jessie/amd64": {
+      "1.1/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.1/runtime/nanoserver-1809/amd64": {
+      "1.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/stretch/amd64": {
+      "1.1/runtime/stretch/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "2.1/runtime/alpine3.7/amd64": {
+      "2.1/runtime/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime/alpine3.9/amd64": {
+      "2.1/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.9",
@@ -293,19 +293,19 @@
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/runtime/bionic/amd64": {
+      "2.1/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/runtime/bionic/arm32v7": {
+      "2.1/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/runtime/nanoserver-1803/amd64": {
+      "2.1/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -315,7 +315,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/runtime/nanoserver-1809/amd64": {
+      "2.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -325,7 +325,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/runtime/nanoserver-1903/amd64": {
+      "2.1/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -335,25 +335,25 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/runtime/stretch-slim/amd64": {
+      "2.1/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/runtime/stretch-slim/arm32v7": {
+      "2.1/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime/alpine3.8/amd64": {
+      "2.2/runtime/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/runtime/alpine3.9/amd64": {
+      "2.2/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.9",
@@ -361,19 +361,19 @@
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/runtime/bionic/amd64": {
+      "2.2/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/runtime/bionic/arm32v7": {
+      "2.2/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1803/amd64": {
+      "2.2/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -383,7 +383,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/runtime/nanoserver-1809/amd64": {
+      "2.2/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -393,7 +393,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/runtime/nanoserver-1809/arm32v7": {
+      "2.2/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -403,7 +403,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1903/amd64": {
+      "2.2/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -413,19 +413,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/runtime/stretch-slim/amd64": {
+      "2.2/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/runtime/stretch-slim/arm32v7": {
+      "2.2/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/runtime/alpine3.9/amd64": {
+      "3.0/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -433,7 +433,7 @@
           "3.0.0-preview8-alpine3.9"
         ]
       },
-      "3.0/runtime/alpine3.9/arm64v8": {
+      "3.0/runtime/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.9-arm64v8",
@@ -441,61 +441,61 @@
           "3.0.0-preview8-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime/bionic/amd64": {
+      "3.0/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-preview8-bionic"
         ]
       },
-      "3.0/runtime/bionic/arm32v7": {
+      "3.0/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-preview8-bionic-arm32v7"
         ]
       },
-      "3.0/runtime/bionic/arm64v8": {
+      "3.0/runtime/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-preview8-bionic-arm64v8"
         ]
       },
-      "3.0/runtime/buster-slim/amd64": {
+      "3.0/runtime/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-preview9-buster-slim"
         ]
       },
-      "3.0/runtime/buster-slim/arm32v7": {
+      "3.0/runtime/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-preview8-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime/buster-slim/arm64v8": {
+      "3.0/runtime/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-preview9-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime/disco/amd64": {
+      "3.0/runtime/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-preview8-disco"
         ]
       },
-      "3.0/runtime/disco/arm32v7": {
+      "3.0/runtime/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-preview8-disco-arm32v7"
         ]
       },
-      "3.0/runtime/disco/arm64v8": {
+      "3.0/runtime/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-preview8-disco-arm64v8"
         ]
       },
-      "3.0/runtime/nanoserver-1803/amd64": {
+      "3.0/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -505,7 +505,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/runtime/nanoserver-1809/amd64": {
+      "3.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -515,7 +515,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/runtime/nanoserver-1809/arm32v7": {
+      "3.0/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -524,7 +524,7 @@
           "3.0.0-preview9-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/runtime/nanoserver-1903/amd64": {
+      "3.0/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -539,19 +539,19 @@
   {
     "repo": "dotnet/core/runtime-deps",
     "images": {
-      "1.0/runtime-deps/jessie/amd64": {
+      "1.0/runtime-deps/jessie/amd64/Dockerfile": {
         "baseImages": {
           "debian:jessie": "debian@sha256:6b95a104400bb99ad60b47a48e37d5d1eb71a3f9ec8e86854e0cf64ecc5fd0e8"
         },
         "simpleTags": []
       },
-      "1.1/runtime-deps/stretch/amd64": {
+      "1.1/runtime-deps/stretch/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch": "debian@sha256:2b20d1b80dbcdef98ff4e747109c39d2b91539f7f12d7873fdd452306eddb04d"
         },
         "simpleTags": []
       },
-      "2.1/runtime-deps/alpine3.7/amd64": {
+      "2.1/runtime-deps/alpine3.7/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.7": "alpine@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10"
         },
@@ -560,7 +560,7 @@
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime-deps/alpine3.9/amd64": {
+      "2.1/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -575,7 +575,7 @@
           "2.2.7-alpine3.9"
         ]
       },
-      "2.1/runtime-deps/bionic/amd64": {
+      "2.1/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -586,7 +586,7 @@
           "2.2.7-bionic"
         ]
       },
-      "2.1/runtime-deps/bionic/arm32v7": {
+      "2.1/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -597,7 +597,7 @@
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/amd64": {
+      "2.1/runtime-deps/stretch-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch-slim": "debian@sha256:8ef99f5a3e800df50ea02334d233360d26c414208815686fbcbf34648ec596d4"
         },
@@ -608,7 +608,7 @@
           "2.2.7-stretch-slim"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/arm32v7": {
+      "2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:stretch-slim": "arm32v7/debian@sha256:186f8d340ce3c2b3dc5a3ef376b574d284a86a335844e743c9d0b1ab0c574b8c"
         },
@@ -619,7 +619,7 @@
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime-deps/alpine3.8/amd64": {
+      "2.2/runtime-deps/alpine3.8/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.8": "alpine@sha256:04696b491e0cc3c58a75bace8941c14c924b9f313b03ce5029ebbc040ed9dcd9"
         },
@@ -628,7 +628,7 @@
           "2.2.7-alpine3.8"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/amd64": {
+      "3.0/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -639,7 +639,7 @@
           "3.0.0-preview8-alpine3.9"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/arm64v8": {
+      "3.0/runtime-deps/alpine3.9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
         },
@@ -650,7 +650,7 @@
           "3.0.0-preview8-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime-deps/bionic/amd64": {
+      "3.0/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -659,7 +659,7 @@
           "3.0.0-preview8-bionic"
         ]
       },
-      "3.0/runtime-deps/bionic/arm32v7": {
+      "3.0/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -668,7 +668,7 @@
           "3.0.0-preview8-bionic-arm32v7"
         ]
       },
-      "3.0/runtime-deps/bionic/arm64v8": {
+      "3.0/runtime-deps/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:bionic": "arm64v8/ubuntu@sha256:1a06d68cb9117b52965035a5b0fa4c1470ef892e6062ffedb1af1922952e0950"
         },
@@ -677,7 +677,7 @@
           "3.0.0-preview8-bionic-arm64v8"
         ]
       },
-      "3.0/runtime-deps/buster-slim/amd64": {
+      "3.0/runtime-deps/buster-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:buster-slim": "debian@sha256:80cc84d66e12d590d2f82ed7e57f906a89f8d10c5b9d7be23ed04e5c6dbb865b"
         },
@@ -686,7 +686,7 @@
           "3.0.0-preview9-buster-slim"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm32v7": {
+      "3.0/runtime-deps/buster-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:buster-slim": "arm32v7/debian@sha256:c3fc2c5de08375bd411c2316c6b944beb47e670da2bf3160cb9d219f5ec96934"
         },
@@ -695,7 +695,7 @@
           "3.0.0-preview8-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm64v8": {
+      "3.0/runtime-deps/buster-slim/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:buster-slim": "arm64v8/debian@sha256:dde35769e3fccb0bf9f714f78e61b7d89ca722e85109f02866a55d3210439f18"
         },
@@ -704,7 +704,7 @@
           "3.0.0-preview9-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime-deps/disco/amd64": {
+      "3.0/runtime-deps/disco/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:disco": "ubuntu@sha256:23f56d855075d7a8ca49b79d61edaab2f28645f4834767abf1b7d3884b969e92"
         },
@@ -713,7 +713,7 @@
           "3.0.0-preview8-disco"
         ]
       },
-      "3.0/runtime-deps/disco/arm32v7": {
+      "3.0/runtime-deps/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:disco": "arm32v7/ubuntu@sha256:48bcb63022b888120570bdf8b1db3a6f244f60e811eab47317ce3c2d6c5a6c9f"
         },
@@ -722,7 +722,7 @@
           "3.0.0-preview8-disco-arm32v7"
         ]
       },
-      "3.0/runtime-deps/disco/arm64v8": {
+      "3.0/runtime-deps/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:disco": "arm64v8/ubuntu@sha256:2e3740619e32e69031b01cd915bac3aebe6de10654737bec52f617ed56df7760"
         },
@@ -736,7 +736,7 @@
   {
     "repo": "dotnet/core/samples",
     "images": {
-      "samples/aspnetapp": {
+      "samples/aspnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/core/aspnet:2.2": "mcr.microsoft.com/dotnet/core/aspnet@sha256:7ec5aaee0d88954394eee20762270bfbf56c938172e81bd415274d633a2c515f",
           "mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim-arm32v7": "mcr.microsoft.com/dotnet/core/aspnet@sha256:4624723ce4e7e4386bec1f5ae749df458c9d25e5dc1d8f44f64b51c6cc8ba768",
@@ -752,7 +752,7 @@
           "aspnetapp-stretch-arm32v7"
         ]
       },
-      "samples/dotnetapp": {
+      "samples/dotnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/core/runtime:2.2": "mcr.microsoft.com/dotnet/core/runtime@sha256:318e18f1616bb2e85f489bf6caca8d9934a5610178df2f0fff8e9bf4ba34091f",
           "mcr.microsoft.com/dotnet/core/runtime:2.2-stretch-slim-arm32v7": "mcr.microsoft.com/dotnet/core/runtime@sha256:377e9cbc240396cba3e5e24d0b3bbf3c3be39e621c1154337ce78b7171963456",
@@ -773,32 +773,32 @@
   {
     "repo": "dotnet/core/sdk",
     "images": {
-      "1.1/sdk/jessie/amd64": {
+      "1.1/sdk/jessie/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:jessie-scm": "buildpack-deps@sha256:44d0d909383bb6976c231000af4bcf7988a84afff293270b3df8fdc8af0d3483"
         },
         "simpleTags": []
       },
-      "1.1/sdk/nanoserver-1809/amd64": {
+      "1.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/sdk/stretch/amd64": {
+      "1.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:0c69a4523a91a858e7e49d8818c97a467edda24553eafae8d409e3b04953226a"
         },
         "simpleTags": []
       },
-      "2.1/sdk/alpine3.7/amd64": {
+      "2.1/sdk/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.802-alpine3.7"
         ]
       },
-      "2.1/sdk/alpine3.9/amd64": {
+      "2.1/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.9",
@@ -806,7 +806,7 @@
           "2.1.802-alpine3.9"
         ]
       },
-      "2.1/sdk/bionic/amd64": {
+      "2.1/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -815,7 +815,7 @@
           "2.1.802-bionic"
         ]
       },
-      "2.1/sdk/bionic/arm32v7": {
+      "2.1/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -824,7 +824,7 @@
           "2.1.802-bionic-arm32v7"
         ]
       },
-      "2.1/sdk/nanoserver-1803/amd64": {
+      "2.1/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -834,7 +834,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/sdk/nanoserver-1809/amd64": {
+      "2.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -844,7 +844,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/sdk/nanoserver-1903/amd64": {
+      "2.1/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -854,7 +854,7 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/sdk/stretch/amd64": {
+      "2.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -863,7 +863,7 @@
           "2.1.802-stretch"
         ]
       },
-      "2.1/sdk/stretch/arm32v7": {
+      "2.1/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:6e1365eba3ed31ceec34fed67cd15bdf31ffc6b46729a6ab966718a864b7ba18"
         },
@@ -872,13 +872,13 @@
           "2.1.802-stretch-arm32v7"
         ]
       },
-      "2.2/sdk/alpine3.8/amd64": {
+      "2.2/sdk/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.402-alpine3.8"
         ]
       },
-      "2.2/sdk/alpine3.9/amd64": {
+      "2.2/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.9",
@@ -886,7 +886,7 @@
           "2.2.402-alpine3.9"
         ]
       },
-      "2.2/sdk/bionic/amd64": {
+      "2.2/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -895,7 +895,7 @@
           "2.2.402-bionic"
         ]
       },
-      "2.2/sdk/bionic/arm32v7": {
+      "2.2/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -904,7 +904,7 @@
           "2.2.402-bionic-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1803/amd64": {
+      "2.2/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -914,7 +914,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/sdk/nanoserver-1809/amd64": {
+      "2.2/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -924,7 +924,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/sdk/nanoserver-1809/arm32v7": {
+      "2.2/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -934,7 +934,7 @@
           "2.2.402-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1903/amd64": {
+      "2.2/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -944,7 +944,7 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/sdk/stretch/amd64": {
+      "2.2/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -953,7 +953,7 @@
           "2.2.402-stretch"
         ]
       },
-      "2.2/sdk/stretch/arm32v7": {
+      "2.2/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:6e1365eba3ed31ceec34fed67cd15bdf31ffc6b46729a6ab966718a864b7ba18"
         },
@@ -962,7 +962,7 @@
           "2.2.402-stretch-arm32v7"
         ]
       },
-      "3.0/sdk/alpine3.9/amd64": {
+      "3.0/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -970,7 +970,7 @@
           "3.0.100-preview8-alpine3.9"
         ]
       },
-      "3.0/sdk/bionic/amd64": {
+      "3.0/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -979,7 +979,7 @@
           "3.0.100-preview8-bionic"
         ]
       },
-      "3.0/sdk/bionic/arm32v7": {
+      "3.0/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -988,7 +988,7 @@
           "3.0.100-preview8-bionic-arm32v7"
         ]
       },
-      "3.0/sdk/bionic/arm64v8": {
+      "3.0/sdk/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:bionic-scm": "arm64v8/buildpack-deps@sha256:382662800e0f4cd0b1258311e7f74a782c71ff23a54273300b8a396e6dfebb89"
         },
@@ -997,7 +997,7 @@
           "3.0.100-preview8-bionic-arm64v8"
         ]
       },
-      "3.0/sdk/buster/amd64": {
+      "3.0/sdk/buster/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:buster-scm": "buildpack-deps@sha256:ef75fcad284d5db55eb4da1b41606763e01587c6dccb9e2f2c1cb404c256e062"
         },
@@ -1006,7 +1006,7 @@
           "3.0.100-preview9-buster"
         ]
       },
-      "3.0/sdk/buster/arm32v7": {
+      "3.0/sdk/buster/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:buster-scm": "arm32v7/buildpack-deps@sha256:2f1c1a4b3b90ee0bac5661c1189077625b101a348b7f62cdbd86e2e7bc17cebc"
         },
@@ -1015,7 +1015,7 @@
           "3.0.100-preview8-buster-arm32v7"
         ]
       },
-      "3.0/sdk/buster/arm64v8": {
+      "3.0/sdk/buster/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:buster-scm": "arm64v8/buildpack-deps@sha256:6e245b3ce8e863e21535c54322721844f776ea7c5a75093aed2c76a95b2033cd"
         },
@@ -1024,7 +1024,7 @@
           "3.0.100-preview9-buster-arm64v8"
         ]
       },
-      "3.0/sdk/disco/amd64": {
+      "3.0/sdk/disco/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:disco-scm": "buildpack-deps@sha256:f85866a166daf23b5868abe07045bd057ed068b06071719f44770fe0f4daa8a9"
         },
@@ -1033,7 +1033,7 @@
           "3.0.100-preview8-disco"
         ]
       },
-      "3.0/sdk/disco/arm32v7": {
+      "3.0/sdk/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:disco-scm": "arm32v7/buildpack-deps@sha256:e057392d3f3565790388371f8681105d2c25610bbb6a8e8b79ce8c092c11d427"
         },
@@ -1042,7 +1042,7 @@
           "3.0.100-preview8-disco-arm32v7"
         ]
       },
-      "3.0/sdk/disco/arm64v8": {
+      "3.0/sdk/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:disco-scm": "arm64v8/buildpack-deps@sha256:37ed2ce17e31d7211f3f73aa551582b760d306277aa292ac5ace09833261d90e"
         },
@@ -1051,7 +1051,7 @@
           "3.0.100-preview8-disco-arm64v8"
         ]
       },
-      "3.0/sdk/nanoserver-1803/amd64": {
+      "3.0/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1061,7 +1061,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/sdk/nanoserver-1809/amd64": {
+      "3.0/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1071,7 +1071,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/sdk/nanoserver-1809/arm32v7": {
+      "3.0/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1080,7 +1080,7 @@
           "3.0.100-preview9-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/sdk/nanoserver-1903/amd64": {
+      "3.0/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
@@ -2,7 +2,7 @@
   {
     "repo": "dotnet/core-nightly/aspnet",
     "images": {
-      "2.1/aspnet/alpine3.10/amd64": {
+      "2.1/aspnet/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.10",
@@ -10,31 +10,31 @@
           "2.1.13-alpine3.10"
         ]
       },
-      "2.1/aspnet/alpine3.7/amd64": {
+      "2.1/aspnet/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/aspnet/alpine3.9/amd64": {
+      "2.1/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.9",
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/aspnet/bionic/amd64": {
+      "2.1/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/aspnet/bionic/arm32v7": {
+      "2.1/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/aspnet/nanoserver-1803/amd64": {
+      "2.1/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -44,7 +44,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/aspnet/nanoserver-1809/amd64": {
+      "2.1/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -54,7 +54,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/aspnet/nanoserver-1903/amd64": {
+      "2.1/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -64,19 +64,19 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/aspnet/stretch-slim/amd64": {
+      "2.1/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/aspnet/stretch-slim/arm32v7": {
+      "2.1/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/aspnet/alpine3.10/amd64": {
+      "2.2/aspnet/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.10",
@@ -84,31 +84,31 @@
           "2.2.7-alpine3.10"
         ]
       },
-      "2.2/aspnet/alpine3.8/amd64": {
+      "2.2/aspnet/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/aspnet/alpine3.9/amd64": {
+      "2.2/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/aspnet/bionic/amd64": {
+      "2.2/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/aspnet/bionic/arm32v7": {
+      "2.2/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1803/amd64": {
+      "2.2/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -118,7 +118,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/amd64": {
+      "2.2/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -128,7 +128,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/arm32v7": {
+      "2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -138,7 +138,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1903/amd64": {
+      "2.2/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -148,19 +148,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/aspnet/stretch-slim/amd64": {
+      "2.2/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/aspnet/stretch-slim/arm32v7": {
+      "2.2/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/alpine3.10/amd64": {
+      "3.0/aspnet/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.10",
@@ -168,7 +168,7 @@
           "3.0.0-alpine3.10"
         ]
       },
-      "3.0/aspnet/alpine3.10/arm64v8": {
+      "3.0/aspnet/alpine3.10/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.10-arm64v8",
@@ -176,73 +176,73 @@
           "3.0.0-alpine3.10-arm64v8"
         ]
       },
-      "3.0/aspnet/alpine3.9/amd64": {
+      "3.0/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9",
           "3.0.0-alpine3.9"
         ]
       },
-      "3.0/aspnet/alpine3.9/arm64v8": {
+      "3.0/aspnet/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9-arm64v8",
           "3.0.0-alpine3.9-arm64v8"
         ]
       },
-      "3.0/aspnet/bionic/amd64": {
+      "3.0/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-bionic"
         ]
       },
-      "3.0/aspnet/bionic/arm32v7": {
+      "3.0/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-bionic-arm32v7"
         ]
       },
-      "3.0/aspnet/bionic/arm64v8": {
+      "3.0/aspnet/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-bionic-arm64v8"
         ]
       },
-      "3.0/aspnet/buster-slim/amd64": {
+      "3.0/aspnet/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-buster-slim"
         ]
       },
-      "3.0/aspnet/buster-slim/arm32v7": {
+      "3.0/aspnet/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-buster-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/buster-slim/arm64v8": {
+      "3.0/aspnet/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-buster-slim-arm64v8"
         ]
       },
-      "3.0/aspnet/disco/amd64": {
+      "3.0/aspnet/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-disco"
         ]
       },
-      "3.0/aspnet/disco/arm32v7": {
+      "3.0/aspnet/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-disco-arm32v7"
         ]
       },
-      "3.0/aspnet/disco/arm64v8": {
+      "3.0/aspnet/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-disco-arm64v8"
         ]
       },
-      "3.0/aspnet/nanoserver-1803/amd64": {
+      "3.0/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -251,7 +251,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/amd64": {
+      "3.0/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
         },
@@ -260,13 +260,13 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/arm32v7": {
+      "3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-nanoserver-1809-arm32v7",
           "3.0.0-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/aspnet/nanoserver-1903/amd64": {
+      "3.0/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -280,30 +280,30 @@
   {
     "repo": "dotnet/core-nightly/runtime",
     "images": {
-      "1.0/runtime/jessie/amd64": {
+      "1.0/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.0/runtime/nanoserver-1809/amd64": {
+      "1.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/jessie/amd64": {
+      "1.1/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.1/runtime/nanoserver-1809/amd64": {
+      "1.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/stretch/amd64": {
+      "1.1/runtime/stretch/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "2.1/runtime/alpine3.10/amd64": {
+      "2.1/runtime/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.10",
@@ -311,31 +311,31 @@
           "2.1.13-alpine3.10"
         ]
       },
-      "2.1/runtime/alpine3.7/amd64": {
+      "2.1/runtime/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime/alpine3.9/amd64": {
+      "2.1/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.9",
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/runtime/bionic/amd64": {
+      "2.1/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/runtime/bionic/arm32v7": {
+      "2.1/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/runtime/nanoserver-1803/amd64": {
+      "2.1/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -345,7 +345,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/runtime/nanoserver-1809/amd64": {
+      "2.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -355,7 +355,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/runtime/nanoserver-1903/amd64": {
+      "2.1/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -365,19 +365,19 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/runtime/stretch-slim/amd64": {
+      "2.1/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/runtime/stretch-slim/arm32v7": {
+      "2.1/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime/alpine3.10/amd64": {
+      "2.2/runtime/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.10",
@@ -385,31 +385,31 @@
           "2.2.7-alpine3.10"
         ]
       },
-      "2.2/runtime/alpine3.8/amd64": {
+      "2.2/runtime/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/runtime/alpine3.9/amd64": {
+      "2.2/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/runtime/bionic/amd64": {
+      "2.2/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/runtime/bionic/arm32v7": {
+      "2.2/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1803/amd64": {
+      "2.2/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -419,7 +419,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/runtime/nanoserver-1809/amd64": {
+      "2.2/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -429,7 +429,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/runtime/nanoserver-1809/arm32v7": {
+      "2.2/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -439,7 +439,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1903/amd64": {
+      "2.2/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -449,19 +449,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/runtime/stretch-slim/amd64": {
+      "2.2/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/runtime/stretch-slim/arm32v7": {
+      "2.2/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/runtime/alpine3.10/amd64": {
+      "3.0/runtime/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.10",
@@ -469,7 +469,7 @@
           "3.0.0-alpine3.10"
         ]
       },
-      "3.0/runtime/alpine3.10/arm64v8": {
+      "3.0/runtime/alpine3.10/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.10-arm64v8",
@@ -477,73 +477,73 @@
           "3.0.0-alpine3.10-arm64v8"
         ]
       },
-      "3.0/runtime/alpine3.9/amd64": {
+      "3.0/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9",
           "3.0.0-alpine3.9"
         ]
       },
-      "3.0/runtime/alpine3.9/arm64v8": {
+      "3.0/runtime/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9-arm64v8",
           "3.0.0-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime/bionic/amd64": {
+      "3.0/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-bionic"
         ]
       },
-      "3.0/runtime/bionic/arm32v7": {
+      "3.0/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-bionic-arm32v7"
         ]
       },
-      "3.0/runtime/bionic/arm64v8": {
+      "3.0/runtime/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-bionic-arm64v8"
         ]
       },
-      "3.0/runtime/buster-slim/amd64": {
+      "3.0/runtime/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-buster-slim"
         ]
       },
-      "3.0/runtime/buster-slim/arm32v7": {
+      "3.0/runtime/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime/buster-slim/arm64v8": {
+      "3.0/runtime/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime/disco/amd64": {
+      "3.0/runtime/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-disco"
         ]
       },
-      "3.0/runtime/disco/arm32v7": {
+      "3.0/runtime/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-disco-arm32v7"
         ]
       },
-      "3.0/runtime/disco/arm64v8": {
+      "3.0/runtime/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-disco-arm64v8"
         ]
       },
-      "3.0/runtime/nanoserver-1803/amd64": {
+      "3.0/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -553,7 +553,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/runtime/nanoserver-1809/amd64": {
+      "3.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -563,7 +563,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/runtime/nanoserver-1809/arm32v7": {
+      "3.0/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -572,7 +572,7 @@
           "3.0.0-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/runtime/nanoserver-1903/amd64": {
+      "3.0/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -587,19 +587,19 @@
   {
     "repo": "dotnet/core-nightly/runtime-deps",
     "images": {
-      "1.0/runtime-deps/jessie/amd64": {
+      "1.0/runtime-deps/jessie/amd64/Dockerfile": {
         "baseImages": {
           "debian:jessie": "debian@sha256:6b95a104400bb99ad60b47a48e37d5d1eb71a3f9ec8e86854e0cf64ecc5fd0e8"
         },
         "simpleTags": []
       },
-      "1.1/runtime-deps/stretch/amd64": {
+      "1.1/runtime-deps/stretch/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch": "debian@sha256:2b20d1b80dbcdef98ff4e747109c39d2b91539f7f12d7873fdd452306eddb04d"
         },
         "simpleTags": []
       },
-      "2.1/runtime-deps/alpine3.10/amd64": {
+      "2.1/runtime-deps/alpine3.10/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.10": "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
         },
@@ -614,7 +614,7 @@
           "2.2.7-alpine3.10"
         ]
       },
-      "2.1/runtime-deps/alpine3.7/amd64": {
+      "2.1/runtime-deps/alpine3.7/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.7": "alpine@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10"
         },
@@ -623,7 +623,7 @@
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime-deps/alpine3.9/amd64": {
+      "2.1/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -634,7 +634,7 @@
           "2.2.7-alpine3.9"
         ]
       },
-      "2.1/runtime-deps/bionic/amd64": {
+      "2.1/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -645,7 +645,7 @@
           "2.2.7-bionic"
         ]
       },
-      "2.1/runtime-deps/bionic/arm32v7": {
+      "2.1/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -656,7 +656,7 @@
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/amd64": {
+      "2.1/runtime-deps/stretch-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch-slim": "debian@sha256:8ef99f5a3e800df50ea02334d233360d26c414208815686fbcbf34648ec596d4"
         },
@@ -667,7 +667,7 @@
           "2.2.7-stretch-slim"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/arm32v7": {
+      "2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:stretch-slim": "arm32v7/debian@sha256:738c21d3d4352dbd5ffd2f86fa13f17a040496fac70a549ee939d1ebb34b5dde"
         },
@@ -678,7 +678,7 @@
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime-deps/alpine3.8/amd64": {
+      "2.2/runtime-deps/alpine3.8/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.8": "alpine@sha256:04696b491e0cc3c58a75bace8941c14c924b9f313b03ce5029ebbc040ed9dcd9"
         },
@@ -687,7 +687,7 @@
           "2.2.7-alpine3.8"
         ]
       },
-      "3.0/runtime-deps/alpine3.10/amd64": {
+      "3.0/runtime-deps/alpine3.10/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.10": "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
         },
@@ -698,7 +698,7 @@
           "3.0.0-alpine3.10"
         ]
       },
-      "3.0/runtime-deps/alpine3.10/arm64v8": {
+      "3.0/runtime-deps/alpine3.10/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.10": "arm64v8/alpine@sha256:db7f3dcef3d586f7dd123f107c93d7911515a5991c4b9e51fa2a43e46335a43e"
         },
@@ -709,7 +709,7 @@
           "3.0.0-alpine3.10-arm64v8"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/amd64": {
+      "3.0/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -718,7 +718,7 @@
           "3.0.0-alpine3.9"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/arm64v8": {
+      "3.0/runtime-deps/alpine3.9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
         },
@@ -727,7 +727,7 @@
           "3.0.0-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime-deps/bionic/amd64": {
+      "3.0/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -736,7 +736,7 @@
           "3.0.0-bionic"
         ]
       },
-      "3.0/runtime-deps/bionic/arm32v7": {
+      "3.0/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -745,7 +745,7 @@
           "3.0.0-bionic-arm32v7"
         ]
       },
-      "3.0/runtime-deps/bionic/arm64v8": {
+      "3.0/runtime-deps/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:bionic": "arm64v8/ubuntu@sha256:1a06d68cb9117b52965035a5b0fa4c1470ef892e6062ffedb1af1922952e0950"
         },
@@ -754,7 +754,7 @@
           "3.0.0-bionic-arm64v8"
         ]
       },
-      "3.0/runtime-deps/buster-slim/amd64": {
+      "3.0/runtime-deps/buster-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:buster-slim": "debian@sha256:80cc84d66e12d590d2f82ed7e57f906a89f8d10c5b9d7be23ed04e5c6dbb865b"
         },
@@ -763,7 +763,7 @@
           "3.0.0-buster-slim"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm32v7": {
+      "3.0/runtime-deps/buster-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:buster-slim": "arm32v7/debian@sha256:5b5994d4ed9ca8f31f3c0f5ad90733cde33e8ddc6c4de6c4447dd0b4f0b7ce53"
         },
@@ -772,7 +772,7 @@
           "3.0.0-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm64v8": {
+      "3.0/runtime-deps/buster-slim/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:buster-slim": "arm64v8/debian@sha256:dde35769e3fccb0bf9f714f78e61b7d89ca722e85109f02866a55d3210439f18"
         },
@@ -781,7 +781,7 @@
           "3.0.0-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime-deps/disco/amd64": {
+      "3.0/runtime-deps/disco/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:disco": "ubuntu@sha256:23f56d855075d7a8ca49b79d61edaab2f28645f4834767abf1b7d3884b969e92"
         },
@@ -790,7 +790,7 @@
           "3.0.0-disco"
         ]
       },
-      "3.0/runtime-deps/disco/arm32v7": {
+      "3.0/runtime-deps/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:disco": "arm32v7/ubuntu@sha256:48bcb63022b888120570bdf8b1db3a6f244f60e811eab47317ce3c2d6c5a6c9f"
         },
@@ -799,7 +799,7 @@
           "3.0.0-disco-arm32v7"
         ]
       },
-      "3.0/runtime-deps/disco/arm64v8": {
+      "3.0/runtime-deps/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:disco": "arm64v8/ubuntu@sha256:2e3740619e32e69031b01cd915bac3aebe6de10654737bec52f617ed56df7760"
         },
@@ -813,26 +813,26 @@
   {
     "repo": "dotnet/core-nightly/sdk",
     "images": {
-      "1.1/sdk/jessie/amd64": {
+      "1.1/sdk/jessie/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:jessie-scm": "buildpack-deps@sha256:44d0d909383bb6976c231000af4bcf7988a84afff293270b3df8fdc8af0d3483"
         },
         "simpleTags": []
       },
-      "1.1/sdk/nanoserver-1809/amd64": {
+      "1.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/sdk/stretch/amd64": {
+      "1.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:0c69a4523a91a858e7e49d8818c97a467edda24553eafae8d409e3b04953226a"
         },
         "simpleTags": []
       },
-      "2.1/sdk/alpine3.10/amd64": {
+      "2.1/sdk/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.10",
@@ -840,19 +840,19 @@
           "2.1.802-alpine3.10"
         ]
       },
-      "2.1/sdk/alpine3.7/amd64": {
+      "2.1/sdk/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.802-alpine3.7"
         ]
       },
-      "2.1/sdk/alpine3.9/amd64": {
+      "2.1/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.9",
           "2.1.802-alpine3.9"
         ]
       },
-      "2.1/sdk/bionic/amd64": {
+      "2.1/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -861,7 +861,7 @@
           "2.1.802-bionic"
         ]
       },
-      "2.1/sdk/bionic/arm32v7": {
+      "2.1/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -870,7 +870,7 @@
           "2.1.802-bionic-arm32v7"
         ]
       },
-      "2.1/sdk/nanoserver-1803/amd64": {
+      "2.1/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -880,7 +880,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/sdk/nanoserver-1809/amd64": {
+      "2.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -890,7 +890,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/sdk/nanoserver-1903/amd64": {
+      "2.1/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -900,7 +900,7 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/sdk/stretch/amd64": {
+      "2.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -909,7 +909,7 @@
           "2.1.802-stretch"
         ]
       },
-      "2.1/sdk/stretch/arm32v7": {
+      "2.1/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:13e73fbcec6e3a0a5e35916beac60cb35104c3208292c78a82584f8417061066"
         },
@@ -918,7 +918,7 @@
           "2.1.802-stretch-arm32v7"
         ]
       },
-      "2.2/sdk/alpine3.10/amd64": {
+      "2.2/sdk/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.10",
@@ -926,19 +926,19 @@
           "2.2.402-alpine3.10"
         ]
       },
-      "2.2/sdk/alpine3.8/amd64": {
+      "2.2/sdk/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.402-alpine3.8"
         ]
       },
-      "2.2/sdk/alpine3.9/amd64": {
+      "2.2/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.402-alpine3.9"
         ]
       },
-      "2.2/sdk/bionic/amd64": {
+      "2.2/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -947,7 +947,7 @@
           "2.2.402-bionic"
         ]
       },
-      "2.2/sdk/bionic/arm32v7": {
+      "2.2/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -956,7 +956,7 @@
           "2.2.402-bionic-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1803/amd64": {
+      "2.2/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -966,7 +966,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/sdk/nanoserver-1809/amd64": {
+      "2.2/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -976,7 +976,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/sdk/nanoserver-1809/arm32v7": {
+      "2.2/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -986,7 +986,7 @@
           "2.2.402-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1903/amd64": {
+      "2.2/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -996,7 +996,7 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/sdk/stretch/amd64": {
+      "2.2/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -1005,7 +1005,7 @@
           "2.2.402-stretch"
         ]
       },
-      "2.2/sdk/stretch/arm32v7": {
+      "2.2/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:13e73fbcec6e3a0a5e35916beac60cb35104c3208292c78a82584f8417061066"
         },
@@ -1014,7 +1014,7 @@
           "2.2.402-stretch-arm32v7"
         ]
       },
-      "3.0/sdk/alpine3.10/amd64": {
+      "3.0/sdk/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.10",
@@ -1022,13 +1022,13 @@
           "3.0.100-alpine3.10"
         ]
       },
-      "3.0/sdk/alpine3.9/amd64": {
+      "3.0/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9",
           "3.0.100-alpine3.9"
         ]
       },
-      "3.0/sdk/bionic/amd64": {
+      "3.0/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -1037,7 +1037,7 @@
           "3.0.100-bionic"
         ]
       },
-      "3.0/sdk/bionic/arm32v7": {
+      "3.0/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -1046,7 +1046,7 @@
           "3.0.100-bionic-arm32v7"
         ]
       },
-      "3.0/sdk/bionic/arm64v8": {
+      "3.0/sdk/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:bionic-scm": "arm64v8/buildpack-deps@sha256:382662800e0f4cd0b1258311e7f74a782c71ff23a54273300b8a396e6dfebb89"
         },
@@ -1055,7 +1055,7 @@
           "3.0.100-bionic-arm64v8"
         ]
       },
-      "3.0/sdk/buster/amd64": {
+      "3.0/sdk/buster/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:buster-scm": "buildpack-deps@sha256:ef75fcad284d5db55eb4da1b41606763e01587c6dccb9e2f2c1cb404c256e062"
         },
@@ -1064,7 +1064,7 @@
           "3.0.100-buster"
         ]
       },
-      "3.0/sdk/buster/arm32v7": {
+      "3.0/sdk/buster/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:buster-scm": "arm32v7/buildpack-deps@sha256:6ac435c55946bfba506488f61499de6032d53d6c40792103944c58f1e9badb0e"
         },
@@ -1073,7 +1073,7 @@
           "3.0.100-buster-arm32v7"
         ]
       },
-      "3.0/sdk/buster/arm64v8": {
+      "3.0/sdk/buster/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:buster-scm": "arm64v8/buildpack-deps@sha256:6e245b3ce8e863e21535c54322721844f776ea7c5a75093aed2c76a95b2033cd"
         },
@@ -1082,7 +1082,7 @@
           "3.0.100-buster-arm64v8"
         ]
       },
-      "3.0/sdk/disco/amd64": {
+      "3.0/sdk/disco/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:disco-scm": "buildpack-deps@sha256:f85866a166daf23b5868abe07045bd057ed068b06071719f44770fe0f4daa8a9"
         },
@@ -1091,7 +1091,7 @@
           "3.0.100-disco"
         ]
       },
-      "3.0/sdk/disco/arm32v7": {
+      "3.0/sdk/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:disco-scm": "arm32v7/buildpack-deps@sha256:e057392d3f3565790388371f8681105d2c25610bbb6a8e8b79ce8c092c11d427"
         },
@@ -1100,7 +1100,7 @@
           "3.0.100-disco-arm32v7"
         ]
       },
-      "3.0/sdk/disco/arm64v8": {
+      "3.0/sdk/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:disco-scm": "arm64v8/buildpack-deps@sha256:37ed2ce17e31d7211f3f73aa551582b760d306277aa292ac5ace09833261d90e"
         },
@@ -1109,7 +1109,7 @@
           "3.0.100-disco-arm64v8"
         ]
       },
-      "3.0/sdk/nanoserver-1803/amd64": {
+      "3.0/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1119,7 +1119,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/sdk/nanoserver-1809/amd64": {
+      "3.0/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1129,7 +1129,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/sdk/nanoserver-1809/arm32v7": {
+      "3.0/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1138,7 +1138,7 @@
           "3.0.100-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/sdk/nanoserver-1903/amd64": {
+      "3.0/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1153,7 +1153,7 @@
   {
     "repo": "dotnet/core/aspnet",
     "images": {
-      "3.0/aspnet/alpine3.9/amd64": {
+      "3.0/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -1161,7 +1161,7 @@
           "3.0.0-rc1-alpine3.9"
         ]
       },
-      "3.0/aspnet/alpine3.9/arm64v8": {
+      "3.0/aspnet/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.9-arm64v8",
@@ -1169,61 +1169,61 @@
           "3.0.0-rc1-alpine3.9-arm64v8"
         ]
       },
-      "3.0/aspnet/bionic/amd64": {
+      "3.0/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-rc1-bionic"
         ]
       },
-      "3.0/aspnet/bionic/arm32v7": {
+      "3.0/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/aspnet/bionic/arm64v8": {
+      "3.0/aspnet/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/aspnet/buster-slim/amd64": {
+      "3.0/aspnet/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-rc1-buster-slim"
         ]
       },
-      "3.0/aspnet/buster-slim/arm32v7": {
+      "3.0/aspnet/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-rc1-buster-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/buster-slim/arm64v8": {
+      "3.0/aspnet/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-rc1-buster-slim-arm64v8"
         ]
       },
-      "3.0/aspnet/disco/amd64": {
+      "3.0/aspnet/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-rc1-disco"
         ]
       },
-      "3.0/aspnet/disco/arm32v7": {
+      "3.0/aspnet/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-rc1-disco-arm32v7"
         ]
       },
-      "3.0/aspnet/disco/arm64v8": {
+      "3.0/aspnet/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-rc1-disco-arm64v8"
         ]
       },
-      "3.0/aspnet/nanoserver-1803/amd64": {
+      "3.0/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -1232,7 +1232,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/amd64": {
+      "3.0/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
         },
@@ -1241,13 +1241,13 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/arm32v7": {
+      "3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-nanoserver-1809-arm32v7",
           "3.0.0-rc1-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/aspnet/nanoserver-1903/amd64": {
+      "3.0/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -1261,7 +1261,7 @@
   {
     "repo": "dotnet/core/runtime",
     "images": {
-      "3.0/runtime/alpine3.9/amd64": {
+      "3.0/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -1269,7 +1269,7 @@
           "3.0.0-rc1-alpine3.9"
         ]
       },
-      "3.0/runtime/alpine3.9/arm64v8": {
+      "3.0/runtime/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.9-arm64v8",
@@ -1277,61 +1277,61 @@
           "3.0.0-rc1-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime/bionic/amd64": {
+      "3.0/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-rc1-bionic"
         ]
       },
-      "3.0/runtime/bionic/arm32v7": {
+      "3.0/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/runtime/bionic/arm64v8": {
+      "3.0/runtime/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/runtime/buster-slim/amd64": {
+      "3.0/runtime/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-rc1-buster-slim"
         ]
       },
-      "3.0/runtime/buster-slim/arm32v7": {
+      "3.0/runtime/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-rc1-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime/buster-slim/arm64v8": {
+      "3.0/runtime/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-rc1-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime/disco/amd64": {
+      "3.0/runtime/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-rc1-disco"
         ]
       },
-      "3.0/runtime/disco/arm32v7": {
+      "3.0/runtime/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-rc1-disco-arm32v7"
         ]
       },
-      "3.0/runtime/disco/arm64v8": {
+      "3.0/runtime/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-rc1-disco-arm64v8"
         ]
       },
-      "3.0/runtime/nanoserver-1803/amd64": {
+      "3.0/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1341,7 +1341,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/runtime/nanoserver-1809/amd64": {
+      "3.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1351,7 +1351,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/runtime/nanoserver-1809/arm32v7": {
+      "3.0/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1360,7 +1360,7 @@
           "3.0.0-rc1-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/runtime/nanoserver-1903/amd64": {
+      "3.0/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1375,7 +1375,7 @@
   {
     "repo": "dotnet/core/runtime-deps",
     "images": {
-      "3.0/runtime-deps/alpine3.9/amd64": {
+      "3.0/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -1386,7 +1386,7 @@
           "3.0.0-rc1-alpine3.9"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/arm64v8": {
+      "3.0/runtime-deps/alpine3.9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
         },
@@ -1397,7 +1397,7 @@
           "3.0.0-rc1-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime-deps/bionic/amd64": {
+      "3.0/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -1406,7 +1406,7 @@
           "3.0.0-rc1-bionic"
         ]
       },
-      "3.0/runtime-deps/bionic/arm32v7": {
+      "3.0/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -1415,7 +1415,7 @@
           "3.0.0-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/runtime-deps/bionic/arm64v8": {
+      "3.0/runtime-deps/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:bionic": "arm64v8/ubuntu@sha256:1a06d68cb9117b52965035a5b0fa4c1470ef892e6062ffedb1af1922952e0950"
         },
@@ -1424,7 +1424,7 @@
           "3.0.0-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/runtime-deps/buster-slim/amd64": {
+      "3.0/runtime-deps/buster-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:buster-slim": "debian@sha256:80cc84d66e12d590d2f82ed7e57f906a89f8d10c5b9d7be23ed04e5c6dbb865b"
         },
@@ -1433,7 +1433,7 @@
           "3.0.0-rc1-buster-slim"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm32v7": {
+      "3.0/runtime-deps/buster-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:buster-slim": "arm32v7/debian@sha256:5b5994d4ed9ca8f31f3c0f5ad90733cde33e8ddc6c4de6c4447dd0b4f0b7ce53"
         },
@@ -1442,7 +1442,7 @@
           "3.0.0-rc1-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm64v8": {
+      "3.0/runtime-deps/buster-slim/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:buster-slim": "arm64v8/debian@sha256:dde35769e3fccb0bf9f714f78e61b7d89ca722e85109f02866a55d3210439f18"
         },
@@ -1451,7 +1451,7 @@
           "3.0.0-rc1-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime-deps/disco/amd64": {
+      "3.0/runtime-deps/disco/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:disco": "ubuntu@sha256:23f56d855075d7a8ca49b79d61edaab2f28645f4834767abf1b7d3884b969e92"
         },
@@ -1460,7 +1460,7 @@
           "3.0.0-rc1-disco"
         ]
       },
-      "3.0/runtime-deps/disco/arm32v7": {
+      "3.0/runtime-deps/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:disco": "arm32v7/ubuntu@sha256:48bcb63022b888120570bdf8b1db3a6f244f60e811eab47317ce3c2d6c5a6c9f"
         },
@@ -1469,7 +1469,7 @@
           "3.0.0-rc1-disco-arm32v7"
         ]
       },
-      "3.0/runtime-deps/disco/arm64v8": {
+      "3.0/runtime-deps/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:disco": "arm64v8/ubuntu@sha256:2e3740619e32e69031b01cd915bac3aebe6de10654737bec52f617ed56df7760"
         },
@@ -1483,7 +1483,7 @@
   {
     "repo": "dotnet/core/sdk",
     "images": {
-      "3.0/sdk/alpine3.9/amd64": {
+      "3.0/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -1491,7 +1491,7 @@
           "3.0.100-rc1-alpine3.9"
         ]
       },
-      "3.0/sdk/bionic/amd64": {
+      "3.0/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -1500,7 +1500,7 @@
           "3.0.100-rc1-bionic"
         ]
       },
-      "3.0/sdk/bionic/arm32v7": {
+      "3.0/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -1509,7 +1509,7 @@
           "3.0.100-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/sdk/bionic/arm64v8": {
+      "3.0/sdk/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:bionic-scm": "arm64v8/buildpack-deps@sha256:382662800e0f4cd0b1258311e7f74a782c71ff23a54273300b8a396e6dfebb89"
         },
@@ -1518,7 +1518,7 @@
           "3.0.100-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/sdk/buster/amd64": {
+      "3.0/sdk/buster/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:buster-scm": "buildpack-deps@sha256:ef75fcad284d5db55eb4da1b41606763e01587c6dccb9e2f2c1cb404c256e062"
         },
@@ -1527,7 +1527,7 @@
           "3.0.100-rc1-buster"
         ]
       },
-      "3.0/sdk/buster/arm32v7": {
+      "3.0/sdk/buster/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:buster-scm": "arm32v7/buildpack-deps@sha256:6ac435c55946bfba506488f61499de6032d53d6c40792103944c58f1e9badb0e"
         },
@@ -1536,7 +1536,7 @@
           "3.0.100-rc1-buster-arm32v7"
         ]
       },
-      "3.0/sdk/buster/arm64v8": {
+      "3.0/sdk/buster/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:buster-scm": "arm64v8/buildpack-deps@sha256:6e245b3ce8e863e21535c54322721844f776ea7c5a75093aed2c76a95b2033cd"
         },
@@ -1545,7 +1545,7 @@
           "3.0.100-rc1-buster-arm64v8"
         ]
       },
-      "3.0/sdk/disco/amd64": {
+      "3.0/sdk/disco/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:disco-scm": "buildpack-deps@sha256:f85866a166daf23b5868abe07045bd057ed068b06071719f44770fe0f4daa8a9"
         },
@@ -1554,7 +1554,7 @@
           "3.0.100-rc1-disco"
         ]
       },
-      "3.0/sdk/disco/arm32v7": {
+      "3.0/sdk/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:disco-scm": "arm32v7/buildpack-deps@sha256:e057392d3f3565790388371f8681105d2c25610bbb6a8e8b79ce8c092c11d427"
         },
@@ -1563,7 +1563,7 @@
           "3.0.100-rc1-disco-arm32v7"
         ]
       },
-      "3.0/sdk/disco/arm64v8": {
+      "3.0/sdk/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:disco-scm": "arm64v8/buildpack-deps@sha256:37ed2ce17e31d7211f3f73aa551582b760d306277aa292ac5ace09833261d90e"
         },
@@ -1572,7 +1572,7 @@
           "3.0.100-rc1-disco-arm64v8"
         ]
       },
-      "3.0/sdk/nanoserver-1803/amd64": {
+      "3.0/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1582,7 +1582,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/sdk/nanoserver-1809/amd64": {
+      "3.0/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1592,7 +1592,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/sdk/nanoserver-1809/arm32v7": {
+      "3.0/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1601,7 +1601,7 @@
           "3.0.100-rc1-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/sdk/nanoserver-1903/amd64": {
+      "3.0/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"

--- a/build-info/docker/image-info.json
+++ b/build-info/docker/image-info.json
@@ -2,7 +2,7 @@
   {
     "repo": "dotnet-buildtools/prereqs",
     "images": {
-      "src/alpine/3.8/helix/amd64": {
+      "src/alpine/3.8/helix/amd64/Dockerfile": {
         "baseImages": {
           "python:3.7.3-alpine3.8": "python@sha256:3491d1abd29b3f87ca5cb1afd34bc696855a2403df1ff854da55cb6754af1ff8"
         },
@@ -10,7 +10,7 @@
           "alpine-3.8-helix-2e197e0-20190809151301"
         ]
       },
-      "src/alpine/3.8/helix/arm64v8": {
+      "src/alpine/3.8/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.8": "arm64v8/alpine@sha256:360e20fc240529450cf378756935230541da805701e3ff895305b72f37ce4d9c"
         },
@@ -18,7 +18,7 @@
           "alpine-3.8-helix-arm64v8-2e197e0-20190809151315"
         ]
       },
-      "src/alpine/3.9/amd64": {
+      "src/alpine/3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -26,7 +26,7 @@
           "alpine-3.9-44e2650-20190809151252"
         ]
       },
-      "src/alpine/3.9/arm32v7": {
+      "src/alpine/3.9/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/alpine:3.9": "arm32v7/alpine@sha256:f6d15ec5c7cf08079309c59f59ff1e092eb9a678ab891257b1d2b118e7aecc2b"
         },
@@ -34,7 +34,7 @@
           "alpine-3.9-arm32v7-44e2650-20190809151323"
         ]
       },
-      "src/alpine/3.9/arm64v8": {
+      "src/alpine/3.9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
         },
@@ -42,7 +42,7 @@
           "alpine-3.9-arm64v8-44e2650-20190809151317"
         ]
       },
-      "src/alpine/3.9/helix/amd64": {
+      "src/alpine/3.9/helix/amd64/Dockerfile": {
         "baseImages": {
           "python:3.7.3-alpine3.9": "python@sha256:69f4cedf780ea95e7a0591e5ec3db85207142278501dfab6ef483ccfa5340fe2"
         },
@@ -50,12 +50,12 @@
           "alpine-3.9-helix-2e197e0-20190809151254"
         ]
       },
-      "src/alpine/3.9/WithNode/amd64": {
+      "src/alpine/3.9/WithNode/amd64/Dockerfile": {
         "simpleTags": [
           "alpine-3.9-WithNode-0fc54a3-20190809151252"
         ]
       },
-      "src/centos/6": {
+      "src/centos/6/Dockerfile": {
         "baseImages": {
           "centos:6": "centos@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7"
         },
@@ -63,7 +63,7 @@
           "centos-6-3e800f1-20190809151311"
         ]
       },
-      "src/centos/7": {
+      "src/centos/7/Dockerfile": {
         "baseImages": {
           "centos:7": "centos@sha256:a799dd8a2ded4a83484bbae769d97655392b3f86533ceb7dd96bbac929809f3c"
         },
@@ -71,12 +71,12 @@
           "centos-7-3e800f1-20190815164629"
         ]
       },
-      "src/centos/7/mlnet": {
+      "src/centos/7/mlnet/Dockerfile": {
         "simpleTags": [
           "centos-7-mlnet-8bba86b-20190815164629"
         ]
       },
-      "src/debian/10/helix/amd64": {
+      "src/debian/10/helix/amd64/Dockerfile": {
         "baseImages": {
           "debian:buster": "debian@sha256:903779f30a7ee46937bfb21406f125d5fdace4178074e1cc71c49039ebf7f48f"
         },
@@ -84,7 +84,7 @@
           "debian-10-helix-amd64-6b166d8-20190807161114"
         ]
       },
-      "src/debian/10/helix/arm32v7": {
+      "src/debian/10/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:buster": "arm32v7/debian@sha256:2dc27b0362abdf8e47f6090c7f5f855efbfc870cb0d03ad990021ff2d9bf9541"
         },
@@ -92,7 +92,7 @@
           "debian-10-helix-arm32v7-6b166d8-20190807161034"
         ]
       },
-      "src/debian/10/helix/arm64v8": {
+      "src/debian/10/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:buster": "arm64v8/debian@sha256:d5d8c18489f86d65c77cb7e9f2b4f7fc438a0c4cc9ac563e290524ce2d2f11c2"
         },
@@ -100,7 +100,7 @@
           "debian-10-helix-arm64v8-6b166d8-20190807161035"
         ]
       },
-      "src/debian/9/arm32v7": {
+      "src/debian/9/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:9": "arm32v7/debian@sha256:205a3d2b05453df39a6bf7339dfd81878f9828985f8dcc1b7fa5c6fdbb94fd4a"
         },
@@ -108,7 +108,7 @@
           "debian-9-arm32v7-0dbbad8-20190807161034"
         ]
       },
-      "src/debian/9/arm64v8": {
+      "src/debian/9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:9": "arm64v8/debian@sha256:e8f82c8a38bc474644ccd16911793ad4a676fd6f5c0508555ca5fc7e12be06ec"
         },
@@ -116,7 +116,7 @@
           "debian-9-arm64v8-3e800f1-20190807161037"
         ]
       },
-      "src/debian/9/helix/arm32v7": {
+      "src/debian/9/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:9": "arm32v7/debian@sha256:205a3d2b05453df39a6bf7339dfd81878f9828985f8dcc1b7fa5c6fdbb94fd4a"
         },
@@ -124,7 +124,7 @@
           "debian-9-helix-arm32v7-6b166d8-20190807161035"
         ]
       },
-      "src/debian/9/helix/arm64v8": {
+      "src/debian/9/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:9": "arm64v8/debian@sha256:e8f82c8a38bc474644ccd16911793ad4a676fd6f5c0508555ca5fc7e12be06ec"
         },
@@ -132,7 +132,7 @@
           "debian-9-helix-arm64v8-a12566d-20190807161036"
         ]
       },
-      "src/debian/iot/arm32v7": {
+      "src/debian/iot/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:latest": "arm32v7/debian@sha256:2dc27b0362abdf8e47f6090c7f5f855efbfc870cb0d03ad990021ff2d9bf9541"
         },
@@ -140,12 +140,12 @@
           "debian-iot-arm32v7-be5b37d-20190807161037"
         ]
       },
-      "src/debian/jessie": {
+      "src/debian/jessie/Dockerfile": {
         "simpleTags": [
           "debian-jessie-3e800f1-20190807161116"
         ]
       },
-      "src/debian/jessie/coredeps": {
+      "src/debian/jessie/coredeps/Dockerfile": {
         "baseImages": {
           "debian:jessie": "debian@sha256:a8ae3c5129fb2e10a62b5c059a24308831508c44018c24ccda2e4fc6fd7cdda7"
         },
@@ -153,17 +153,17 @@
           "debian-jessie-coredeps-3e800f1-20190807161116"
         ]
       },
-      "src/debian/jessie/corert": {
+      "src/debian/jessie/corert/Dockerfile": {
         "simpleTags": [
           "debian-jessie-corert-58e4974-20190807161116"
         ]
       },
-      "src/debian/jessie/debpkg": {
+      "src/debian/jessie/debpkg/Dockerfile": {
         "simpleTags": [
           "debian-jessie-debpkg-58e4974-20190807161116"
         ]
       },
-      "src/debian/stretch-slim/docker-testrunner": {
+      "src/debian/stretch-slim/docker-testrunner/Dockerfile": {
         "baseImages": {
           "debian:stretch-slim": "debian@sha256:0c04edb9ae10feb7ac03a659dd41e16c79e04fdb2b10cf93c3cbcef1fd6cc1d5"
         },
@@ -171,7 +171,7 @@
           "debian-stretch-slim-docker-testrunner-d61254f-20190807161111"
         ]
       },
-      "src/debian/stretch/": {
+      "src/debian/stretch/Dockerfile": {
         "baseImages": {
           "debian:stretch": "debian@sha256:397b2157a9ea8d7f16c613aded70284292106e8b813fb1ed5de8a8785310a26a"
         },
@@ -179,7 +179,7 @@
           "debian-stretch-d61254f-20190807161114"
         ]
       },
-      "src/fedora/29": {
+      "src/fedora/29/Dockerfile": {
         "baseImages": {
           "fedora:29": "fedora@sha256:2c20e5bb324735427f8a659e36f4fe14d6955c74c7baa25067418dddbb71d67a"
         },
@@ -187,12 +187,12 @@
           "fedora-29-a12566d-20190806171712"
         ]
       },
-      "src/fedora/29/helix/amd64": {
+      "src/fedora/29/helix/amd64/Dockerfile/Dockerfile": {
         "simpleTags": [
           "fedora-29-helix-a12566d-20190806171712"
         ]
       },
-      "src/fedora/30/amd64": {
+      "src/fedora/30/amd64/Dockerfile": {
         "baseImages": {
           "fedora:30": "fedora@sha256:d39a02a0f13c1df3bbcb0ccea4021c53b8e0bfd87f701a5115e18ec089814e70"
         },
@@ -200,12 +200,12 @@
           "fedora-30-39ec319-20190806171718"
         ]
       },
-      "src/fedora/30/helix/amd64": {
+      "src/fedora/30/helix/amd64/Dockerfile": {
         "simpleTags": [
           "fedora-30-helix-2e197e0-20190806171718"
         ]
       },
-      "src/nanoserver/1803/helix/amd64": {
+      "src/nanoserver/1803/helix/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/powershell:6.2.0-nanoserver-1803": "mcr.microsoft.com/powershell@sha256:ed8ec196c698713d8814f3c586265a294938d3880943c925cf48d42531bf6675"
         },
@@ -213,7 +213,7 @@
           "nanoserver-1803-helix-amd64-1441ed6-20190815130533"
         ]
       },
-      "src/nanoserver/1809/helix/amd64": {
+      "src/nanoserver/1809/helix/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/powershell:6.2.0-nanoserver-1809": "mcr.microsoft.com/powershell@sha256:8a4e778616607888d88eb64ca72eab4740b2ecef4c93fccf12e1d13cec204646"
         },
@@ -221,7 +221,7 @@
           "nanoserver-1809-helix-amd64-61052b7-20190809151858"
         ]
       },
-      "src/ubuntu/14.04": {
+      "src/ubuntu/14.04/Dockerfile": {
         "baseImages": {
           "ubuntu:14.04": "ubuntu@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90"
         },
@@ -229,7 +229,7 @@
           "ubuntu-14.04-1735d26-20190809151504"
         ]
       },
-      "src/ubuntu/14.04/coredeps": {
+      "src/ubuntu/14.04/coredeps/Dockerfile": {
         "baseImages": {
           "ubuntu:14.04": "ubuntu@sha256:2f7c79927b346e436cc14c92bd4e5bd778c3bd7037f35bc639ac1589a7acfa90"
         },
@@ -237,22 +237,22 @@
           "ubuntu-14.04-coredeps-3e800f1-20190809151457"
         ]
       },
-      "src/ubuntu/14.04/cross": {
+      "src/ubuntu/14.04/cross/Dockerfile": {
         "simpleTags": [
           "ubuntu-14.04-cross-1735d26-20190809151457"
         ]
       },
-      "src/ubuntu/14.04/crossdeps": {
+      "src/ubuntu/14.04/crossdeps/Dockerfile": {
         "simpleTags": [
           "ubuntu-14.04-crossdeps-cfdd435-20190809151457"
         ]
       },
-      "src/ubuntu/14.04/debpkg": {
+      "src/ubuntu/14.04/debpkg/Dockerfile": {
         "simpleTags": [
           "ubuntu-14.04-debpkg-cfdd435-20190809151504"
         ]
       },
-      "src/ubuntu/16.04": {
+      "src/ubuntu/16.04/Dockerfile": {
         "baseImages": {
           "ubuntu:16.04": "ubuntu@sha256:97b54e5692c27072234ff958a7442dde4266af21e7b688e7fca5dc5acc8ed7d9"
         },
@@ -260,7 +260,7 @@
           "ubuntu-16.04-30f6673-20190814211612"
         ]
       },
-      "src/ubuntu/16.04/arm32v7": {
+      "src/ubuntu/16.04/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:16.04": "arm32v7/ubuntu@sha256:7826e9ef78e9c2a71388dd08316dcbd94a26a7be5c9ccdeb134d6360665c3d7f"
         },
@@ -268,7 +268,7 @@
           "ubuntu-16.04-arm32v7-0dbbad8-20190814211513"
         ]
       },
-      "src/ubuntu/16.04/arm64v8": {
+      "src/ubuntu/16.04/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:16.04": "arm64v8/ubuntu@sha256:6c6dc3e0c188da27e29edb852d03034e6b7d50a0f10b8ff296220c3a141b703a"
         },
@@ -276,7 +276,7 @@
           "ubuntu-16.04-arm64v8-3e800f1-20190814211510"
         ]
       },
-      "src/ubuntu/16.04/coredeps": {
+      "src/ubuntu/16.04/coredeps/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/powershell:6.2.1-ubuntu-16.04": "mcr.microsoft.com/powershell@sha256:828aaedfbfbf6885800754618a99b7126f5dde4bb51d19a61a22f9a6044f70ee"
         },
@@ -284,37 +284,37 @@
           "ubuntu-16.04-coredeps-d9d81d0-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/cross": {
+      "src/ubuntu/16.04/cross/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-cross-23cacb0-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/cross/14.04": {
+      "src/ubuntu/16.04/cross/14.04/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-cross-14.04-23cacb0-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/cross/arm64": {
+      "src/ubuntu/16.04/cross/arm64/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-cross-arm64-cfdd435-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/cross/arm64-alpine": {
+      "src/ubuntu/16.04/cross/arm64-alpine/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-cross-arm64-alpine-406629a-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/crossdeps": {
+      "src/ubuntu/16.04/crossdeps/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-crossdeps-cfdd435-20190814211620"
         ]
       },
-      "src/ubuntu/16.04/debpkg": {
+      "src/ubuntu/16.04/debpkg/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-debpkg-cfdd435-20190814211612"
         ]
       },
-      "src/ubuntu/16.04/helix/arm32v7": {
+      "src/ubuntu/16.04/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:16.04": "arm32v7/ubuntu@sha256:7826e9ef78e9c2a71388dd08316dcbd94a26a7be5c9ccdeb134d6360665c3d7f"
         },
@@ -322,7 +322,7 @@
           "ubuntu-16.04-helix-arm32v7-30f6673-20190814211508"
         ]
       },
-      "src/ubuntu/16.04/helix/arm64v8": {
+      "src/ubuntu/16.04/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:16.04": "arm64v8/ubuntu@sha256:6c6dc3e0c188da27e29edb852d03034e6b7d50a0f10b8ff296220c3a141b703a"
         },
@@ -330,12 +330,12 @@
           "ubuntu-16.04-helix-arm64v8-2e197e0-20190814211515"
         ]
       },
-      "src/ubuntu/16.04/mlnet": {
+      "src/ubuntu/16.04/mlnet/Dockerfile": {
         "simpleTags": [
           "ubuntu-16.04-mlnet-207e097-20190814211612"
         ]
       },
-      "src/ubuntu/18.04/amd64": {
+      "src/ubuntu/18.04/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:18.04": "ubuntu@sha256:c303f19cfe9ee92badbbbd7567bc1ca47789f79303ddcef56f77687d4744cd7a"
         },
@@ -343,7 +343,7 @@
           "ubuntu-18.04-3e800f1-20190814211606"
         ]
       },
-      "src/ubuntu/18.04/arm32v7": {
+      "src/ubuntu/18.04/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:46fe74f7b605368593fd21ff9db45429d9faa86550ad13f7eefb2c995c69b271"
         },
@@ -351,7 +351,7 @@
           "ubuntu-18.04-arm32v7-3e800f1-20190814211515"
         ]
       },
-      "src/ubuntu/18.04/arm64v8": {
+      "src/ubuntu/18.04/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:be2ef80501adc5a13c4a58a8045923d4e64b691aaa7e6e470c14e88a45845d0d"
         },
@@ -359,12 +359,12 @@
           "ubuntu-18.04-arm64v8-3e800f1-20190814211508"
         ]
       },
-      "src/ubuntu/18.04/debpkg": {
+      "src/ubuntu/18.04/debpkg/Dockerfile": {
         "simpleTags": [
           "ubuntu-18.04-debpkg-cfdd435-20190814211606"
         ]
       },
-      "src/ubuntu/18.04/helix/arm32v7": {
+      "src/ubuntu/18.04/helix/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:46fe74f7b605368593fd21ff9db45429d9faa86550ad13f7eefb2c995c69b271"
         },
@@ -372,7 +372,7 @@
           "ubuntu-18.04-helix-arm32v7-30f6673-20190814211509"
         ]
       },
-      "src/ubuntu/18.04/helix/arm64v8": {
+      "src/ubuntu/18.04/helix/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:be2ef80501adc5a13c4a58a8045923d4e64b691aaa7e6e470c14e88a45845d0d"
         },
@@ -380,7 +380,7 @@
           "ubuntu-18.04-helix-arm64v8-2e197e0-20190814211510"
         ]
       },
-      "src/ubuntu/19.04/helix/amd64": {
+      "src/ubuntu/19.04/helix/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:19.04": "ubuntu@sha256:23f56d855075d7a8ca49b79d61edaab2f28645f4834767abf1b7d3884b969e92"
         },
@@ -393,7 +393,7 @@
   {
     "repo": "dotnet/core-nightly/aspnet",
     "images": {
-      "2.1/aspnet/alpine3.10/amd64": {
+      "2.1/aspnet/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.10",
@@ -401,31 +401,31 @@
           "2.1.13-alpine3.10"
         ]
       },
-      "2.1/aspnet/alpine3.7/amd64": {
+      "2.1/aspnet/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/aspnet/alpine3.9/amd64": {
+      "2.1/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.9",
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/aspnet/bionic/amd64": {
+      "2.1/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/aspnet/bionic/arm32v7": {
+      "2.1/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/aspnet/nanoserver-1803/amd64": {
+      "2.1/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -435,7 +435,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/aspnet/nanoserver-1809/amd64": {
+      "2.1/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -445,7 +445,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/aspnet/nanoserver-1903/amd64": {
+      "2.1/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -455,19 +455,19 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/aspnet/stretch-slim/amd64": {
+      "2.1/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/aspnet/stretch-slim/arm32v7": {
+      "2.1/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/aspnet/alpine3.10/amd64": {
+      "2.2/aspnet/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.10",
@@ -475,31 +475,31 @@
           "2.2.7-alpine3.10"
         ]
       },
-      "2.2/aspnet/alpine3.8/amd64": {
+      "2.2/aspnet/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/aspnet/alpine3.9/amd64": {
+      "2.2/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/aspnet/bionic/amd64": {
+      "2.2/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/aspnet/bionic/arm32v7": {
+      "2.2/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1803/amd64": {
+      "2.2/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -509,7 +509,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/amd64": {
+      "2.2/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -519,7 +519,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/arm32v7": {
+      "2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -529,7 +529,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1903/amd64": {
+      "2.2/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -539,19 +539,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/aspnet/stretch-slim/amd64": {
+      "2.2/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/aspnet/stretch-slim/arm32v7": {
+      "2.2/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/alpine3.10/amd64": {
+      "3.0/aspnet/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.10",
@@ -559,7 +559,7 @@
           "3.0.0-alpine3.10"
         ]
       },
-      "3.0/aspnet/alpine3.10/arm64v8": {
+      "3.0/aspnet/alpine3.10/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.10-arm64v8",
@@ -567,73 +567,73 @@
           "3.0.0-alpine3.10-arm64v8"
         ]
       },
-      "3.0/aspnet/alpine3.9/amd64": {
+      "3.0/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9",
           "3.0.0-alpine3.9"
         ]
       },
-      "3.0/aspnet/alpine3.9/arm64v8": {
+      "3.0/aspnet/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9-arm64v8",
           "3.0.0-alpine3.9-arm64v8"
         ]
       },
-      "3.0/aspnet/bionic/amd64": {
+      "3.0/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-bionic"
         ]
       },
-      "3.0/aspnet/bionic/arm32v7": {
+      "3.0/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-bionic-arm32v7"
         ]
       },
-      "3.0/aspnet/bionic/arm64v8": {
+      "3.0/aspnet/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-bionic-arm64v8"
         ]
       },
-      "3.0/aspnet/buster-slim/amd64": {
+      "3.0/aspnet/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-buster-slim"
         ]
       },
-      "3.0/aspnet/buster-slim/arm32v7": {
+      "3.0/aspnet/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-buster-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/buster-slim/arm64v8": {
+      "3.0/aspnet/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-buster-slim-arm64v8"
         ]
       },
-      "3.0/aspnet/disco/amd64": {
+      "3.0/aspnet/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-disco"
         ]
       },
-      "3.0/aspnet/disco/arm32v7": {
+      "3.0/aspnet/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-disco-arm32v7"
         ]
       },
-      "3.0/aspnet/disco/arm64v8": {
+      "3.0/aspnet/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-disco-arm64v8"
         ]
       },
-      "3.0/aspnet/nanoserver-1803/amd64": {
+      "3.0/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -642,7 +642,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/amd64": {
+      "3.0/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
         },
@@ -651,13 +651,13 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/arm32v7": {
+      "3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-nanoserver-1809-arm32v7",
           "3.0.0-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/aspnet/nanoserver-1903/amd64": {
+      "3.0/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -671,30 +671,30 @@
   {
     "repo": "dotnet/core-nightly/runtime",
     "images": {
-      "1.0/runtime/jessie/amd64": {
+      "1.0/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.0/runtime/nanoserver-1809/amd64": {
+      "1.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/jessie/amd64": {
+      "1.1/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.1/runtime/nanoserver-1809/amd64": {
+      "1.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/stretch/amd64": {
+      "1.1/runtime/stretch/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "2.1/runtime/alpine3.10/amd64": {
+      "2.1/runtime/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.10",
@@ -702,31 +702,31 @@
           "2.1.13-alpine3.10"
         ]
       },
-      "2.1/runtime/alpine3.7/amd64": {
+      "2.1/runtime/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime/alpine3.9/amd64": {
+      "2.1/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.9",
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/runtime/bionic/amd64": {
+      "2.1/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/runtime/bionic/arm32v7": {
+      "2.1/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/runtime/nanoserver-1803/amd64": {
+      "2.1/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -736,7 +736,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/runtime/nanoserver-1809/amd64": {
+      "2.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -746,7 +746,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/runtime/nanoserver-1903/amd64": {
+      "2.1/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -756,19 +756,19 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/runtime/stretch-slim/amd64": {
+      "2.1/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/runtime/stretch-slim/arm32v7": {
+      "2.1/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime/alpine3.10/amd64": {
+      "2.2/runtime/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.10",
@@ -776,31 +776,31 @@
           "2.2.7-alpine3.10"
         ]
       },
-      "2.2/runtime/alpine3.8/amd64": {
+      "2.2/runtime/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/runtime/alpine3.9/amd64": {
+      "2.2/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/runtime/bionic/amd64": {
+      "2.2/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/runtime/bionic/arm32v7": {
+      "2.2/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1803/amd64": {
+      "2.2/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -810,7 +810,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/runtime/nanoserver-1809/amd64": {
+      "2.2/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -820,7 +820,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/runtime/nanoserver-1809/arm32v7": {
+      "2.2/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -830,7 +830,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1903/amd64": {
+      "2.2/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -840,19 +840,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/runtime/stretch-slim/amd64": {
+      "2.2/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/runtime/stretch-slim/arm32v7": {
+      "2.2/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/runtime/alpine3.10/amd64": {
+      "3.0/runtime/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.10",
@@ -860,7 +860,7 @@
           "3.0.0-alpine3.10"
         ]
       },
-      "3.0/runtime/alpine3.10/arm64v8": {
+      "3.0/runtime/alpine3.10/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.10-arm64v8",
@@ -868,73 +868,73 @@
           "3.0.0-alpine3.10-arm64v8"
         ]
       },
-      "3.0/runtime/alpine3.9/amd64": {
+      "3.0/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9",
           "3.0.0-alpine3.9"
         ]
       },
-      "3.0/runtime/alpine3.9/arm64v8": {
+      "3.0/runtime/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9-arm64v8",
           "3.0.0-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime/bionic/amd64": {
+      "3.0/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-bionic"
         ]
       },
-      "3.0/runtime/bionic/arm32v7": {
+      "3.0/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-bionic-arm32v7"
         ]
       },
-      "3.0/runtime/bionic/arm64v8": {
+      "3.0/runtime/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-bionic-arm64v8"
         ]
       },
-      "3.0/runtime/buster-slim/amd64": {
+      "3.0/runtime/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-buster-slim"
         ]
       },
-      "3.0/runtime/buster-slim/arm32v7": {
+      "3.0/runtime/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime/buster-slim/arm64v8": {
+      "3.0/runtime/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime/disco/amd64": {
+      "3.0/runtime/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-disco"
         ]
       },
-      "3.0/runtime/disco/arm32v7": {
+      "3.0/runtime/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-disco-arm32v7"
         ]
       },
-      "3.0/runtime/disco/arm64v8": {
+      "3.0/runtime/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-disco-arm64v8"
         ]
       },
-      "3.0/runtime/nanoserver-1803/amd64": {
+      "3.0/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -944,7 +944,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/runtime/nanoserver-1809/amd64": {
+      "3.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -954,7 +954,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/runtime/nanoserver-1809/arm32v7": {
+      "3.0/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -963,7 +963,7 @@
           "3.0.0-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/runtime/nanoserver-1903/amd64": {
+      "3.0/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -978,19 +978,19 @@
   {
     "repo": "dotnet/core-nightly/runtime-deps",
     "images": {
-      "1.0/runtime-deps/jessie/amd64": {
+      "1.0/runtime-deps/jessie/amd64/Dockerfile": {
         "baseImages": {
           "debian:jessie": "debian@sha256:6b95a104400bb99ad60b47a48e37d5d1eb71a3f9ec8e86854e0cf64ecc5fd0e8"
         },
         "simpleTags": []
       },
-      "1.1/runtime-deps/stretch/amd64": {
+      "1.1/runtime-deps/stretch/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch": "debian@sha256:2b20d1b80dbcdef98ff4e747109c39d2b91539f7f12d7873fdd452306eddb04d"
         },
         "simpleTags": []
       },
-      "2.1/runtime-deps/alpine3.10/amd64": {
+      "2.1/runtime-deps/alpine3.10/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.10": "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
         },
@@ -1005,7 +1005,7 @@
           "2.2.7-alpine3.10"
         ]
       },
-      "2.1/runtime-deps/alpine3.7/amd64": {
+      "2.1/runtime-deps/alpine3.7/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.7": "alpine@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10"
         },
@@ -1014,7 +1014,7 @@
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime-deps/alpine3.9/amd64": {
+      "2.1/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -1025,7 +1025,7 @@
           "2.2.7-alpine3.9"
         ]
       },
-      "2.1/runtime-deps/bionic/amd64": {
+      "2.1/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -1036,7 +1036,7 @@
           "2.2.7-bionic"
         ]
       },
-      "2.1/runtime-deps/bionic/arm32v7": {
+      "2.1/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -1047,7 +1047,7 @@
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/amd64": {
+      "2.1/runtime-deps/stretch-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch-slim": "debian@sha256:8ef99f5a3e800df50ea02334d233360d26c414208815686fbcbf34648ec596d4"
         },
@@ -1058,7 +1058,7 @@
           "2.2.7-stretch-slim"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/arm32v7": {
+      "2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:stretch-slim": "arm32v7/debian@sha256:738c21d3d4352dbd5ffd2f86fa13f17a040496fac70a549ee939d1ebb34b5dde"
         },
@@ -1069,7 +1069,7 @@
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime-deps/alpine3.8/amd64": {
+      "2.2/runtime-deps/alpine3.8/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.8": "alpine@sha256:04696b491e0cc3c58a75bace8941c14c924b9f313b03ce5029ebbc040ed9dcd9"
         },
@@ -1078,7 +1078,7 @@
           "2.2.7-alpine3.8"
         ]
       },
-      "3.0/runtime-deps/alpine3.10/amd64": {
+      "3.0/runtime-deps/alpine3.10/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.10": "alpine@sha256:72c42ed48c3a2db31b7dafe17d275b634664a708d901ec9fd57b1529280f01fb"
         },
@@ -1089,7 +1089,7 @@
           "3.0.0-alpine3.10"
         ]
       },
-      "3.0/runtime-deps/alpine3.10/arm64v8": {
+      "3.0/runtime-deps/alpine3.10/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.10": "arm64v8/alpine@sha256:db7f3dcef3d586f7dd123f107c93d7911515a5991c4b9e51fa2a43e46335a43e"
         },
@@ -1100,7 +1100,7 @@
           "3.0.0-alpine3.10-arm64v8"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/amd64": {
+      "3.0/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -1109,7 +1109,7 @@
           "3.0.0-alpine3.9"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/arm64v8": {
+      "3.0/runtime-deps/alpine3.9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
         },
@@ -1118,7 +1118,7 @@
           "3.0.0-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime-deps/bionic/amd64": {
+      "3.0/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -1127,7 +1127,7 @@
           "3.0.0-bionic"
         ]
       },
-      "3.0/runtime-deps/bionic/arm32v7": {
+      "3.0/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -1136,7 +1136,7 @@
           "3.0.0-bionic-arm32v7"
         ]
       },
-      "3.0/runtime-deps/bionic/arm64v8": {
+      "3.0/runtime-deps/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:bionic": "arm64v8/ubuntu@sha256:1a06d68cb9117b52965035a5b0fa4c1470ef892e6062ffedb1af1922952e0950"
         },
@@ -1145,7 +1145,7 @@
           "3.0.0-bionic-arm64v8"
         ]
       },
-      "3.0/runtime-deps/buster-slim/amd64": {
+      "3.0/runtime-deps/buster-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:buster-slim": "debian@sha256:80cc84d66e12d590d2f82ed7e57f906a89f8d10c5b9d7be23ed04e5c6dbb865b"
         },
@@ -1154,7 +1154,7 @@
           "3.0.0-buster-slim"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm32v7": {
+      "3.0/runtime-deps/buster-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:buster-slim": "arm32v7/debian@sha256:5b5994d4ed9ca8f31f3c0f5ad90733cde33e8ddc6c4de6c4447dd0b4f0b7ce53"
         },
@@ -1163,7 +1163,7 @@
           "3.0.0-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm64v8": {
+      "3.0/runtime-deps/buster-slim/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:buster-slim": "arm64v8/debian@sha256:dde35769e3fccb0bf9f714f78e61b7d89ca722e85109f02866a55d3210439f18"
         },
@@ -1172,7 +1172,7 @@
           "3.0.0-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime-deps/disco/amd64": {
+      "3.0/runtime-deps/disco/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:disco": "ubuntu@sha256:23f56d855075d7a8ca49b79d61edaab2f28645f4834767abf1b7d3884b969e92"
         },
@@ -1181,7 +1181,7 @@
           "3.0.0-disco"
         ]
       },
-      "3.0/runtime-deps/disco/arm32v7": {
+      "3.0/runtime-deps/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:disco": "arm32v7/ubuntu@sha256:48bcb63022b888120570bdf8b1db3a6f244f60e811eab47317ce3c2d6c5a6c9f"
         },
@@ -1190,7 +1190,7 @@
           "3.0.0-disco-arm32v7"
         ]
       },
-      "3.0/runtime-deps/disco/arm64v8": {
+      "3.0/runtime-deps/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:disco": "arm64v8/ubuntu@sha256:2e3740619e32e69031b01cd915bac3aebe6de10654737bec52f617ed56df7760"
         },
@@ -1204,26 +1204,26 @@
   {
     "repo": "dotnet/core-nightly/sdk",
     "images": {
-      "1.1/sdk/jessie/amd64": {
+      "1.1/sdk/jessie/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:jessie-scm": "buildpack-deps@sha256:44d0d909383bb6976c231000af4bcf7988a84afff293270b3df8fdc8af0d3483"
         },
         "simpleTags": []
       },
-      "1.1/sdk/nanoserver-1809/amd64": {
+      "1.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/sdk/stretch/amd64": {
+      "1.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:0c69a4523a91a858e7e49d8818c97a467edda24553eafae8d409e3b04953226a"
         },
         "simpleTags": []
       },
-      "2.1/sdk/alpine3.10/amd64": {
+      "2.1/sdk/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.10",
@@ -1231,19 +1231,19 @@
           "2.1.802-alpine3.10"
         ]
       },
-      "2.1/sdk/alpine3.7/amd64": {
+      "2.1/sdk/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.802-alpine3.7"
         ]
       },
-      "2.1/sdk/alpine3.9/amd64": {
+      "2.1/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.9",
           "2.1.802-alpine3.9"
         ]
       },
-      "2.1/sdk/bionic/amd64": {
+      "2.1/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -1252,7 +1252,7 @@
           "2.1.802-bionic"
         ]
       },
-      "2.1/sdk/bionic/arm32v7": {
+      "2.1/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -1261,7 +1261,7 @@
           "2.1.802-bionic-arm32v7"
         ]
       },
-      "2.1/sdk/nanoserver-1803/amd64": {
+      "2.1/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1271,7 +1271,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/sdk/nanoserver-1809/amd64": {
+      "2.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1281,7 +1281,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/sdk/nanoserver-1903/amd64": {
+      "2.1/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1291,7 +1291,7 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/sdk/stretch/amd64": {
+      "2.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -1300,7 +1300,7 @@
           "2.1.802-stretch"
         ]
       },
-      "2.1/sdk/stretch/arm32v7": {
+      "2.1/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:13e73fbcec6e3a0a5e35916beac60cb35104c3208292c78a82584f8417061066"
         },
@@ -1309,7 +1309,7 @@
           "2.1.802-stretch-arm32v7"
         ]
       },
-      "2.2/sdk/alpine3.10/amd64": {
+      "2.2/sdk/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.10",
@@ -1317,19 +1317,19 @@
           "2.2.402-alpine3.10"
         ]
       },
-      "2.2/sdk/alpine3.8/amd64": {
+      "2.2/sdk/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.402-alpine3.8"
         ]
       },
-      "2.2/sdk/alpine3.9/amd64": {
+      "2.2/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.402-alpine3.9"
         ]
       },
-      "2.2/sdk/bionic/amd64": {
+      "2.2/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -1338,7 +1338,7 @@
           "2.2.402-bionic"
         ]
       },
-      "2.2/sdk/bionic/arm32v7": {
+      "2.2/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -1347,7 +1347,7 @@
           "2.2.402-bionic-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1803/amd64": {
+      "2.2/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1357,7 +1357,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/sdk/nanoserver-1809/amd64": {
+      "2.2/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1367,7 +1367,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/sdk/nanoserver-1809/arm32v7": {
+      "2.2/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1377,7 +1377,7 @@
           "2.2.402-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1903/amd64": {
+      "2.2/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1387,7 +1387,7 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/sdk/stretch/amd64": {
+      "2.2/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -1396,7 +1396,7 @@
           "2.2.402-stretch"
         ]
       },
-      "2.2/sdk/stretch/arm32v7": {
+      "2.2/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:13e73fbcec6e3a0a5e35916beac60cb35104c3208292c78a82584f8417061066"
         },
@@ -1405,7 +1405,7 @@
           "2.2.402-stretch-arm32v7"
         ]
       },
-      "3.0/sdk/alpine3.10/amd64": {
+      "3.0/sdk/alpine3.10/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.10",
@@ -1413,13 +1413,13 @@
           "3.0.100-alpine3.10"
         ]
       },
-      "3.0/sdk/alpine3.9/amd64": {
+      "3.0/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine3.9",
           "3.0.100-alpine3.9"
         ]
       },
-      "3.0/sdk/bionic/amd64": {
+      "3.0/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -1428,7 +1428,7 @@
           "3.0.100-bionic"
         ]
       },
-      "3.0/sdk/bionic/arm32v7": {
+      "3.0/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -1437,7 +1437,7 @@
           "3.0.100-bionic-arm32v7"
         ]
       },
-      "3.0/sdk/bionic/arm64v8": {
+      "3.0/sdk/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:bionic-scm": "arm64v8/buildpack-deps@sha256:382662800e0f4cd0b1258311e7f74a782c71ff23a54273300b8a396e6dfebb89"
         },
@@ -1446,7 +1446,7 @@
           "3.0.100-bionic-arm64v8"
         ]
       },
-      "3.0/sdk/buster/amd64": {
+      "3.0/sdk/buster/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:buster-scm": "buildpack-deps@sha256:ef75fcad284d5db55eb4da1b41606763e01587c6dccb9e2f2c1cb404c256e062"
         },
@@ -1455,7 +1455,7 @@
           "3.0.100-buster"
         ]
       },
-      "3.0/sdk/buster/arm32v7": {
+      "3.0/sdk/buster/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:buster-scm": "arm32v7/buildpack-deps@sha256:6ac435c55946bfba506488f61499de6032d53d6c40792103944c58f1e9badb0e"
         },
@@ -1464,7 +1464,7 @@
           "3.0.100-buster-arm32v7"
         ]
       },
-      "3.0/sdk/buster/arm64v8": {
+      "3.0/sdk/buster/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:buster-scm": "arm64v8/buildpack-deps@sha256:6e245b3ce8e863e21535c54322721844f776ea7c5a75093aed2c76a95b2033cd"
         },
@@ -1473,7 +1473,7 @@
           "3.0.100-buster-arm64v8"
         ]
       },
-      "3.0/sdk/disco/amd64": {
+      "3.0/sdk/disco/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:disco-scm": "buildpack-deps@sha256:f85866a166daf23b5868abe07045bd057ed068b06071719f44770fe0f4daa8a9"
         },
@@ -1482,7 +1482,7 @@
           "3.0.100-disco"
         ]
       },
-      "3.0/sdk/disco/arm32v7": {
+      "3.0/sdk/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:disco-scm": "arm32v7/buildpack-deps@sha256:e057392d3f3565790388371f8681105d2c25610bbb6a8e8b79ce8c092c11d427"
         },
@@ -1491,7 +1491,7 @@
           "3.0.100-disco-arm32v7"
         ]
       },
-      "3.0/sdk/disco/arm64v8": {
+      "3.0/sdk/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:disco-scm": "arm64v8/buildpack-deps@sha256:37ed2ce17e31d7211f3f73aa551582b760d306277aa292ac5ace09833261d90e"
         },
@@ -1500,7 +1500,7 @@
           "3.0.100-disco-arm64v8"
         ]
       },
-      "3.0/sdk/nanoserver-1803/amd64": {
+      "3.0/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1510,7 +1510,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/sdk/nanoserver-1809/amd64": {
+      "3.0/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1520,7 +1520,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/sdk/nanoserver-1809/arm32v7": {
+      "3.0/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1529,7 +1529,7 @@
           "3.0.100-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/sdk/nanoserver-1903/amd64": {
+      "3.0/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1544,13 +1544,13 @@
   {
     "repo": "dotnet/core/aspnet",
     "images": {
-      "2.1/aspnet/alpine3.7/amd64": {
+      "2.1/aspnet/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/aspnet/alpine3.9/amd64": {
+      "2.1/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.9",
@@ -1558,19 +1558,19 @@
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/aspnet/bionic/amd64": {
+      "2.1/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/aspnet/bionic/arm32v7": {
+      "2.1/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/aspnet/nanoserver-1803/amd64": {
+      "2.1/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1580,7 +1580,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/aspnet/nanoserver-1809/amd64": {
+      "2.1/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1590,7 +1590,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/aspnet/nanoserver-1903/amd64": {
+      "2.1/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1600,19 +1600,19 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/aspnet/stretch-slim/amd64": {
+      "2.1/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/aspnet/stretch-slim/arm32v7": {
+      "2.1/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/aspnet/alpine3.8/amd64": {
+      "2.2/aspnet/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.8",
@@ -1620,25 +1620,25 @@
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/aspnet/alpine3.9/amd64": {
+      "2.2/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.9",
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/aspnet/bionic/amd64": {
+      "2.2/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/aspnet/bionic/arm32v7": {
+      "2.2/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1803/amd64": {
+      "2.2/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1648,7 +1648,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/amd64": {
+      "2.2/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1658,7 +1658,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/aspnet/nanoserver-1809/arm32v7": {
+      "2.2/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1668,7 +1668,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/aspnet/nanoserver-1903/amd64": {
+      "2.2/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1678,19 +1678,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/aspnet/stretch-slim/amd64": {
+      "2.2/aspnet/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/aspnet/stretch-slim/arm32v7": {
+      "2.2/aspnet/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/alpine3.9/amd64": {
+      "3.0/aspnet/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -1698,7 +1698,7 @@
           "3.0.0-rc1-alpine3.9"
         ]
       },
-      "3.0/aspnet/alpine3.9/arm64v8": {
+      "3.0/aspnet/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.9-arm64v8",
@@ -1706,61 +1706,61 @@
           "3.0.0-rc1-alpine3.9-arm64v8"
         ]
       },
-      "3.0/aspnet/bionic/amd64": {
+      "3.0/aspnet/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-rc1-bionic"
         ]
       },
-      "3.0/aspnet/bionic/arm32v7": {
+      "3.0/aspnet/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/aspnet/bionic/arm64v8": {
+      "3.0/aspnet/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/aspnet/buster-slim/amd64": {
+      "3.0/aspnet/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-rc1-buster-slim"
         ]
       },
-      "3.0/aspnet/buster-slim/arm32v7": {
+      "3.0/aspnet/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-rc1-buster-slim-arm32v7"
         ]
       },
-      "3.0/aspnet/buster-slim/arm64v8": {
+      "3.0/aspnet/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-rc1-buster-slim-arm64v8"
         ]
       },
-      "3.0/aspnet/disco/amd64": {
+      "3.0/aspnet/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-rc1-disco"
         ]
       },
-      "3.0/aspnet/disco/arm32v7": {
+      "3.0/aspnet/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-rc1-disco-arm32v7"
         ]
       },
-      "3.0/aspnet/disco/arm64v8": {
+      "3.0/aspnet/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-rc1-disco-arm64v8"
         ]
       },
-      "3.0/aspnet/nanoserver-1803/amd64": {
+      "3.0/aspnet/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -1769,7 +1769,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/amd64": {
+      "3.0/aspnet/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
         },
@@ -1778,13 +1778,13 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/aspnet/nanoserver-1809/arm32v7": {
+      "3.0/aspnet/nanoserver-1809/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-nanoserver-1809-arm32v7",
           "3.0.0-rc1-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/aspnet/nanoserver-1903/amd64": {
+      "3.0/aspnet/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -1798,36 +1798,36 @@
   {
     "repo": "dotnet/core/runtime",
     "images": {
-      "1.0/runtime/jessie/amd64": {
+      "1.0/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.0/runtime/nanoserver-1809/amd64": {
+      "1.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/jessie/amd64": {
+      "1.1/runtime/jessie/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "1.1/runtime/nanoserver-1809/amd64": {
+      "1.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/runtime/stretch/amd64": {
+      "1.1/runtime/stretch/amd64/Dockerfile": {
         "simpleTags": []
       },
-      "2.1/runtime/alpine3.7/amd64": {
+      "2.1/runtime/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime/alpine3.9/amd64": {
+      "2.1/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.9",
@@ -1835,19 +1835,19 @@
           "2.1.13-alpine3.9"
         ]
       },
-      "2.1/runtime/bionic/amd64": {
+      "2.1/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-bionic",
           "2.1.13-bionic"
         ]
       },
-      "2.1/runtime/bionic/arm32v7": {
+      "2.1/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-bionic-arm32v7",
           "2.1.13-bionic-arm32v7"
         ]
       },
-      "2.1/runtime/nanoserver-1803/amd64": {
+      "2.1/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1857,7 +1857,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/runtime/nanoserver-1809/amd64": {
+      "2.1/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1867,7 +1867,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/runtime/nanoserver-1903/amd64": {
+      "2.1/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1877,25 +1877,25 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/runtime/stretch-slim/amd64": {
+      "2.1/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim",
           "2.1.13-stretch-slim"
         ]
       },
-      "2.1/runtime/stretch-slim/arm32v7": {
+      "2.1/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.1-stretch-slim-arm32v7",
           "2.1.13-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime/alpine3.8/amd64": {
+      "2.2/runtime/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.7-alpine3.8"
         ]
       },
-      "2.2/runtime/alpine3.9/amd64": {
+      "2.2/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.9",
@@ -1903,19 +1903,19 @@
           "2.2.7-alpine3.9"
         ]
       },
-      "2.2/runtime/bionic/amd64": {
+      "2.2/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-bionic",
           "2.2.7-bionic"
         ]
       },
-      "2.2/runtime/bionic/arm32v7": {
+      "2.2/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-bionic-arm32v7",
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1803/amd64": {
+      "2.2/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -1925,7 +1925,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/runtime/nanoserver-1809/amd64": {
+      "2.2/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -1935,7 +1935,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/runtime/nanoserver-1809/arm32v7": {
+      "2.2/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -1945,7 +1945,7 @@
           "2.2.7-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/runtime/nanoserver-1903/amd64": {
+      "2.2/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -1955,19 +1955,19 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/runtime/stretch-slim/amd64": {
+      "2.2/runtime/stretch-slim/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim",
           "2.2.7-stretch-slim"
         ]
       },
-      "2.2/runtime/stretch-slim/arm32v7": {
+      "2.2/runtime/stretch-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "2.2-stretch-slim-arm32v7",
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "3.0/runtime/alpine3.9/amd64": {
+      "3.0/runtime/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -1975,7 +1975,7 @@
           "3.0.0-rc1-alpine3.9"
         ]
       },
-      "3.0/runtime/alpine3.9/arm64v8": {
+      "3.0/runtime/alpine3.9/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-alpine-arm64v8",
           "3.0-alpine3.9-arm64v8",
@@ -1983,61 +1983,61 @@
           "3.0.0-rc1-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime/bionic/amd64": {
+      "3.0/runtime/bionic/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-bionic",
           "3.0.0-rc1-bionic"
         ]
       },
-      "3.0/runtime/bionic/arm32v7": {
+      "3.0/runtime/bionic/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm32v7",
           "3.0.0-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/runtime/bionic/arm64v8": {
+      "3.0/runtime/bionic/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-bionic-arm64v8",
           "3.0.0-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/runtime/buster-slim/amd64": {
+      "3.0/runtime/buster-slim/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim",
           "3.0.0-rc1-buster-slim"
         ]
       },
-      "3.0/runtime/buster-slim/arm32v7": {
+      "3.0/runtime/buster-slim/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm32v7",
           "3.0.0-rc1-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime/buster-slim/arm64v8": {
+      "3.0/runtime/buster-slim/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-buster-slim-arm64v8",
           "3.0.0-rc1-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime/disco/amd64": {
+      "3.0/runtime/disco/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-disco",
           "3.0.0-rc1-disco"
         ]
       },
-      "3.0/runtime/disco/arm32v7": {
+      "3.0/runtime/disco/arm32v7/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm32v7",
           "3.0.0-rc1-disco-arm32v7"
         ]
       },
-      "3.0/runtime/disco/arm64v8": {
+      "3.0/runtime/disco/arm64v8/Dockerfile": {
         "simpleTags": [
           "3.0-disco-arm64v8",
           "3.0.0-rc1-disco-arm64v8"
         ]
       },
-      "3.0/runtime/nanoserver-1803/amd64": {
+      "3.0/runtime/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -2047,7 +2047,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/runtime/nanoserver-1809/amd64": {
+      "3.0/runtime/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -2057,7 +2057,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/runtime/nanoserver-1809/arm32v7": {
+      "3.0/runtime/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -2066,7 +2066,7 @@
           "3.0.0-rc1-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/runtime/nanoserver-1903/amd64": {
+      "3.0/runtime/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -2081,19 +2081,19 @@
   {
     "repo": "dotnet/core/runtime-deps",
     "images": {
-      "1.0/runtime-deps/jessie/amd64": {
+      "1.0/runtime-deps/jessie/amd64/Dockerfile": {
         "baseImages": {
           "debian:jessie": "debian@sha256:6b95a104400bb99ad60b47a48e37d5d1eb71a3f9ec8e86854e0cf64ecc5fd0e8"
         },
         "simpleTags": []
       },
-      "1.1/runtime-deps/stretch/amd64": {
+      "1.1/runtime-deps/stretch/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch": "debian@sha256:2b20d1b80dbcdef98ff4e747109c39d2b91539f7f12d7873fdd452306eddb04d"
         },
         "simpleTags": []
       },
-      "2.1/runtime-deps/alpine3.7/amd64": {
+      "2.1/runtime-deps/alpine3.7/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.7": "alpine@sha256:8421d9a84432575381bfabd248f1eb56f3aa21d9d7cd2511583c68c9b7511d10"
         },
@@ -2102,7 +2102,7 @@
           "2.1.13-alpine3.7"
         ]
       },
-      "2.1/runtime-deps/alpine3.9/amd64": {
+      "2.1/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -2117,7 +2117,7 @@
           "2.2.7-alpine3.9"
         ]
       },
-      "2.1/runtime-deps/bionic/amd64": {
+      "2.1/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -2128,7 +2128,7 @@
           "2.2.7-bionic"
         ]
       },
-      "2.1/runtime-deps/bionic/arm32v7": {
+      "2.1/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -2139,7 +2139,7 @@
           "2.2.7-bionic-arm32v7"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/amd64": {
+      "2.1/runtime-deps/stretch-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:stretch-slim": "debian@sha256:8ef99f5a3e800df50ea02334d233360d26c414208815686fbcbf34648ec596d4"
         },
@@ -2150,7 +2150,7 @@
           "2.2.7-stretch-slim"
         ]
       },
-      "2.1/runtime-deps/stretch-slim/arm32v7": {
+      "2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:stretch-slim": "arm32v7/debian@sha256:186f8d340ce3c2b3dc5a3ef376b574d284a86a335844e743c9d0b1ab0c574b8c"
         },
@@ -2161,7 +2161,7 @@
           "2.2.7-stretch-slim-arm32v7"
         ]
       },
-      "2.2/runtime-deps/alpine3.8/amd64": {
+      "2.2/runtime-deps/alpine3.8/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.8": "alpine@sha256:04696b491e0cc3c58a75bace8941c14c924b9f313b03ce5029ebbc040ed9dcd9"
         },
@@ -2170,7 +2170,7 @@
           "2.2.7-alpine3.8"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/amd64": {
+      "3.0/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
           "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
         },
@@ -2181,7 +2181,7 @@
           "3.0.0-rc1-alpine3.9"
         ]
       },
-      "3.0/runtime-deps/alpine3.9/arm64v8": {
+      "3.0/runtime-deps/alpine3.9/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
         },
@@ -2192,7 +2192,7 @@
           "3.0.0-rc1-alpine3.9-arm64v8"
         ]
       },
-      "3.0/runtime-deps/bionic/amd64": {
+      "3.0/runtime-deps/bionic/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:bionic": "ubuntu@sha256:d1d454df0f579c6be4d8161d227462d69e163a8ff9d20a847533989cf0c94d90"
         },
@@ -2201,7 +2201,7 @@
           "3.0.0-rc1-bionic"
         ]
       },
-      "3.0/runtime-deps/bionic/arm32v7": {
+      "3.0/runtime-deps/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:bionic": "arm32v7/ubuntu@sha256:e9c44dbc9e1b732118bddc9b13f23295750889571ab8d66dd0b07fde59dc187e"
         },
@@ -2210,7 +2210,7 @@
           "3.0.0-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/runtime-deps/bionic/arm64v8": {
+      "3.0/runtime-deps/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:bionic": "arm64v8/ubuntu@sha256:1a06d68cb9117b52965035a5b0fa4c1470ef892e6062ffedb1af1922952e0950"
         },
@@ -2219,7 +2219,7 @@
           "3.0.0-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/runtime-deps/buster-slim/amd64": {
+      "3.0/runtime-deps/buster-slim/amd64/Dockerfile": {
         "baseImages": {
           "debian:buster-slim": "debian@sha256:80cc84d66e12d590d2f82ed7e57f906a89f8d10c5b9d7be23ed04e5c6dbb865b"
         },
@@ -2228,7 +2228,7 @@
           "3.0.0-rc1-buster-slim"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm32v7": {
+      "3.0/runtime-deps/buster-slim/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/debian:buster-slim": "arm32v7/debian@sha256:5b5994d4ed9ca8f31f3c0f5ad90733cde33e8ddc6c4de6c4447dd0b4f0b7ce53"
         },
@@ -2237,7 +2237,7 @@
           "3.0.0-rc1-buster-slim-arm32v7"
         ]
       },
-      "3.0/runtime-deps/buster-slim/arm64v8": {
+      "3.0/runtime-deps/buster-slim/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/debian:buster-slim": "arm64v8/debian@sha256:dde35769e3fccb0bf9f714f78e61b7d89ca722e85109f02866a55d3210439f18"
         },
@@ -2246,7 +2246,7 @@
           "3.0.0-rc1-buster-slim-arm64v8"
         ]
       },
-      "3.0/runtime-deps/disco/amd64": {
+      "3.0/runtime-deps/disco/amd64/Dockerfile": {
         "baseImages": {
           "ubuntu:disco": "ubuntu@sha256:23f56d855075d7a8ca49b79d61edaab2f28645f4834767abf1b7d3884b969e92"
         },
@@ -2255,7 +2255,7 @@
           "3.0.0-rc1-disco"
         ]
       },
-      "3.0/runtime-deps/disco/arm32v7": {
+      "3.0/runtime-deps/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/ubuntu:disco": "arm32v7/ubuntu@sha256:48bcb63022b888120570bdf8b1db3a6f244f60e811eab47317ce3c2d6c5a6c9f"
         },
@@ -2264,7 +2264,7 @@
           "3.0.0-rc1-disco-arm32v7"
         ]
       },
-      "3.0/runtime-deps/disco/arm64v8": {
+      "3.0/runtime-deps/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/ubuntu:disco": "arm64v8/ubuntu@sha256:2e3740619e32e69031b01cd915bac3aebe6de10654737bec52f617ed56df7760"
         },
@@ -2278,7 +2278,7 @@
   {
     "repo": "dotnet/core/samples",
     "images": {
-      "samples/aspnetapp": {
+      "samples/aspnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/core/aspnet:2.2": "mcr.microsoft.com/dotnet/core/aspnet@sha256:7ec5aaee0d88954394eee20762270bfbf56c938172e81bd415274d633a2c515f",
           "mcr.microsoft.com/dotnet/core/aspnet:2.2-stretch-slim-arm32v7": "mcr.microsoft.com/dotnet/core/aspnet@sha256:4624723ce4e7e4386bec1f5ae749df458c9d25e5dc1d8f44f64b51c6cc8ba768",
@@ -2294,7 +2294,7 @@
           "aspnetapp-stretch-arm32v7"
         ]
       },
-      "samples/dotnetapp": {
+      "samples/dotnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/core/runtime:2.2": "mcr.microsoft.com/dotnet/core/runtime@sha256:318e18f1616bb2e85f489bf6caca8d9934a5610178df2f0fff8e9bf4ba34091f",
           "mcr.microsoft.com/dotnet/core/runtime:2.2-stretch-slim-arm32v7": "mcr.microsoft.com/dotnet/core/runtime@sha256:377e9cbc240396cba3e5e24d0b3bbf3c3be39e621c1154337ce78b7171963456",
@@ -2315,32 +2315,32 @@
   {
     "repo": "dotnet/core/sdk",
     "images": {
-      "1.1/sdk/jessie/amd64": {
+      "1.1/sdk/jessie/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:jessie-scm": "buildpack-deps@sha256:44d0d909383bb6976c231000af4bcf7988a84afff293270b3df8fdc8af0d3483"
         },
         "simpleTags": []
       },
-      "1.1/sdk/nanoserver-1809/amd64": {
+      "1.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:535887492a56d570a018063d259a99e576cf6092204f87c0d2937fb160e5b090",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:370afa846b124b4674257e193352b38c65790ef75bce27418da0738fa208e66a"
         },
         "simpleTags": []
       },
-      "1.1/sdk/stretch/amd64": {
+      "1.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:0c69a4523a91a858e7e49d8818c97a467edda24553eafae8d409e3b04953226a"
         },
         "simpleTags": []
       },
-      "2.1/sdk/alpine3.7/amd64": {
+      "2.1/sdk/alpine3.7/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine3.7",
           "2.1.802-alpine3.7"
         ]
       },
-      "2.1/sdk/alpine3.9/amd64": {
+      "2.1/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.1-alpine",
           "2.1-alpine3.9",
@@ -2348,7 +2348,7 @@
           "2.1.802-alpine3.9"
         ]
       },
-      "2.1/sdk/bionic/amd64": {
+      "2.1/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -2357,7 +2357,7 @@
           "2.1.802-bionic"
         ]
       },
-      "2.1/sdk/bionic/arm32v7": {
+      "2.1/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -2366,7 +2366,7 @@
           "2.1.802-bionic-arm32v7"
         ]
       },
-      "2.1/sdk/nanoserver-1803/amd64": {
+      "2.1/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -2376,7 +2376,7 @@
           "2.1-nanoserver-1803"
         ]
       },
-      "2.1/sdk/nanoserver-1809/amd64": {
+      "2.1/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -2386,7 +2386,7 @@
           "2.1-nanoserver-1809"
         ]
       },
-      "2.1/sdk/nanoserver-1903/amd64": {
+      "2.1/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -2396,7 +2396,7 @@
           "2.1-nanoserver-1903"
         ]
       },
-      "2.1/sdk/stretch/amd64": {
+      "2.1/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -2405,7 +2405,7 @@
           "2.1.802-stretch"
         ]
       },
-      "2.1/sdk/stretch/arm32v7": {
+      "2.1/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:6e1365eba3ed31ceec34fed67cd15bdf31ffc6b46729a6ab966718a864b7ba18"
         },
@@ -2414,13 +2414,13 @@
           "2.1.802-stretch-arm32v7"
         ]
       },
-      "2.2/sdk/alpine3.8/amd64": {
+      "2.2/sdk/alpine3.8/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine3.8",
           "2.2.402-alpine3.8"
         ]
       },
-      "2.2/sdk/alpine3.9/amd64": {
+      "2.2/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "2.2-alpine",
           "2.2-alpine3.9",
@@ -2428,7 +2428,7 @@
           "2.2.402-alpine3.9"
         ]
       },
-      "2.2/sdk/bionic/amd64": {
+      "2.2/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -2437,7 +2437,7 @@
           "2.2.402-bionic"
         ]
       },
-      "2.2/sdk/bionic/arm32v7": {
+      "2.2/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -2446,7 +2446,7 @@
           "2.2.402-bionic-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1803/amd64": {
+      "2.2/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -2456,7 +2456,7 @@
           "2.2-nanoserver-1803"
         ]
       },
-      "2.2/sdk/nanoserver-1809/amd64": {
+      "2.2/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -2466,7 +2466,7 @@
           "2.2-nanoserver-1809"
         ]
       },
-      "2.2/sdk/nanoserver-1809/arm32v7": {
+      "2.2/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -2476,7 +2476,7 @@
           "2.2.402-nanoserver-1809-arm32v7"
         ]
       },
-      "2.2/sdk/nanoserver-1903/amd64": {
+      "2.2/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -2486,7 +2486,7 @@
           "2.2-nanoserver-1903"
         ]
       },
-      "2.2/sdk/stretch/amd64": {
+      "2.2/sdk/stretch/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:stretch-scm": "buildpack-deps@sha256:e16ed89b62179d26281dffe97cc268696059cc3ac9640a222959c9fa649c7e3a"
         },
@@ -2495,7 +2495,7 @@
           "2.2.402-stretch"
         ]
       },
-      "2.2/sdk/stretch/arm32v7": {
+      "2.2/sdk/stretch/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:stretch-scm": "arm32v7/buildpack-deps@sha256:6e1365eba3ed31ceec34fed67cd15bdf31ffc6b46729a6ab966718a864b7ba18"
         },
@@ -2504,7 +2504,7 @@
           "2.2.402-stretch-arm32v7"
         ]
       },
-      "3.0/sdk/alpine3.9/amd64": {
+      "3.0/sdk/alpine3.9/amd64/Dockerfile": {
         "simpleTags": [
           "3.0-alpine",
           "3.0-alpine3.9",
@@ -2512,7 +2512,7 @@
           "3.0.100-rc1-alpine3.9"
         ]
       },
-      "3.0/sdk/bionic/amd64": {
+      "3.0/sdk/bionic/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:bionic-scm": "buildpack-deps@sha256:da678dd6bf1ab4cafd55751774b4a5a56c94be2077b617c550db3e4c2066000b"
         },
@@ -2521,7 +2521,7 @@
           "3.0.100-rc1-bionic"
         ]
       },
-      "3.0/sdk/bionic/arm32v7": {
+      "3.0/sdk/bionic/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:bionic-scm": "arm32v7/buildpack-deps@sha256:80f14e29a5a0bd27b440b30ac79ea71ae752320c252546837d6de9fcd6887d52"
         },
@@ -2530,7 +2530,7 @@
           "3.0.100-rc1-bionic-arm32v7"
         ]
       },
-      "3.0/sdk/bionic/arm64v8": {
+      "3.0/sdk/bionic/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:bionic-scm": "arm64v8/buildpack-deps@sha256:382662800e0f4cd0b1258311e7f74a782c71ff23a54273300b8a396e6dfebb89"
         },
@@ -2539,7 +2539,7 @@
           "3.0.100-rc1-bionic-arm64v8"
         ]
       },
-      "3.0/sdk/buster/amd64": {
+      "3.0/sdk/buster/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:buster-scm": "buildpack-deps@sha256:ef75fcad284d5db55eb4da1b41606763e01587c6dccb9e2f2c1cb404c256e062"
         },
@@ -2548,7 +2548,7 @@
           "3.0.100-rc1-buster"
         ]
       },
-      "3.0/sdk/buster/arm32v7": {
+      "3.0/sdk/buster/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:buster-scm": "arm32v7/buildpack-deps@sha256:6ac435c55946bfba506488f61499de6032d53d6c40792103944c58f1e9badb0e"
         },
@@ -2557,7 +2557,7 @@
           "3.0.100-rc1-buster-arm32v7"
         ]
       },
-      "3.0/sdk/buster/arm64v8": {
+      "3.0/sdk/buster/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:buster-scm": "arm64v8/buildpack-deps@sha256:6e245b3ce8e863e21535c54322721844f776ea7c5a75093aed2c76a95b2033cd"
         },
@@ -2566,7 +2566,7 @@
           "3.0.100-rc1-buster-arm64v8"
         ]
       },
-      "3.0/sdk/disco/amd64": {
+      "3.0/sdk/disco/amd64/Dockerfile": {
         "baseImages": {
           "buildpack-deps:disco-scm": "buildpack-deps@sha256:f85866a166daf23b5868abe07045bd057ed068b06071719f44770fe0f4daa8a9"
         },
@@ -2575,7 +2575,7 @@
           "3.0.100-rc1-disco"
         ]
       },
-      "3.0/sdk/disco/arm32v7": {
+      "3.0/sdk/disco/arm32v7/Dockerfile": {
         "baseImages": {
           "arm32v7/buildpack-deps:disco-scm": "arm32v7/buildpack-deps@sha256:e057392d3f3565790388371f8681105d2c25610bbb6a8e8b79ce8c092c11d427"
         },
@@ -2584,7 +2584,7 @@
           "3.0.100-rc1-disco-arm32v7"
         ]
       },
-      "3.0/sdk/disco/arm64v8": {
+      "3.0/sdk/disco/arm64v8/Dockerfile": {
         "baseImages": {
           "arm64v8/buildpack-deps:disco-scm": "arm64v8/buildpack-deps@sha256:37ed2ce17e31d7211f3f73aa551582b760d306277aa292ac5ace09833261d90e"
         },
@@ -2593,7 +2593,7 @@
           "3.0.100-rc1-disco-arm64v8"
         ]
       },
-      "3.0/sdk/nanoserver-1803/amd64": {
+      "3.0/sdk/nanoserver-1803/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1803": "mcr.microsoft.com/windows/nanoserver@sha256:47aa6f7f8ff1a02acc34b9f22689e9c89b3387efdd7c0f2cf6da9db810c0d4de",
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
@@ -2603,7 +2603,7 @@
           "3.0-nanoserver-1803"
         ]
       },
-      "3.0/sdk/nanoserver-1809/amd64": {
+      "3.0/sdk/nanoserver-1809/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809": "mcr.microsoft.com/windows/nanoserver@sha256:408c7ec68f510485ccca904d9ab69c3ad165126b44786d9f2fffbbc4d2d9646b",
           "mcr.microsoft.com/windows/servercore:1809": "mcr.microsoft.com/windows/servercore@sha256:dcf51699ac0d02fad88b79d9e21ef0bc78099ab0c48fe63a05b48122dba83543"
@@ -2613,7 +2613,7 @@
           "3.0-nanoserver-1809"
         ]
       },
-      "3.0/sdk/nanoserver-1809/arm32v7": {
+      "3.0/sdk/nanoserver-1809/arm32v7/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1809-arm32v7": "mcr.microsoft.com/windows/nanoserver@sha256:6d36bed2a7fc28ede2b5b93e3b421506e692bef4d3b158aa6bcc51fb1f1401de"
         },
@@ -2622,7 +2622,7 @@
           "3.0.100-rc1-nanoserver-1809-arm32v7"
         ]
       },
-      "3.0/sdk/nanoserver-1903/amd64": {
+      "3.0/sdk/nanoserver-1903/amd64/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/nanoserver:1903": "mcr.microsoft.com/windows/nanoserver@sha256:de4e46be4ebc593c815ae6ad17a33eb89481c85276b46d96c000f31aedc8cb67",
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
@@ -2637,85 +2637,85 @@
   {
     "repo": "dotnet/framework/aspnet",
     "images": {
-      "3.5/aspnet/windowsservercore-1803": {
+      "3.5/aspnet/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1803",
           "3.5-windowsservercore-1803"
         ]
       },
-      "3.5/aspnet/windowsservercore-1903": {
+      "3.5/aspnet/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1903",
           "3.5-windowsservercore-1903"
         ]
       },
-      "3.5/aspnet/windowsservercore-ltsc2016": {
+      "3.5/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2016",
           "3.5-windowsservercore-ltsc2016"
         ]
       },
-      "3.5/aspnet/windowsservercore-ltsc2019": {
+      "3.5/aspnet/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2019",
           "3.5-windowsservercore-ltsc2019"
         ]
       },
-      "4.6.2/aspnet/windowsservercore-ltsc2016": {
+      "4.6.2/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.6.2-20190910-windowsservercore-ltsc2016",
           "4.6.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.1/aspnet/windowsservercore-ltsc2016": {
+      "4.7.1/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.1-20190910-windowsservercore-ltsc2016",
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/aspnet/windowsservercore-1803": {
+      "4.7.2/aspnet/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-1803",
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/aspnet/windowsservercore-ltsc2016": {
+      "4.7.2/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2016",
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/aspnet/windowsservercore-ltsc2019": {
+      "4.7.2/aspnet/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2019",
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.7/aspnet/windowsservercore-ltsc2016": {
+      "4.7/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7-20190910-windowsservercore-ltsc2016",
           "4.7-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/aspnet/windowsservercore-1803": {
+      "4.8/aspnet/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1803",
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/aspnet/windowsservercore-1903": {
+      "4.8/aspnet/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1903",
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/aspnet/windowsservercore-ltsc2016": {
+      "4.8/aspnet/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2016",
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/aspnet/windowsservercore-ltsc2019": {
+      "4.8/aspnet/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2019",
           "4.8-windowsservercore-ltsc2019"
@@ -2726,7 +2726,7 @@
   {
     "repo": "dotnet/framework/runtime",
     "images": {
-      "3.5/runtime/windowsservercore-1803": {
+      "3.5/runtime/windowsservercore-1803/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -2735,7 +2735,7 @@
           "3.5-windowsservercore-1803"
         ]
       },
-      "3.5/runtime/windowsservercore-1903": {
+      "3.5/runtime/windowsservercore-1903/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -2744,7 +2744,7 @@
           "3.5-windowsservercore-1903"
         ]
       },
-      "3.5/runtime/windowsservercore-ltsc2016": {
+      "3.5/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -2753,7 +2753,7 @@
           "3.5-windowsservercore-ltsc2016"
         ]
       },
-      "3.5/runtime/windowsservercore-ltsc2019": {
+      "3.5/runtime/windowsservercore-ltsc2019/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2019": "mcr.microsoft.com/windows/servercore@sha256:d7e7e3702cbc4d8ea29001a02c1c852d0229a0679d94e017a41c43dbaa01db20"
         },
@@ -2762,7 +2762,7 @@
           "3.5-windowsservercore-ltsc2019"
         ]
       },
-      "4.6.2/runtime/windowsservercore-ltsc2016": {
+      "4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -2771,7 +2771,7 @@
           "4.6.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.1/runtime/windowsservercore-ltsc2016": {
+      "4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -2780,7 +2780,7 @@
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/runtime/windowsservercore-1803": {
+      "4.7.2/runtime/windowsservercore-1803/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -2789,7 +2789,7 @@
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/runtime/windowsservercore-ltsc2016": {
+      "4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -2798,7 +2798,7 @@
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/runtime/windowsservercore-ltsc2019": {
+      "4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2019": "mcr.microsoft.com/windows/servercore@sha256:d7e7e3702cbc4d8ea29001a02c1c852d0229a0679d94e017a41c43dbaa01db20"
         },
@@ -2807,7 +2807,7 @@
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.7/runtime/windowsservercore-ltsc2016": {
+      "4.7/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -2816,7 +2816,7 @@
           "4.7-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/runtime/windowsservercore-1803": {
+      "4.8/runtime/windowsservercore-1803/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1803": "mcr.microsoft.com/windows/servercore@sha256:9b22618ec9b832f7e74c5461b67761423fea83dd10bf627fe715e232aad0dc1e"
         },
@@ -2825,7 +2825,7 @@
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/runtime/windowsservercore-1903": {
+      "4.8/runtime/windowsservercore-1903/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:1903": "mcr.microsoft.com/windows/servercore@sha256:f1763ae98b70b9fafca385af507729c73327bdd05b21533ddb82ca57bb7092ba"
         },
@@ -2834,7 +2834,7 @@
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/runtime/windowsservercore-ltsc2016": {
+      "4.8/runtime/windowsservercore-ltsc2016/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2016": "mcr.microsoft.com/windows/servercore@sha256:c1c0c43f28b3d994e5f215946786c34634dcc813aa7afe2f28a968c02ca1de68"
         },
@@ -2843,7 +2843,7 @@
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/runtime/windowsservercore-ltsc2019": {
+      "4.8/runtime/windowsservercore-ltsc2019/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/windows/servercore:ltsc2019": "mcr.microsoft.com/windows/servercore@sha256:d7e7e3702cbc4d8ea29001a02c1c852d0229a0679d94e017a41c43dbaa01db20"
         },
@@ -2857,7 +2857,7 @@
   {
     "repo": "dotnet/framework/samples",
     "images": {
-      "samples/aspnetapp": {
+      "samples/aspnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/framework/aspnet:4.8": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:0fd2131bcd54775080b9058d0b38c9dee57f57e4f6ac8ac77ba21786c0b373d7",
           "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220"
@@ -2866,7 +2866,7 @@
           "aspnetapp-windowsservercore-ltsc2019"
         ]
       },
-      "samples/dotnetapp": {
+      "samples/dotnetapp/Dockerfile": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/framework/runtime:4.8": "mcr.microsoft.com/dotnet/framework/runtime@sha256:337903387835a83eb65e19f60719f76eae3a71ec8276d2983c20766e6b745a77",
           "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220"
@@ -2875,9 +2875,17 @@
           "dotnetapp-windowsservercore-ltsc2019"
         ]
       },
-      "samples\\wcfapp": {
+      "samples/wcfapp/Dockerfile.client": {
         "baseImages": {
           "mcr.microsoft.com/dotnet/framework/runtime:4.8": "mcr.microsoft.com/dotnet/framework/runtime@sha256:337903387835a83eb65e19f60719f76eae3a71ec8276d2983c20766e6b745a77",
+          "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220"
+        },
+        "simpleTags": [
+          "wcfclient-windowsservercore-ltsc2019"
+        ]
+      },
+      "samples/wcfapp/Dockerfile.web": {
+        "baseImages": {
           "mcr.microsoft.com/dotnet/framework/sdk:4.8": "mcr.microsoft.com/dotnet/framework/sdk@sha256:219761abac416eb00cfe4fa8a4aa7b300606f389bf325f7825d168622a627220",
           "mcr.microsoft.com/dotnet/framework/wcf:4.8": "mcr.microsoft.com/dotnet/framework/wcf@sha256:61cbbdb6c20a5a988032bafc8244ac28c26cd10599a512a98a17602f1ffb8417"
         },
@@ -2890,73 +2898,73 @@
   {
     "repo": "dotnet/framework/sdk",
     "images": {
-      "3.5/sdk/windowsservercore-1803": {
+      "3.5/sdk/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1803",
           "3.5-windowsservercore-1803"
         ]
       },
-      "3.5/sdk/windowsservercore-1903": {
+      "3.5/sdk/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-1903",
           "3.5-windowsservercore-1903"
         ]
       },
-      "3.5/sdk/windowsservercore-ltsc2016": {
+      "3.5/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2016",
           "3.5-windowsservercore-ltsc2016"
         ]
       },
-      "3.5/sdk/windowsservercore-ltsc2019": {
+      "3.5/sdk/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "3.5-20190910-windowsservercore-ltsc2019",
           "3.5-windowsservercore-ltsc2019"
         ]
       },
-      "4.7.1/sdk/windowsservercore-ltsc2016": {
+      "4.7.1/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.1-20190910-windowsservercore-ltsc2016",
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/sdk/windowsservercore-1803": {
+      "4.7.2/sdk/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-1803",
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/sdk/windowsservercore-ltsc2016": {
+      "4.7.2/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2016",
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/sdk/windowsservercore-ltsc2019": {
+      "4.7.2/sdk/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2019",
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.8/sdk/windowsservercore-1803": {
+      "4.8/sdk/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1803",
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/sdk/windowsservercore-1903": {
+      "4.8/sdk/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1903",
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/sdk/windowsservercore-ltsc2016": {
+      "4.8/sdk/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2016",
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/sdk/windowsservercore-ltsc2019": {
+      "4.8/sdk/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2019",
           "4.8-windowsservercore-ltsc2019"
@@ -2967,61 +2975,61 @@
   {
     "repo": "dotnet/framework/wcf",
     "images": {
-      "4.6.2/wcf/windowsservercore-ltsc2016": {
+      "4.6.2/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.6.2-20190910-windowsservercore-ltsc2016",
           "4.6.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.1/wcf/windowsservercore-ltsc2016": {
+      "4.7.1/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.1-20190910-windowsservercore-ltsc2016",
           "4.7.1-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/wcf/windowsservercore-1803": {
+      "4.7.2/wcf/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-1803",
           "4.7.2-windowsservercore-1803"
         ]
       },
-      "4.7.2/wcf/windowsservercore-ltsc2016": {
+      "4.7.2/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2016",
           "4.7.2-windowsservercore-ltsc2016"
         ]
       },
-      "4.7.2/wcf/windowsservercore-ltsc2019": {
+      "4.7.2/wcf/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.7.2-20190910-windowsservercore-ltsc2019",
           "4.7.2-windowsservercore-ltsc2019"
         ]
       },
-      "4.7/wcf/windowsservercore-ltsc2016": {
+      "4.7/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.7-20190910-windowsservercore-ltsc2016",
           "4.7-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/wcf/windowsservercore-1803": {
+      "4.8/wcf/windowsservercore-1803/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1803",
           "4.8-windowsservercore-1803"
         ]
       },
-      "4.8/wcf/windowsservercore-1903": {
+      "4.8/wcf/windowsservercore-1903/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-1903",
           "4.8-windowsservercore-1903"
         ]
       },
-      "4.8/wcf/windowsservercore-ltsc2016": {
+      "4.8/wcf/windowsservercore-ltsc2016/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2016",
           "4.8-windowsservercore-ltsc2016"
         ]
       },
-      "4.8/wcf/windowsservercore-ltsc2019": {
+      "4.8/wcf/windowsservercore-ltsc2019/Dockerfile": {
         "simpleTags": [
           "4.8-20190910-windowsservercore-ltsc2019",
           "4.8-windowsservercore-ltsc2019"


### PR DESCRIPTION
The new format for image info files that is rolling out will explicitly have the Dockerfile name included for the image's key value.  This updates the existing image info files so they are compatible.

See https://github.com/dotnet/docker-tools/pull/302