### PR TITLE
Disable automatic opening of prs into 2.2 branch

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1882,25 +1882,6 @@
         }
       }
     },
-    // Automate opening PRs to merge dotnet org repos' release/2.1 changes into release/2.2 branches
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/buildtools/blob/release/2.1/**/*",
-        "https://github.com/dotnet/coreclr/blob/release/2.1/**/*",
-        "https://github.com/dotnet/corefx/blob/release/2.1/**/*",
-        "https://github.com/dotnet/core-setup/blob/release/2.1/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/2.2"
-        }
-      }
-    },
     // Automate opening PRs to merge dotnet org repos' release/3.0 changes into release/3.1 branches
     {
       "triggerPaths": [


### PR DESCRIPTION
We are no longer want any functional fixes so switching of the autmatic prs opening.
This should also prevent any accidental merges of functional fixes