### PR TITLE
Update base digest values of .NET Alpine Docker images

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -857,7 +857,7 @@
       },
       "2.1/runtime-deps/alpine3.10/amd64/Dockerfile": {
         "baseImages": {
-          "alpine:3.10": "alpine@sha256:c19173c5ada610a5989151111163d28a67368362762534d8a8121ce95cf2bd5a"
+          "alpine:3.10": "alpine@sha256:7c3773f7bcc969f03f8f653910001d99a9d324b4b9caa008846ad2c3089f5a5f"
         },
         "simpleTags": [
           "2.1-alpine",
@@ -877,7 +877,7 @@
       },
       "2.1/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
-          "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
+          "alpine:3.9": "alpine@sha256:115731bab0862031b44766733890091c17924f9b7781b79997f5f163be262178"
         },
         "simpleTags": [
           "2.1-alpine3.9",
@@ -931,7 +931,7 @@
       },
       "3.0/runtime-deps/alpine3.10/amd64/Dockerfile": {
         "baseImages": {
-          "alpine:3.10": "alpine@sha256:c19173c5ada610a5989151111163d28a67368362762534d8a8121ce95cf2bd5a"
+          "alpine:3.10": "alpine@sha256:7c3773f7bcc969f03f8f653910001d99a9d324b4b9caa008846ad2c3089f5a5f"
         },
         "simpleTags": [
           "3.0-alpine",
@@ -946,7 +946,7 @@
       },
       "3.0/runtime-deps/alpine3.10/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/alpine:3.10": "arm64v8/alpine@sha256:1827be57ca85c28287d18349bbfdb3870419692656cb67c4cd0f5042f0f63aec"
+          "arm64v8/alpine:3.10": "arm64v8/alpine@sha256:4491fd429b8ad188ba5e120782b2bbb704261fd2ef9942fcdee128c5fcc594d5"
         },
         "simpleTags": [
           "3.0-alpine-arm64v8",
@@ -961,7 +961,7 @@
       },
       "3.0/runtime-deps/alpine3.9/amd64/Dockerfile": {
         "baseImages": {
-          "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
+          "alpine:3.9": "alpine@sha256:115731bab0862031b44766733890091c17924f9b7781b79997f5f163be262178"
         },
         "simpleTags": [
           "3.0-alpine3.9",
@@ -970,7 +970,7 @@
       },
       "3.0/runtime-deps/alpine3.9/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
+          "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:cae6522b6a351615e547ae9222c9a05d172bc5c3240eec03072d4e1d0429a17a"
         },
         "simpleTags": [
           "3.0-alpine3.9-arm64v8",


### PR DESCRIPTION
Official .NET Docker build didn't update the image info file for some Alpine runtime-deps images.  Manually updating them to the correct values.