### PR TITLE
remove F# feature merges

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -749,7 +749,6 @@
         "https://github.com/dotnet/docker-tools/blob/master/**/*",
         "https://github.com/dotnet/dotnet-docker/blob/master/**/*",
         "https://github.com/dotnet/dotnet-docker/blob/nightly/**/*",
-        "https://github.com/dotnet/fsharp/blob/feature/**/*",
         "https://github.com/dotnet/fsharp/blob/master/**/*",
         "https://github.com/dotnet/fsharp/blob/release/**/*",
         "https://github.com/dotnet/interactive/blob/master/**/*",


### PR DESCRIPTION
F# doesn't need internal signed builds from any `feature/*` branches, so the mirror can be turned off.