### PR TITLE
Update build tools prereqs image info

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -4,90 +4,87 @@
     "images": {
       "src/alpine/3.10/helix/amd64/Dockerfile": {
         "baseImages": {
-          "python:3.7-alpine3.10": "python@sha256:7a0906606a96929c62f81d17251b6562f37951b89c60fce9505f0091e3d7d7cb",
-          "python:3.7.3-alpine3.10": "python@sha256:93b2b24b95cf74229b41237126e22420580f05f51c76de015986fbd79d8d7e42"
+          "python:3.7-alpine3.10": "python@sha256:16b4608c775575bbb2accd8ef347fb2a2b5a0f15c50fbd3204f18cc287d0772c"
         },
         "simpleTags": [
-          "alpine-3.10-helix-08e8e40-20200107182422"
+          "alpine-3.10-helix-bfcd90a-20200123191054"
         ]
       },
       "src/alpine/3.10/helix/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/alpine:3.10": "arm64v8/alpine@sha256:1827be57ca85c28287d18349bbfdb3870419692656cb67c4cd0f5042f0f63aec"
+          "arm64v8/alpine:3.10": "arm64v8/alpine@sha256:4491fd429b8ad188ba5e120782b2bbb704261fd2ef9942fcdee128c5fcc594d5"
         },
         "simpleTags": [
-          "alpine-3.10-helix-arm64v8-4f8cef7-20200107182325"
+          "alpine-3.10-helix-arm64v8-bfcd90a-20200123191029"
         ]
       },
       "src/alpine/3.11/helix/amd64/Dockerfile": {
         "baseImages": {
-          "python:3.7-alpine3.11": "python@sha256:860856fce0f6f17e48b1a9ca89ec8ac99293af6bbc73e4e46a1ebce86daf122b"
+          "python:3.7-alpine3.11": "python@sha256:7655eea15dfd981eeb7d243af21e8561e967709caba938d50b136cdb992f3546"
         },
         "simpleTags": [
-          "alpine-3.11-helix-08e8e40-20200107182408"
+          "alpine-3.11-helix-bfcd90a-20200123191053"
         ]
       },
       "src/alpine/3.11/helix/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/alpine:3.11": "arm64v8/alpine@sha256:892105a25acfbcb693eba42428b5a7daa63e20a1b1c85bd225ef36f447db9182"
+          "arm64v8/alpine:3.11": "arm64v8/alpine@sha256:4d5c5951669588e23881c158629ae6bac4ab44866d5b4d150c3f15d91f26682b"
         },
         "simpleTags": [
-          "alpine-3.11-helix-arm64v8-4f8cef7-20200107182324"
+          "alpine-3.11-helix-arm64v8-bfcd90a-20200123191027"
         ]
       },
       "src/alpine/3.8/helix/amd64/Dockerfile": {
         "baseImages": {
-          "python:3.7-alpine3.8": "python@sha256:3491d1abd29b3f87ca5cb1afd34bc696855a2403df1ff854da55cb6754af1ff8",
-          "python:3.7.3-alpine3.8": "python@sha256:3491d1abd29b3f87ca5cb1afd34bc696855a2403df1ff854da55cb6754af1ff8"
+          "python:3.7-alpine3.8": "python@sha256:3491d1abd29b3f87ca5cb1afd34bc696855a2403df1ff854da55cb6754af1ff8"
         },
         "simpleTags": [
-          "alpine-3.8-helix-08e8e40-20200107182403"
+          "alpine-3.8-helix-bfcd90a-20200123191050"
         ]
       },
       "src/alpine/3.8/helix/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/alpine:3.8": "arm64v8/alpine@sha256:360e20fc240529450cf378756935230541da805701e3ff895305b72f37ce4d9c"
+          "arm64v8/alpine:3.8": "arm64v8/alpine@sha256:e802987f152d7826cf929ad4999fb3bb956ce7a30966aeb46c749f9120eaf22c"
         },
         "simpleTags": [
-          "alpine-3.8-helix-arm64v8-4f8cef7-20200107182315"
+          "alpine-3.8-helix-arm64v8-bfcd90a-20200123191027"
         ]
       },
       "src/alpine/3.9/amd64/Dockerfile": {
         "baseImages": {
-          "alpine:3.9": "alpine@sha256:7746df395af22f04212cd25a92c1d6dbc5a06a0ca9579a229ef43008d4d1302a"
+          "alpine:3.9": "alpine@sha256:115731bab0862031b44766733890091c17924f9b7781b79997f5f163be262178"
         },
         "simpleTags": [
-          "alpine-3.9-50f0d02-20200107182347"
+          "alpine-3.9-aa8f37c-20200123191053"
         ]
       },
       "src/alpine/3.9/arm32v7/Dockerfile": {
         "baseImages": {
-          "arm32v7/alpine:3.9": "arm32v7/alpine@sha256:f6d15ec5c7cf08079309c59f59ff1e092eb9a678ab891257b1d2b118e7aecc2b"
+          "arm32v7/alpine:3.9": "arm32v7/alpine@sha256:0c6b515386fda00a17e4653f007979825f35e0086e583ddc9b91d3eda941bd1b"
         },
         "simpleTags": [
-          "alpine-3.9-arm32v7-44e2650-20200107182332"
+          "alpine-3.9-arm32v7-bfcd90a-20200123191038"
         ]
       },
       "src/alpine/3.9/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:1032bdba4c5f88facf7eceb259c18deb28a51785eb35e469285a03eba78dd3fc"
