### PR TITLE
Disable 3.0 -> 3.1 auto-merges during Preview3 build window

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1193,26 +1193,6 @@
         }
       }
     },
-    // Automate opening PRs to merge cli 3.0.1xx to 3.1.1xx
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/cli/blob/release/3.0.1xx/**/*",
-        "https://github.com/dotnet/toolset/blob/release/3.0.1xx/**/*",
-        "https://github.com/dotnet/sdk/blob/release/3.0.1xx/**/*",
-        "https://github.com/dotnet/core-sdk/blob/release/3.0.1xx/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.1.1xx",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
     // Automate opening PRs to merge cli 3.1.1xx to master
     {
       "triggerPaths": [
@@ -1769,28 +1749,6 @@
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
           "BaseBranch": "release/2.2"
-        }
-      }
-    },
-    // Automate opening PRs to merge dotnet org repos' release/3.0 changes into release/3.1 branches
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/buildtools/blob/release/3.0/**/*",
-        "https://github.com/dotnet/coreclr/blob/release/3.0/**/*",
-        "https://github.com/dotnet/corefx/blob/release/3.0/**/*",
-        "https://github.com/dotnet/core-setup/blob/release/3.0/**/*",
-        "https://github.com/dotnet/source-build/blob/release/3.0/**/*",
-        "https://github.com/dotnet/templating/blob/release/3.0/**/*",
-        "https://github.com/dotnet/wpf/blob/release/3.0/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.1"
         }
       }
     },

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1172,41 +1172,6 @@
         }
       }
     },
-    // Automate opening PRs to merge aspnet release/3.0 branches back to release/3.1
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/AspNetCore/blob/release/3.0//**/*",
-        "https://github.com/aspnet/AspNetCore-Tooling/blob/release/3.0//**/*",
-        "https://github.com/aspnet/Blazor/blob/release/3.0//**/*",
-        "https://github.com/aspnet/EntityFrameworkCore/blob/release/3.0//**/*",
-        "https://github.com/aspnet/Extensions/blob/release/3.0//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.1"
-        }
-      }
-    },
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/EntityFramework6/blob/release/6.3//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/6.4"
-        }
-      }
-    },
     // Automate opening PRs to merge aspnet release/3.1 branches back to master
     {
       "triggerPaths": [


### PR DESCRIPTION
CC @Anipik @livarcocc @nguerrera @dagood @dougbu 

I'll merge this Sunday, then revert it after we declare a final build for GA