### PR TITLE
Update source-build subscriptions.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1761,8 +1761,7 @@
         "https://github.com/dotnet/buildtools/blob/release/2.1/**/*",
         "https://github.com/dotnet/coreclr/blob/release/2.1/**/*",
         "https://github.com/dotnet/corefx/blob/release/2.1/**/*",
-        "https://github.com/dotnet/core-setup/blob/release/2.1/**/*",
-        "https://github.com/dotnet/source-build/blob/release/2.1/**/*"
+        "https://github.com/dotnet/core-setup/blob/release/2.1/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -1795,22 +1794,6 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/buildtools/blob/release/2.2/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "master"
-        }
-      }
-    },
-    // Automate opening PRs to merge dotnet org repos' release/3.0 changes into master branches
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/source-build/blob/release/3.0/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
- Remove 3.0 -> master merge.  Master will likely diverge quite a bit from 3.0, and replacing it with a 3.1 -> master merge doesn't seem any better.
- Remove 2.1 -> 2.2 merge.  The only updates being made in 2.x are Version.Details.xml changes, which we never want to mirror anyway.