+          "arm64v8/alpine:3.9": "arm64v8/alpine@sha256:cae6522b6a351615e547ae9222c9a05d172bc5c3240eec03072d4e1d0429a17a"
         },
         "simpleTags": [
-          "alpine-3.9-arm64v8-44e2650-20200107182315"
+          "alpine-3.9-arm64v8-bfcd90a-20200123191027"
         ]
       },
       "src/alpine/3.9/helix/amd64/Dockerfile": {
         "baseImages": {
-          "python:3.7-alpine3.9": "python@sha256:d3953acf09227baf26919dbb4dc3637e8015ce46debbed4cf5444702728cfc16",
-          "python:3.7.3-alpine3.9": "python@sha256:69f4cedf780ea95e7a0591e5ec3db85207142278501dfab6ef483ccfa5340fe2"
+          "python:3.7-alpine3.9": "python@sha256:d3953acf09227baf26919dbb4dc3637e8015ce46debbed4cf5444702728cfc16"
         },
         "simpleTags": [
-          "alpine-3.9-helix-08e8e40-20200107182422"
+          "alpine-3.9-helix-bfcd90a-20200123191053"
         ]
       },
       "src/alpine/3.9/WithNode/amd64/Dockerfile": {
         "simpleTags": [
-          "alpine-3.9-WithNode-0fc54a3-20200107182347"
+          "alpine-3.9-WithNode-0fc54a3-20200123191053"
         ]
       },
       "src/centos/6/Dockerfile": {
@@ -95,20 +92,20 @@
           "centos:6": "centos@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7"
         },
         "simpleTags": [
-          "centos-6-6aaa05d-20191106231336"
+          "centos-6-bfcd90a-20200121150028"
         ]
       },
       "src/centos/7/Dockerfile": {
         "baseImages": {
-          "centos:7": "centos@sha256:307835c385f656ec2e2fec602cf093224173c51119bbebd602c53c3653a3d6eb"
+          "centos:7": "centos@sha256:4a701376d03f6b39b8c2a8f4a8e499441b0d567f9ab9d58e4991de4472fb813c"
         },
         "simpleTags": [
-          "centos-7-6aaa05d-20191106231356"
+          "centos-7-bfcd90a-20200121150017"
         ]
       },
       "src/centos/7/mlnet/Dockerfile": {
         "simpleTags": [
-          "centos-7-mlnet-50f0d02-20191106231356"
+          "centos-7-mlnet-bfcd90a-20200121150017"
         ]
       },
       "src/debian/10/helix/amd64/Dockerfile": {
@@ -116,7 +113,7 @@
           "debian:buster": "debian@sha256:f19be6b8095d6ea46f5345e2651eec4e5ee9e84fc83f3bc3b73587197853dc9e"
         },
         "simpleTags": [
-          "debian-10-helix-amd64-4f8cef7-20200107182428"
+          "debian-10-helix-amd64-bfcd90a-20200121150006"
         ]
       },
       "src/debian/10/helix/arm32v7/Dockerfile": {
@@ -124,7 +121,7 @@
           "arm32v7/debian:buster": "arm32v7/debian@sha256:021a25168df52aeff4eb2e88f448a51a23e13fbbfecbfc5371b629134f17e2d6"
         },
         "simpleTags": [
-          "debian-10-helix-arm32v7-4f8cef7-20200107182345"
+          "debian-10-helix-arm32v7-bfcd90a-20200121150055"
         ]
       },
       "src/debian/10/helix/arm64v8/Dockerfile": {
@@ -132,7 +129,7 @@
           "arm64v8/debian:buster": "arm64v8/debian@sha256:e03fb2e7503cd46e2acb213197979ba26a5cd1cd6770cc6076811c477def7d45"
         },
         "simpleTags": [
-          "debian-10-helix-arm64v8-4f8cef7-20200107182343"
+          "debian-10-helix-arm64v8-bfcd90a-20200121150031"
         ]
       },
       "src/debian/9/arm32v7/Dockerfile": {
@@ -140,7 +137,7 @@
           "arm32v7/debian:9": "arm32v7/debian@sha256:786246f306ac0d78fec4ad2af27316769d282b50b1b68f6f688af4364392ce1b"
         },
         "simpleTags": [
-          "debian-9-arm32v7-0dbbad8-20200107182346"
+          "debian-9-arm32v7-bfcd90a-20200121150031"
         ]
       },
       "src/debian/9/arm64v8/Dockerfile": {
@@ -148,7 +145,7 @@
           "arm64v8/debian:9": "arm64v8/debian@sha256:b82b9f553b74b4b18d634f0ada6c12bdfcb3f908bdd16d460f4cd9a6af511ca2"
         },
         "simpleTags": [
-          "debian-9-arm64v8-3e800f1-20200107182347"
+          "debian-9-arm64v8-bfcd90a-20200121150055"
         ]
       },
       "src/debian/9/helix/arm32v7/Dockerfile": {
@@ -156,7 +153,7 @@
           "arm32v7/debian:9": "arm32v7/debian@sha256:786246f306ac0d78fec4ad2af27316769d282b50b1b68f6f688af4364392ce1b"
         },
         "simpleTags": [
-          "debian-9-helix-arm32v7-4f8cef7-20200107182356"
+          "debian-9-helix-arm32v7-bfcd90a-20200121150037"
         ]
       },
       "src/debian/9/helix/arm64v8/Dockerfile": {
@@ -164,7 +161,7 @@
           "arm64v8/debian:9": "arm64v8/debian@sha256:b82b9f553b74b4b18d634f0ada6c12bdfcb3f908bdd16d460f4cd9a6af511ca2"
         },
         "simpleTags": [
-          "debian-9-helix-arm64v8-4f8cef7-20200107182344"
+          "debian-9-helix-arm64v8-bfcd90a-20200121150055"
         ]
       },
       "src/debian/iot/arm32v7/Dockerfile": {
@@ -172,30 +169,7 @@
           "arm32v7/debian:latest": "arm32v7/debian@sha256:021a25168df52aeff4eb2e88f448a51a23e13fbbfecbfc5371b629134f17e2d6"
         },
         "simpleTags": [
-          "debian-iot-arm32v7-be5b37d-20200107182356"
-        ]
-      },
-      "src/debian/jessie/coredeps/Dockerfile": {
-        "baseImages": {
-          "debian:jessie": "debian@sha256:a8ae3c5129fb2e10a62b5c059a24308831508c44018c24ccda2e4fc6fd7cdda7"
-        },
-        "simpleTags": [
-          "debian-jessie-coredeps-3e800f1-20190807161116"
-        ]
-      },
-      "src/debian/jessie/corert/Dockerfile": {
-        "simpleTags": [
-          "debian-jessie-corert-58e4974-20190807161116"
-        ]
-      },
-      "src/debian/jessie/debpkg/Dockerfile": {
-        "simpleTags": [
-          "debian-jessie-debpkg-58e4974-20190807161116"
-        ]
-      },
-      "src/debian/jessie/Dockerfile": {
-        "simpleTags": [
-          "debian-jessie-3e800f1-20190807161116"
+          "debian-iot-arm32v7-be5b37d-20200121150031"
         ]
       },
       "src/debian/stretch-slim/docker-testrunner/Dockerfile": {
@@ -203,7 +177,7 @@
           "debian:stretch-slim": "debian@sha256:5adfa6280283d302f8b5e7ef6c32d54b71704cdb1f6a9f740924ec6113390017"
         },
         "simpleTags": [
-          "debian-stretch-slim-docker-testrunner-d61254f-20200107182419"
+          "debian-stretch-slim-docker-testrunner-d61254f-20200121145958"
         ]
       },
       "src/debian/stretch/Dockerfile": {
@@ -211,20 +185,7 @@
           "debian:stretch": "debian@sha256:85c4668abb4f26e913152ba8fd04fca5f1c2345d3e2653855e6bb0acf461ed50"
         },
         "simpleTags": [
-          "debian-stretch-d61254f-20200107182432"
-        ]
-      },
-      "src/fedora/29/Dockerfile": {
-        "baseImages": {
-          "fedora:29": "fedora@sha256:2c20e5bb324735427f8a659e36f4fe14d6955c74c7baa25067418dddbb71d67a"
-        },
-        "simpleTags": [
-          "fedora-29-a12566d-20191210224553"
-        ]
-      },
-      "src/fedora/29/helix/amd64/Dockerfile": {
-        "simpleTags": [
-          "fedora-29-helix-a12566d-20191210224553"
+          "debian-stretch-bfcd90a-20200121150012"
         ]
       },
       "src/fedora/30/amd64/Dockerfile": {
@@ -232,12 +193,12 @@
           "fedora:30": "fedora@sha256:a31809d5e9d991a291605e932077aaf5f2beff64dee85b34d911228196af406e"
         },
         "simpleTags": [
-          "fedora-30-38e0f29-20200107182502"
+          "fedora-30-bfcd90a-20200121150022"
         ]
       },
       "src/fedora/30/helix/amd64/Dockerfile": {
         "simpleTags": [
-          "fedora-30-helix-4f8cef7-20200107182502"
+          "fedora-30-helix-4f8cef7-20200121150022"
         ]
       },
       "src/nanoserver/1803/helix/amd64/Dockerfile": {
@@ -377,47 +338,47 @@
       },
       "src/ubuntu/18.04/amd64/Dockerfile": {
         "baseImages": {
-          "ubuntu:18.04": "ubuntu@sha256:250cc6f3f3ffc5cdaa9d8f4946ac79821aafb4d3afc93928f0de9336eba21aa4"
+          "ubuntu:18.04": "ubuntu@sha256:8d31dad0c58f552e890d68bbfb735588b6b820a46e459672d96e585871acc110"
         },
         "simpleTags": [
-          "ubuntu-18.04-e468805-20200107182539"
+          "ubuntu-18.04-bfcd90a-20200121150040"
         ]
       },
       "src/ubuntu/18.04/arm32v7/Dockerfile": {
         "baseImages": {
-          "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:56ea270e0c0826ab6b155acf5130fbc59fa36703e982bddea3143261fca60b8d"
+          "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:b05b0c89890927974f939f89c4c5e116325b3e84440104127dd5940bfa1d0b0c"
         },
         "simpleTags": [
-          "ubuntu-18.04-arm32v7-3e800f1-20200107182414"
+          "ubuntu-18.04-arm32v7-bfcd90a-20200121150101"
         ]
       },
       "src/ubuntu/18.04/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:5b5cd6123869f01f0bab03bf23588d203de9e087cd10140dbb2e06e44ff7f28d"
