### PR TITLE
Adding MSBuild vs16.x branches to automate PRs into master

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1694,6 +1694,7 @@
       }
     },
     // Automate opening PRs to merge msbuild's vs16.x branches into master
+    // For details on how the triggerpath globbing syntax works, see: https://github.com/dotnet/versions/issues/558
     {
       "triggerPaths": [
         "https://github.com/microsoft/msbuild/blob/vs16./**/*"

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1693,6 +1693,23 @@
         }
       }
     },
+    // Automate opening PRs to merge msbuild's vs16.x branches into master
+    {
+      "triggerPaths": [
+        "https://github.com/microsoft/msbuild/blob/vs16.5/**/*",
+        "https://github.com/microsoft/msbuild/blob/vs16.6/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "microsoft",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "master"
+        }
+      }
+    },
     // Temporary orchestrated build final publish in release/2.1.15
     {
       "triggerPaths": [

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1696,8 +1696,7 @@
     // Automate opening PRs to merge msbuild's vs16.x branches into master
     {
       "triggerPaths": [
-        "https://github.com/microsoft/msbuild/blob/vs16.5/**/*",
-        "https://github.com/microsoft/msbuild/blob/vs16.6/**/*"
+        "https://github.com/microsoft/msbuild/blob/vs16./**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
Added triggers for MSBuild `vs16.*` branches to get pull requests created from `vs16.*` -> `master`. 

Explanation from @dagood 
> What's going on is that `/**/*` means it matches file changes where the url starts with everything up to the `/`, exclusive.  So `...blob/vs16./**/*` will do what you want. The double-slashes are to make sure this doesn't happen.  It's weird. https://github.com/dotnet/versions/blob/1c00f953854d79e4b2ee368495c58de6b39d8e79/Maestro/src/Microsoft.DotNet.Maestro.WebApi/Models/SubscriptionsModel.cs#L89

Related issue with a detailed explanation: https://github.com/dotnet/versions/issues/558