### PR TITLE
Disable auto-merges into release/3.1 branches while coherent builds are running

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1171,76 +1171,6 @@
         }
       }
     },
-    // Automate opening PRs to merge aspnet release/3.1-preview1 branches back to release/3.1
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/AspNetCore/blob/release/3.1-preview1/**/*",
-        "https://github.com/aspnet/AspNetCore-Tooling/blob/release/3.1-preview1/**/*",
-        "https://github.com/aspnet/Blazor/blob/release/3.1-preview1/**/*",
-        "https://github.com/aspnet/EntityFrameworkCore/blob/release/3.1-preview1/**/*",
-        "https://github.com/aspnet/Extensions/blob/release/3.1-preview1/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.1"
-        }
-      }
-    },
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/EntityFramework6/blob/release/6.4-preview1/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/6.4"
-        }
-      }
-    },
-    // Automate opening PRs to merge aspnet release/3.0 branches back to release/3.1
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/AspNetCore/blob/release/3.0//**/*",
-        "https://github.com/aspnet/AspNetCore-Tooling/blob/release/3.0//**/*",
-        "https://github.com/aspnet/Blazor/blob/release/3.0//**/*",
-        "https://github.com/aspnet/EntityFrameworkCore/blob/release/3.0//**/*",
-        "https://github.com/aspnet/Extensions/blob/release/3.0//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.1"
-        }
-      }
-    },
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/EntityFramework6/blob/release/6.3//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/6.4"
-        }
-      }
-    },
     // Automate opening PRs to merge aspnet release/3.1 branches back to master
     {
       "triggerPaths": [
@@ -1799,28 +1729,6 @@
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
           "BaseBranch": "release/2.2"
-        }
-      }
-    },
-    // Automate opening PRs to merge dotnet org repos' release/3.0 changes into release/3.1 branches
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/buildtools/blob/release/3.0/**/*",
-        "https://github.com/dotnet/coreclr/blob/release/3.0/**/*",
-        "https://github.com/dotnet/corefx/blob/release/3.0/**/*",
-        "https://github.com/dotnet/core-setup/blob/release/3.0/**/*",
-        "https://github.com/dotnet/source-build/blob/release/3.0/**/*",
-        "https://github.com/dotnet/templating/blob/release/3.0/**/*",
-        "https://github.com/dotnet/wpf/blob/release/3.0/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.1"
         }
       }
     },

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1171,6 +1171,76 @@
         }
       }
     },
+    // Automate opening PRs to merge aspnet release/3.1-preview1 branches back to release/3.1
+    {
+      "triggerPaths": [
+        "https://github.com/aspnet/AspNetCore/blob/release/3.1-preview1/**/*",
+        "https://github.com/aspnet/AspNetCore-Tooling/blob/release/3.1-preview1/**/*",
+        "https://github.com/aspnet/Blazor/blob/release/3.1-preview1/**/*",
+        "https://github.com/aspnet/EntityFrameworkCore/blob/release/3.1-preview1/**/*",
+        "https://github.com/aspnet/Extensions/blob/release/3.1-preview1/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "aspnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/3.1"
+        }
+      }
+    },
+    {
+      "triggerPaths": [
+        "https://github.com/aspnet/EntityFramework6/blob/release/6.4-preview1/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "aspnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/6.4"
+        }
+      }
+    },
+    // Automate opening PRs to merge aspnet release/3.0 branches back to release/3.1
+    {
+      "triggerPaths": [
+        "https://github.com/aspnet/AspNetCore/blob/release/3.0//**/*",
+        "https://github.com/aspnet/AspNetCore-Tooling/blob/release/3.0//**/*",
+        "https://github.com/aspnet/Blazor/blob/release/3.0//**/*",
+        "https://github.com/aspnet/EntityFrameworkCore/blob/release/3.0//**/*",
+        "https://github.com/aspnet/Extensions/blob/release/3.0//**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "aspnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/3.1"
+        }
+      }
+    },
+    {
+      "triggerPaths": [
+        "https://github.com/aspnet/EntityFramework6/blob/release/6.3//**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "aspnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/6.4"
+        }
+      }
+    },
     // Automate opening PRs to merge aspnet release/3.1 branches back to master
     {
       "triggerPaths": [


### PR DESCRIPTION
CC @mmitche @dougbu @Anipik 

Will revert this once the 3.1-preview1 builds are done. Incidentally, does anyone know how the merge PRs into core-SDK & friends are created? e.g. https://github.com/dotnet/toolset/pull/2875. These go through dotnet-bot, rather than dotnet-maestro-bot.