### PR TITLE
[NO MERGE] Revert "Disable auto-merges into release/3.1 branches while coherent builds are running"

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1802,6 +1802,28 @@
         }
       }
     },
+    // Automate opening PRs to merge dotnet org repos' release/3.0 changes into release/3.1 branches
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/buildtools/blob/release/3.0/**/*",
+        "https://github.com/dotnet/coreclr/blob/release/3.0/**/*",
+        "https://github.com/dotnet/corefx/blob/release/3.0/**/*",
+        "https://github.com/dotnet/core-setup/blob/release/3.0/**/*",
+        "https://github.com/dotnet/source-build/blob/release/3.0/**/*",
+        "https://github.com/dotnet/templating/blob/release/3.0/**/*",
+        "https://github.com/dotnet/wpf/blob/release/3.0/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/3.1"
+        }
+      }
+    },
     // Automate opening PRs to merge dotnet org repos' release/3.1 changes into master branches
     {
       "triggerPaths": [


### PR DESCRIPTION
Reverts dotnet/versions#513

Re-enables merge PRs for the dotnet repos into release/3.1. I'll merge this once builds for 3.1-preview1 are done.

CC @Anipik 