### PR TITLE
Re-disable merges from aspnetcore rel/3.1 -> blazor-wasm

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1120,22 +1120,6 @@
         }
       }
     },
-    // Automate opening PRs to merge aspnetcore release/3.1 branch to the blazor-wasm feature branch.
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/aspnetcore/blob/release/3.1//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "blazor-wasm"
-        }
-      }
-    },
     // Automate opening PRs to merge cli 3.1.3xx to master
     {
       "triggerPaths": [


### PR DESCRIPTION
https://github.com/dotnet/versions/pull/564 disabled this merge, but https://github.com/dotnet/versions/pull/563 was merged afterwards and touched a neighboring section of the code, so it got put back in during the merge conflict resolution. Re-disabling it here.

CC @mmitche @wli3 @dotnet/aspnet-build 