+          "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:5aca840f27b5daeb771a11356ce9eecc2fe4ec262f25a9565ca2afe02f5b5de1"
         },
         "simpleTags": [
-          "ubuntu-18.04-arm64v8-3e800f1-20200107182416"
+          "ubuntu-18.04-arm64v8-bfcd90a-20200121150531"
         ]
       },
       "src/ubuntu/18.04/debpkg/Dockerfile": {
         "simpleTags": [
-          "ubuntu-18.04-debpkg-cfdd435-20200107182539"
+          "ubuntu-18.04-debpkg-cfdd435-20200121150040"
         ]
       },
       "src/ubuntu/18.04/helix/arm32v7/Dockerfile": {
         "baseImages": {
-          "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:56ea270e0c0826ab6b155acf5130fbc59fa36703e982bddea3143261fca60b8d"
+          "arm32v7/ubuntu:18.04": "arm32v7/ubuntu@sha256:b05b0c89890927974f939f89c4c5e116325b3e84440104127dd5940bfa1d0b0c"
         },
         "simpleTags": [
-          "ubuntu-18.04-helix-arm32v7-4f8cef7-20200107182739"
+          "ubuntu-18.04-helix-arm32v7-bfcd90a-20200121150440"
         ]
       },
       "src/ubuntu/18.04/helix/arm64v8/Dockerfile": {
         "baseImages": {
-          "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:5b5cd6123869f01f0bab03bf23588d203de9e087cd10140dbb2e06e44ff7f28d"
+          "arm64v8/ubuntu:18.04": "arm64v8/ubuntu@sha256:5aca840f27b5daeb771a11356ce9eecc2fe4ec262f25a9565ca2afe02f5b5de1"
         },
         "simpleTags": [
-          "ubuntu-18.04-helix-arm64v8-4f8cef7-20200107182417"
+          "ubuntu-18.04-helix-arm64v8-bfcd90a-20200121150540"
         ]
       },
       "src/ubuntu/19.04/helix/amd64/Dockerfile": {


### PR DESCRIPTION
Manually updating image info data for the https://github.com/dotnet/dotnet-buildtools-prereqs-docker repo because there was infrastructure issues in having that done automatically.  Also removes some obsolete data for out of support images.