### PR TITLE
Revert "Disable auto-merges during 3.1-preview2 lockdown"

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1840,6 +1840,28 @@
         }
       }
     },
+    // Automate opening PRs to merge dotnet org repos' release/3.0 changes into release/3.1 branches
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/buildtools/blob/release/3.0/**/*",
+        "https://github.com/dotnet/coreclr/blob/release/3.0/**/*",
+        "https://github.com/dotnet/corefx/blob/release/3.0/**/*",
+        "https://github.com/dotnet/core-setup/blob/release/3.0/**/*",
+        "https://github.com/dotnet/source-build/blob/release/3.0/**/*",
+        "https://github.com/dotnet/templating/blob/release/3.0/**/*",
+        "https://github.com/dotnet/wpf/blob/release/3.0/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/3.1"
+        }
+      }
+    },
     // Automate opening PRs to merge dotnet org repos' release/3.1 changes into master branches
     {
       "triggerPaths": [


### PR DESCRIPTION
Reverts dotnet/versions#519

Re-enable auto-merges from 3.0 -> 3.1