### PR TITLE
Add dotnet/tye to mirroring job

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -705,6 +705,8 @@
         "https://github.com/dotnet/HttpRepl/blob/release/**/*",
         "https://github.com/aspnet/Scaffolding/blob/master/**/*",
         "https://github.com/aspnet/Scaffolding/blob/release/**/*",
+        "https://github.com/dotnet/tye/blob/master/**/*",
+        "https://github.com/dotnet/tye/blob/release/**/*",
         "https://github.com/aspnet/websdk/blob/master/**/*",
         "https://github.com/aspnet/websdk/blob/release/**/*",
         "https://github.com/aspnet/xdt/blob/master/**/*",


### PR DESCRIPTION
Adds dotnet/tye to the mirroring process.

I could use a double-check from anyone who's familiar with the process, because this is my first time doing this 😁. I don't need any automated merges.

- [x] dotnet/tye is public
- [ ] Do I need to create the internal repo manually? or is that automated?