### PR TITLE
add SignalR C++ client to repo sync jobs

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -763,6 +763,8 @@
         "https://github.com/aspnet/EntityFrameworkCore/blob/release/**/*",
         "https://github.com/aspnet/Extensions/blob/master/**/*",
         "https://github.com/aspnet/Extensions/blob/release/**/*",
+        "https://github.com/aspnet/SignalR-Client-Cpp/blob/master/**/*",
+        "https://github.com/aspnet/SignalR-Client-Cpp/blob/release/**/*",
         "https://github.com/dotnet/HttpRepl/blob/master/**/*",
         "https://github.com/dotnet/HttpRepl/blob/release/**/*",
         "https://github.com/aspnet/Scaffolding/blob/master/**/*",
@@ -1809,6 +1811,7 @@
     // Merge mirrored branches (to internal/) in dnceng Azure Devops
     {
       "triggerPaths": [
+        "https://github.com/aspnet/SignalR-Client-Cpp/blob/release/**/*",
         "https://github.com/aspnet/AspLabs/blob/release/**/*",
         "https://github.com/aspnet/AspNetCore/blob/release/2/**/*",
         // "https://github.com/aspnet/AspNetCore/blob/release/3.0/**/*",


### PR DESCRIPTION
Adding repo https://github.com/aspnet/SignalR-Client-Cpp to the repo syncing (to sync the repo to AzDO).

This repo is for the ASP.NET Core SignalR C++ Client, which doesn't actually ship binaries (the repo is the only actual "shipping" vehicle since every consumer builds the repo from source). However, we still want to do the internal mirroring for "official" validation builds (even though they don't produce artifacts) and archival/continuity purposes.

The intention is to set up the triggers to:
* Mirror `master` and `release/*` branches to AzDO repo aspnet-SignalR-Client-Cpp
* Mirror `release/*` branches to `internal/release/*` branches in the same AzDO repo.

I'd appreciate someone who knows Maestro confirming that I did the right JSON to do those things ;P.