### PR TITLE
Fix up image infos that got corrupted

### DIFF
--- a/build-info/docker/image-info.Microsoft-dotnet-framework-docker-master.json
+++ b/build-info/docker/image-info.Microsoft-dotnet-framework-docker-master.json
@@ -2,131 +2,865 @@
   "schemaVersion": "1.0",
   "repos": [
     {
-      "repo": "dotnet/framework/samples",
+      "repo": "dotnet/framework/aspnet",
       "images": [
         {
           "manifest": {
-            "digest": "sha256:0184a632143bed7a7493da8c2ea296e34e8f4b68a842a51a842c97361429ffc2",
-            "created": "2020-04-09T16:08:44.3423529Z",
+            "digest": "sha256:c90d0a681bc6b65b75a8c350ee29567b2dc52ec6437343bf5f940a845ae32760",
+            "created": "2020-03-18T16:27:59.8166129Z",
             "sharedTags": [
-              "wcfclient"
+              "4.8",
+              "latest"
             ]
           },
           "platforms": [
             {
-              "dockerfile": "samples/wcfapp/Dockerfile.client",
+              "dockerfile": "4.8/aspnet/windowsservercore-1903/Dockerfile",
               "simpleTags": [
-                "wcfclient-windowsservercore-ltsc2016"
+                "4.8-20200310-windowsservercore-1903",
+                "4.8-windowsservercore-1903"
               ],
-              "digest": "sha256:9719014f2c611c8c771af51145a37407068e2a1038de872c9aa4970b3524debf",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
-              "osType": "Windows",
-              "osVersion": "Windows Server 2016",
-              "architecture": "amd64",
-              "created": "2020-04-09T16:02:01.5292112Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
-            },
-            {
-              "dockerfile": "samples/wcfapp/Dockerfile.client",
-              "simpleTags": [
-                "wcfclient-windowsservercore-ltsc2019"
-              ],
-              "digest": "sha256:d537ffee29b2916fc9f5bea306227f62da499612be172e01e0bc3fb7760661b6",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
-              "osType": "Windows",
-              "osVersion": "Windows Server 2019",
-              "architecture": "amd64",
-              "created": "2020-04-09T14:53:23.4826115Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
-            },
-            {
-              "dockerfile": "samples/wcfapp/Dockerfile.client",
-              "simpleTags": [
-                "wcfclient-windowsservercore-1903"
-              ],
-              "digest": "sha256:79c6a0227d22b12ff49c567334c1524947951aba2092534294184baa366b9188",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+              "digest": "sha256:d9e498cb99515fe769f593896fc268427c376cda650affa6138429b4c94ca97e",
               "osType": "Windows",
               "osVersion": "Windows Server, version 1903",
               "architecture": "amd64",
-              "created": "2020-04-09T14:51:40.4544126Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
+              "created": "2020-03-18T16:27:59.8166129Z",
+              "commitUrl": null
             },
             {
-              "dockerfile": "samples/wcfapp/Dockerfile.client",
+              "dockerfile": "4.8/aspnet/windowsservercore-1909/Dockerfile",
               "simpleTags": [
-                "wcfclient-windowsservercore-1909"
+                "4.8-20200310-windowsservercore-1909",
+                "4.8-windowsservercore-1909"
               ],
-              "digest": "sha256:be3db57227043c9035e1f06c7262cd3cfb62e4410b17a4c6822c7bf69f689e83",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+              "digest": "sha256:670af7cc901821183256d41f769875c951b4b95cc9f306f9d837f894b0cae80f",
               "osType": "Windows",
               "osVersion": "Windows Server, version 1909",
               "architecture": "amd64",
-              "created": "2020-04-09T14:51:54.4009726Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
+              "created": "2020-03-16T19:39:08.8592552Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/aspnet/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.8-20200211-windowsservercore-ltsc2016",
+                "4.8-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:7bf99ba791cce2c51091ac0c6922ff98e5a448c1046ba046fab3760070173e0d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:24:59.2793085Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/aspnet/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "4.8-20200211-windowsservercore-ltsc2019",
+                "4.8-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:24ffd5fad1becaf9b16f42ec6f40c90ddf56664986a87212d2d48164e3bb52ba",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:22:38.3195395Z",
+              "commitUrl": null
             }
           ]
         },
         {
           "manifest": {
-            "digest": "sha256:caf815ba18a364d6f1affc7da776bf2a26cd724a7c1ac33a7518e1a5e5f6d2ee",
-            "created": "2020-04-09T16:08:44.3423529Z",
+            "digest": "sha256:c0c411688b6e25f3699e5baa3c0543d0a762c7b35c4025fc0b3efc5c05ae935c",
+            "created": "2020-03-18T16:34:30.1727018Z",
             "sharedTags": [
-              "wcfservice"
+              "4.7.2"
             ]
           },
           "platforms": [
             {
-              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "dockerfile": "4.7.2/aspnet/windowsservercore-ltsc2016/Dockerfile",
               "simpleTags": [
-                "wcfservice-windowsservercore-ltsc2016"
+                "4.7.2-20200312-windowsservercore-ltsc2016",
+                "4.7.2-windowsservercore-ltsc2016"
               ],
-              "digest": "sha256:bec7e34b170ca34da3c1a5c204fb0b6b41138fdb433c9c9f111eb9868dc8a186",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "digest": "sha256:8cf7c034fd20e362f2e8996cf3dbed88d24b717b4cee9ac762f77cc147e7ceac",
               "osType": "Windows",
               "osVersion": "Windows Server 2016",
               "architecture": "amd64",
-              "created": "2020-04-09T15:40:24.2586598Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
+              "created": "2020-03-18T16:34:30.1727018Z",
+              "commitUrl": null
             },
             {
-              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "dockerfile": "4.7.2/aspnet/windowsservercore-ltsc2019/Dockerfile",
               "simpleTags": [
-                "wcfservice-windowsservercore-ltsc2019"
+                "4.7.2-20200310-windowsservercore-ltsc2019",
+                "4.7.2-windowsservercore-ltsc2019"
               ],
-              "digest": "sha256:e5cd71726521dc3f21ca49e071ec1b64e9f53656d0cc77c51421a30d661c268e",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "digest": "sha256:90baaa2950a137a794c962d5d8dbf493276648e6c3b32f1bdde91e5a09fdf001",
               "osType": "Windows",
               "osVersion": "Windows Server 2019",
               "architecture": "amd64",
-              "created": "2020-04-09T14:53:53.6336572Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
-            },
+              "created": "2020-03-18T16:07:13.501506Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:41f6daa9fca49cf5db42b32741074f219ee65dd561df1eeb94f7ad04d993a60c",
+            "created": "2020-03-18T16:33:48.3270617Z",
+            "sharedTags": [
+              "4.7.1"
+            ]
+          },
+          "platforms": [
             {
-              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "dockerfile": "4.7.1/aspnet/windowsservercore-ltsc2016/Dockerfile",
               "simpleTags": [
-                "wcfservice-windowsservercore-1903"
+                "4.7.1-20200312-windowsservercore-ltsc2016",
+                "4.7.1-windowsservercore-ltsc2016"
               ],
-              "digest": "sha256:17fc23b3844c0f4a3cb3afa5938e68d689ff548c49a418e5da777fa937613242",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "digest": "sha256:765e38fe3e1463fe3c0b93138039c1893020050571f793dadd7c70ddbc397c94",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:33:48.3270617Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:e243afcaee34344fe32d5813fd6dfd70d45a1fbdfe564fdb74c541e56d05b07e",
+            "created": "2020-03-18T16:33:05.5795181Z",
+            "sharedTags": [
+              "4.7"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.7/aspnet/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.7-20200312-windowsservercore-ltsc2016",
+                "4.7-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:7223e36c3919f99283d0230e250545a54221d2d5b4ed0304d13e91f095820a70",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:33:05.5795181Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:81dd5fbc112ed836399e9a05f3936fb52e29408be92415f59aa7894f1a153427",
+            "created": "2020-03-18T16:05:32.1574366Z",
+            "sharedTags": [
+              "4.6.2"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.6.2/aspnet/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.6.2-20200211-windowsservercore-ltsc2016",
+                "4.6.2-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:c296aa2eabbf25e5bededca7ffc6ec88038fe964fc82bdb83ef8dd5c38e51e65",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:05:32.1574366Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:19395c4fda916d21936761ae9cf506c35d3d209156163d0fdf5fd715c2ec40a7",
+            "created": "2020-03-18T17:01:14.5221921Z",
+            "sharedTags": [
+              "3.5"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "3.5/aspnet/windowsservercore-1903/Dockerfile",
+              "simpleTags": [
+                "3.5-20200211-windowsservercore-1903",
+                "3.5-windowsservercore-1903"
+              ],
+              "digest": "sha256:973766d0c59f110da376b96bc53dd3fa91d1b458304a7f5b88466de4bdd89654",
               "osType": "Windows",
               "osVersion": "Windows Server, version 1903",
               "architecture": "amd64",
-              "created": "2020-04-09T14:52:09.0137057Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
+              "created": "2020-03-18T16:31:50.2599599Z",
+              "commitUrl": null
             },
             {
-              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "dockerfile": "3.5/aspnet/windowsservercore-1909/Dockerfile",
               "simpleTags": [
-                "wcfservice-windowsservercore-1909"
+                "3.5-20200211-windowsservercore-1909",
+                "3.5-windowsservercore-1909"
               ],
-              "digest": "sha256:b632f8dd3feb38e9b744e1b3e273bc423f1d3ea0b33fdec836c9bfa1b53586e8",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "digest": "sha256:72c3a5b1e063c00bae1561166c7351cdd1ef50f0b212951ad87836cdc140f2ff",
               "osType": "Windows",
               "osVersion": "Windows Server, version 1909",
               "architecture": "amd64",
-              "created": "2020-04-09T14:52:18.0763217Z",
-              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
+              "created": "2020-03-16T19:51:10.6176301Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/aspnet/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "3.5-20200312-windowsservercore-ltsc2016",
+                "3.5-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:7ee41a7d93d399e4331d49ff2e533c96ebd9e55e63e185a7bcc6d6f321a10ba5",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T17:01:14.5221921Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/aspnet/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "3.5-20200211-windowsservercore-ltsc2019",
+                "3.5-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:afd465d356a495a651a9629fec745b0192b25fbe279c681689c9250c164a0b35",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:41:18.9735805Z",
+              "commitUrl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "repo": "dotnet/framework/runtime",
+      "images": [
+        {
+          "manifest": {
+            "digest": "sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+            "created": "2020-03-18T16:11:06.368915Z",
+            "sharedTags": [
+              "4.8",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.8/runtime/windowsservercore-1903/Dockerfile",
+              "simpleTags": [
+                "4.8-20200310-windowsservercore-1903",
+                "4.8-windowsservercore-1903"
+              ],
+              "digest": "sha256:232e88fa3a6817f7ef82ea567bc58bc9689eb7fb1cfb0892de5f26ad2c8b7add",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:ad1d822527c131fa1939dc25083a91c3bb62640b60e754b9f7e504d28cde5157",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:03:50.9915265Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/runtime/windowsservercore-1909/Dockerfile",
+              "simpleTags": [
+                "4.8-20200310-windowsservercore-1909",
+                "4.8-windowsservercore-1909"
+              ],
+              "digest": "sha256:24aa5ab2de11d73be0a4a84f515145866910a60ef37a8e1812c81c54042e6536",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:d0a93cf38daadc18ca7b2ed537bde74cfb867f50556d44e8adcfec4a1d1f2de4",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-16T19:21:37.0187322Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/runtime/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.8-20200211-windowsservercore-ltsc2016",
+                "4.8-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:000d639c6c287bf0e69b27c008f2d411a9e161093dd1855667a8e6189f9adac8",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:5bd97dbab1afe8d3200f5d5c974df3b0130e74e8a69fddcd427699c4c8cb5037",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:11:06.368915Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/runtime/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "4.8-20200211-windowsservercore-ltsc2019",
+                "4.8-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:ceaf6f000f0a0677510a5511f089071c2822dd40f34a77ca0280f96b10621858",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:8dcc65367c900f06ad386da6a1e25d578232f7b15981092986ade2f2fd9468b8",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:09:31.8435391Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:0c843df618406fb8b0829d7fa900a7604af9ec74df8a792e00ca2a93a4c2e111",
+            "created": "2020-03-18T16:30:25.2567423Z",
+            "sharedTags": [
+              "4.7.2"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.7.2/runtime/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.7.2-20200312-windowsservercore-ltsc2016",
+                "4.7.2-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:82ed8a40291254118bd0873550bdf3acb76a26fdc9f3608203f69cf1fe8b31ba",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:5bd97dbab1afe8d3200f5d5c974df3b0130e74e8a69fddcd427699c4c8cb5037",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:30:25.2567423Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.7.2/runtime/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "4.7.2-20200310-windowsservercore-ltsc2019",
+                "4.7.2-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:b8da5060a7c9c47830bfe6030465ff12ea4d31e3af1f3d5c5d419e77b5c2a3e5",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:8dcc65367c900f06ad386da6a1e25d578232f7b15981092986ade2f2fd9468b8",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:03:56.1963488Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:80954d9303504d830ab617b597bf1a5eb1c9875b7e30bddf149e30e727b8612e",
+            "created": "2020-03-18T16:29:52.4698235Z",
+            "sharedTags": [
+              "4.7.1"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.7.1/runtime/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.7.1-20200312-windowsservercore-ltsc2016",
+                "4.7.1-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:77bb35ea1fb45d5c92dcad22efde423ea07dd5e416105fc4326725c5da4fd0b0",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:5bd97dbab1afe8d3200f5d5c974df3b0130e74e8a69fddcd427699c4c8cb5037",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:29:52.4698235Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:1bca013383b60e884957587eac0d91e54db87cf6b42f4775119f2a27a02f6d09",
+            "created": "2020-03-18T16:29:09.969364Z",
+            "sharedTags": [
+              "4.7"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.7/runtime/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.7-20200312-windowsservercore-ltsc2016",
+                "4.7-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:4843ecffa86c3476594fbc02bb40457efddae5ece26948014bc95d6330be3979",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:5bd97dbab1afe8d3200f5d5c974df3b0130e74e8a69fddcd427699c4c8cb5037",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:29:09.969364Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:72b930dc4641ba91c7eb0ccbb5a9384b935b60e1139d953db755017d25d162f5",
+            "created": "2020-03-18T16:01:54.8317998Z",
+            "sharedTags": [
+              "4.6.2"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.6.2/runtime/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.6.2-20200211-windowsservercore-ltsc2016",
+                "4.6.2-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:3f3d961005c329571c01b5e1665c382af054753d07792035b0e81a16190eb3d9",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:5bd97dbab1afe8d3200f5d5c974df3b0130e74e8a69fddcd427699c4c8cb5037",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:01:54.8317998Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:519f696bb7722193a4cca235b4450381cd49fdafe8a5db9275183f8302fe339c",
+            "created": "2020-03-18T16:30:16.0943153Z",
+            "sharedTags": [
+              "3.5"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "3.5/runtime/windowsservercore-1903/Dockerfile",
+              "simpleTags": [
+                "3.5-20200211-windowsservercore-1903",
+                "3.5-windowsservercore-1903"
+              ],
+              "digest": "sha256:661230a1905db54e2e9f4b8c757a45ab512135a1f4af07c504424fa1286060c5",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:ad1d822527c131fa1939dc25083a91c3bb62640b60e754b9f7e504d28cde5157",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:09:21.3325111Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/runtime/windowsservercore-1909/Dockerfile",
+              "simpleTags": [
+                "3.5-20200211-windowsservercore-1909",
+                "3.5-windowsservercore-1909"
+              ],
+              "digest": "sha256:83ca50a469cdbb050ae35d63152b0d906a2d5781580c00664a41dc53f2975e3e",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:d0a93cf38daadc18ca7b2ed537bde74cfb867f50556d44e8adcfec4a1d1f2de4",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-16T19:26:56.0157925Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/runtime/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "3.5-20200312-windowsservercore-ltsc2016",
+                "3.5-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:1321699d6932cc2cfac80220ac9de739afff0aff7d12bb2cf8dbd737233bba63",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:5bd97dbab1afe8d3200f5d5c974df3b0130e74e8a69fddcd427699c4c8cb5037",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:30:16.0943153Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/runtime/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "3.5-20200211-windowsservercore-ltsc2019",
+                "3.5-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:815b643c3a019c51c41d382f8d4305c6218982680fb82885a988b224b3b29f9c",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:8dcc65367c900f06ad386da6a1e25d578232f7b15981092986ade2f2fd9468b8",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:09:00.1481662Z",
+              "commitUrl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "repo": "dotnet/framework/samples",
+      "images": [
+        {
+          "manifest": {
+            "digest": "sha256:5c5f20209542645795da273d5dd67036e36c1064d2369fb0bdf8f96de80164c2",
+            "created": "2020-03-18T19:27:11.2787497Z",
+            "sharedTags": [
+              "dotnetapp",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "simpleTags": [
+                "dotnetapp-windowsservercore-1903",
+                "dotnetapp-windowsservercore-1909",
+                "dotnetapp-windowsservercore-ltsc2016",
+                "dotnetapp-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:b11dd842c71ff09a3b7bc27261a0e80871a5265858d879d30bbf1727d0f8cdb0",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T19:27:11.2787497Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:3cb99b25d0bb630b6ec62902e2eaa970520f54c0e6073a767a06eda29cea1e02",
+            "created": "2020-03-18T19:30:36.4322395Z",
+            "sharedTags": [
+              "aspnetapp"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "simpleTags": [
+                "aspnetapp-windowsservercore-1903",
+                "aspnetapp-windowsservercore-1909",
+                "aspnetapp-windowsservercore-ltsc2016",
+                "aspnetapp-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:5b0ea7963dbc4c772518b605025ddeff7db7735ccd85dd02c4cc2fa56eceacda",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:c90d0a681bc6b65b75a8c350ee29567b2dc52ec6437343bf5f940a845ae32760",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T19:30:36.4322395Z",
+              "commitUrl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "repo": "dotnet/framework/sdk",
+      "images": [
+        {
+          "manifest": {
+            "digest": "sha256:ed4879f58839e708aed586304b03e0307c9c4b73f2aa858f1979eca447f7303e",
+            "created": "2020-03-18T16:23:19.689631Z",
+            "sharedTags": [
+              "4.8",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.8/sdk/windowsservercore-1903/Dockerfile",
+              "simpleTags": [
+                "4.8-20200318-windowsservercore-1903",
+                "4.8-windowsservercore-1903"
+              ],
+              "digest": "sha256:576efdac9d8632a6639da3abaff7f430094575131a080d209181bc8b10f5a823",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:23:19.689631Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/sdk/windowsservercore-1909/Dockerfile",
+              "simpleTags": [
+                "4.8-20200316-windowsservercore-1909",
+                "4.8-windowsservercore-1909"
+              ],
+              "digest": "sha256:1cc8dc2023025e26f7cb28f8a6f888efedc82196a2d0d8d30bd34725d023b51c",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-16T19:34:20.7056585Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/sdk/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.8-20200318-windowsservercore-ltsc2016",
+                "4.8-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:62e074cd4ed773d02a1cb2abd02f8b021ed178bda8a2f3b7d0564b1af76a2fb2",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:21:16.2184817Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/sdk/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "4.8-20200318-windowsservercore-ltsc2019",
+                "4.8-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:ed880468cd9b9775392fe3e25e7ffc8afbcfc456089ce74314b912f1fe82aacd",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:19:10.967069Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:e20605a1d01a2e285e9cb8358c1d4c366872ec18b84f647789cbc432ec8eabc8",
+            "created": "2020-03-18T16:58:23.0622431Z",
+            "sharedTags": [
+              "3.5"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "3.5/sdk/windowsservercore-1903/Dockerfile",
+              "simpleTags": [
+                "3.5-20200318-windowsservercore-1903",
+                "3.5-windowsservercore-1903"
+              ],
+              "digest": "sha256:f0f399c53e244b5e2eca5b0806870b1fd0928a88c10d7f533fae9f1fc3413a1b",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:28:27.703923Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/sdk/windowsservercore-1909/Dockerfile",
+              "simpleTags": [
+                "3.5-20200316-windowsservercore-1909",
+                "3.5-windowsservercore-1909"
+              ],
+              "digest": "sha256:61e756c9e4f5626e1b7c1bf7c6fa6ca4dff794480ea5569408967fffac93fba6",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-16T19:47:53.5606274Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/sdk/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "3.5-20200318-windowsservercore-ltsc2016",
+                "3.5-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:b832645f922b09f428bd865e1ac2c66063d8da48ccc4a3701533647d4d14e62f",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:58:23.0622431Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.5/sdk/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "3.5-20200318-windowsservercore-ltsc2019",
+                "3.5-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:c9d9faef6bb9c9df4109ef578b588de3ef3e03d2aae4570743647931c16a6f1b",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:38:21.3708236Z",
+              "commitUrl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "repo": "dotnet/framework/wcf",
+      "images": [
+        {
+          "manifest": {
+            "digest": "sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+            "created": "2020-03-18T16:30:41.8568818Z",
+            "sharedTags": [
+              "4.8",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.8/wcf/windowsservercore-1903/Dockerfile",
+              "simpleTags": [
+                "4.8-20200310-windowsservercore-1903",
+                "4.8-windowsservercore-1903"
+              ],
+              "digest": "sha256:914875658fad00e06b1eab6a618af00bd52ca9483a697464abe27303bbe31809",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:30:41.8568818Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/wcf/windowsservercore-1909/Dockerfile",
+              "simpleTags": [
+                "4.8-20200310-windowsservercore-1909",
+                "4.8-windowsservercore-1909"
+              ],
+              "digest": "sha256:0bf22a77d6a83c07f167abe5a947a73ba5b23e8f917b59c0bdf99d820634d007",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-16T19:41:52.8682706Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/wcf/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.8-20200211-windowsservercore-ltsc2016",
+                "4.8-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:d76a6686a710e34a2492294b1220aa7bbafffe4998b7af2b391184631aaefa4f",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:26:36.9966323Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.8/wcf/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "4.8-20200211-windowsservercore-ltsc2019",
+                "4.8-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:8ef18ba0be83cad429addecf66348b2ae581e6fa13c384332e19ecc8b9d805f3",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:24:05.6046617Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:d5c66d5ee4b43beab2df4b0676cacd237c7d979b22fa99b8babfd29841577025",
+            "created": "2020-03-18T16:36:09.7653484Z",
+            "sharedTags": [
+              "4.7.2"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.7.2/wcf/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.7.2-20200312-windowsservercore-ltsc2016",
+                "4.7.2-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:cdf4a59bb447ad604e26227e687b6b1e4f104937c6254308e23a93aefed18016",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:36:09.7653484Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "4.7.2/wcf/windowsservercore-ltsc2019/Dockerfile",
+              "simpleTags": [
+                "4.7.2-20200310-windowsservercore-ltsc2019",
+                "4.7.2-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:0ea8be6dec998a4947c7bdacdab99079d84747ff842c5d64974afad0a4d343eb",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:08:35.5012458Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:0333da178738bdf9b3b2da9a466ecae9ea504afad37bbb9462ac0e6179e60f17",
+            "created": "2020-03-18T16:35:30.7374434Z",
+            "sharedTags": [
+              "4.7.1"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.7.1/wcf/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.7.1-20200312-windowsservercore-ltsc2016",
+                "4.7.1-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:fe7f4e720750ad3a72b2be1397b2c42db7eead2adfa20f151c283c003a8f1d26",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:35:30.7374434Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:6b08984de3b11e0863f47397485d8de23887cda9a69901ef70dc4c471648ea4b",
+            "created": "2020-03-18T16:34:46.7679059Z",
+            "sharedTags": [
+              "4.7"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.7/wcf/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.7-20200312-windowsservercore-ltsc2016",
+                "4.7-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:2f048f62604be58b230b5f4fd152b9e636d403e72818b03336cfa44cddfa0570",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:34:46.7679059Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:5f71053fd2e2504b80743ece0fc309120203db8205ac0c67f7aa052314e8f6d6",
+            "created": "2020-03-18T16:06:55.1685929Z",
+            "sharedTags": [
+              "4.6.2"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "4.6.2/wcf/windowsservercore-ltsc2016/Dockerfile",
+              "simpleTags": [
+                "4.6.2-20200211-windowsservercore-ltsc2016",
+                "4.6.2-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:0bd2e0bac8786c962714cb74ba673d1b835875c9ad4912d4544e5deceda71234",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-03-18T16:06:55.1685929Z",
+              "commitUrl": null
             }
           ]
         }

--- a/build-info/docker/image-info.Microsoft-dotnet-framework-docker-master.json
+++ b/build-info/docker/image-info.Microsoft-dotnet-framework-docker-master.json
@@ -553,6 +553,132 @@
               "commitUrl": null
             }
           ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:0184a632143bed7a7493da8c2ea296e34e8f4b68a842a51a842c97361429ffc2",
+            "created": "2020-04-09T16:08:44.3423529Z",
+            "sharedTags": [
+              "wcfclient"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.client",
+              "simpleTags": [
+                "wcfclient-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:9719014f2c611c8c771af51145a37407068e2a1038de872c9aa4970b3524debf",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-04-09T16:02:01.5292112Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.client",
+              "simpleTags": [
+                "wcfclient-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:d537ffee29b2916fc9f5bea306227f62da499612be172e01e0bc3fb7760661b6",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:53:23.4826115Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.client",
+              "simpleTags": [
+                "wcfclient-windowsservercore-1903"
+              ],
+              "digest": "sha256:79c6a0227d22b12ff49c567334c1524947951aba2092534294184baa366b9188",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:51:40.4544126Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.client",
+              "simpleTags": [
+                "wcfclient-windowsservercore-1909"
+              ],
+              "digest": "sha256:be3db57227043c9035e1f06c7262cd3cfb62e4410b17a4c6822c7bf69f689e83",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:14a0e2327fd8ea95e5d20862bdd52589c565ffc55e8a755c2a5adc7ccedc4f76",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:51:54.4009726Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:caf815ba18a364d6f1affc7da776bf2a26cd724a7c1ac33a7518e1a5e5f6d2ee",
+            "created": "2020-04-09T16:08:44.3423529Z",
+            "sharedTags": [
+              "wcfservice"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "simpleTags": [
+                "wcfservice-windowsservercore-ltsc2016"
+              ],
+              "digest": "sha256:bec7e34b170ca34da3c1a5c204fb0b6b41138fdb433c9c9f111eb9868dc8a186",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2016",
+              "architecture": "amd64",
+              "created": "2020-04-09T15:40:24.2586598Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "simpleTags": [
+                "wcfservice-windowsservercore-ltsc2019"
+              ],
+              "digest": "sha256:e5cd71726521dc3f21ca49e071ec1b64e9f53656d0cc77c51421a30d661c268e",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:53:53.6336572Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "simpleTags": [
+                "wcfservice-windowsservercore-1903"
+              ],
+              "digest": "sha256:17fc23b3844c0f4a3cb3afa5938e68d689ff548c49a418e5da777fa937613242",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:52:09.0137057Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
+            },
+            {
+              "dockerfile": "samples/wcfapp/Dockerfile.web",
+              "simpleTags": [
+                "wcfservice-windowsservercore-1909"
+              ],
+              "digest": "sha256:b632f8dd3feb38e9b744e1b3e273bc423f1d3ea0b33fdec836c9bfa1b53586e8",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9263d40f804cf44659763799bf1974dec4cc2507339725cb4e9537a945ecad87",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:52:18.0763217Z",
+              "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
+            }
+          ]
         }
       ]
     },

--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -275,15 +275,15 @@
             {
               "dockerfile": "src/fedora/30/amd64/Dockerfile",
               "simpleTags": [
-                "fedora-30-bfcd90a-20200324132732"
+                "fedora-30-20200409151819-bfcd90a"
               ],
-              "digest": "sha256:7db110d49225f5a13b4da291bda23c13087c11662b8830010fc6f122508ac44c",
+              "digest": "sha256:716c61a5ef31d9dfd88517cb6d55a5b416f56fa309ed3059f2eb82e1f07dac97",
               "baseImageDigest": "fedora@sha256:3a0c8c86d8ac2d1bbcfd08d40d3b757337f7916fb14f40efcb1d1137a4edef45",
               "osType": "Linux",
               "osVersion": "Fedora 30",
               "architecture": "amd64",
-              "created": "2020-03-24T13:31:58.6270408Z",
-              "commitUrl": null
+              "created": "2020-04-09T15:24:30.3335593Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/fedora/30/amd64/Dockerfile"
             }
           ]
         },
@@ -292,14 +292,14 @@
             {
               "dockerfile": "src/fedora/30/helix/amd64/Dockerfile",
               "simpleTags": [
-                "fedora-30-helix-4f8cef7-20200324132732"
+                "fedora-30-helix-20200409151819-4f8cef7"
               ],
-              "digest": "sha256:6ecde80a0144530b54cc37c23922c6cb239586ecc6dfb0301ee38746825660f9",
+              "digest": "sha256:ae3e29670375cd2615d6984eb6f8f4cf47e663a4eca8bc691716fa78f9914a37",
               "osType": "Linux",
               "osVersion": "Fedora 30",
               "architecture": "amd64",
-              "created": "2020-03-24T13:34:01.0749262Z",
-              "commitUrl": null
+              "created": "2020-04-09T15:26:55.426846Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4f8cef786242dbb97c6454787f3f125df2ec5865/src/fedora/30/helix/amd64/Dockerfile"
             }
           ]
         },
@@ -308,15 +308,32 @@
             {
               "dockerfile": "src/fedora/31/amd64/Dockerfile",
               "simpleTags": [
-                "fedora-31-02f7c7e-20200324132728"
+                "fedora-31-20200409151813-02f7c7e"
               ],
-              "digest": "sha256:9293ce4e38b1cbe7f9f96dc2bd3ee78717d26c2f848e2b0819c0a3d2b3ba8345",
+              "digest": "sha256:697404c301bbec79b27f6a4560e6d788e14cefe6147b0889453603ed95c69418",
               "baseImageDigest": "fedora@sha256:c97879f8bebe49744307ea5c77ffc76c7cc97f3ddec72fb9a394bd4e4519b388",
               "osType": "Linux",
               "osVersion": "Fedora 31",
               "architecture": "amd64",
-              "created": "2020-03-24T13:31:06.9915135Z",
-              "commitUrl": null
+              "created": "2020-04-09T15:21:56.0409387Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/02f7c7e83342b4be0509bbcb088477456286c807/src/fedora/31/amd64/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/fedora/rawhide/amd64/Dockerfile",
+              "simpleTags": [
+                "fedora-rawhide-20200409151818-2ad2edd"
+              ],
+              "digest": "sha256:1593ed10e3a8ed6c7632eb7f86f72f580709c57fd998c0d7207e0de9a4556525",
+              "baseImageDigest": "fedora@sha256:42e73b6de8615fe67780b2bea86b6ef5177981b9a0f40e86e0e37cf317dd6b77",
+              "osType": "Linux",
+              "osVersion": "Fedora-rawhide",
+              "architecture": "amd64",
+              "created": "2020-04-09T15:22:07.1586285Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2ad2edd1bfbd300166973089f491f681465fd299/src/fedora/rawhide/amd64/Dockerfile"
             }
           ]
         },
@@ -423,15 +440,15 @@
             {
               "dockerfile": "src/ubuntu/18.04/coredeps/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-coredeps-20200407092345-85814b7"
+                "ubuntu-18.04-coredeps-20200409132031-85814b7"
               ],
-              "digest": "sha256:8a8f23460b989f634860c541c2dd7733c3559fa4b79c6d17737aaeb3aa25b175",
+              "digest": "sha256:84297356fb30d5f7f258bbc9b93f12b036dbdfe3662ee7e204fade6a48d5396d",
               "baseImageDigest": "mcr.microsoft.com/powershell@sha256:e5eb8e021d1f3b0c7d4343d4c16ec68b284a4a0d5446b6fe2f8b5572f96a5481",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:26:38.8211064Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:23:23.017999Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/coredeps/Dockerfile"
             }
           ]
         },
@@ -440,14 +457,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/android/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-android-20200407092345-1517ea2"
+                "ubuntu-18.04-android-20200409132031-1517ea2"
               ],
-              "digest": "sha256:c5cb284527f3f73d2b043816ce6a9ed0f4afaaaf01fd8210373fc9602f31d623",
+              "digest": "sha256:829bdc97c3edc10d12a9fbcc9c278bde7185d5b34b454456e446c9f02716c67e",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:28:48.7874208Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:25:30.3031005Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/1517ea28a64f3834dd4c187f2766b36fe47d6a86/src/ubuntu/18.04/android/Dockerfile"
             }
           ]
         },
@@ -456,14 +473,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/webassembly/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-webassembly-20200407092345-059fef0"
+                "ubuntu-18.04-webassembly-20200409132031-f70ea41"
               ],
-              "digest": "sha256:d4788c9144c391f41b24c11781f680990a86a210cad66e3c01546d81f2d9df1e",
+              "digest": "sha256:4bf3a71f74767938c566b85168386d9b38fcae329e8895645c4ee9904deed39f",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:30:00.7294167Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:26:45.4543333Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f70ea4164a3a0d5930d06828274ef9bf6e413209/src/ubuntu/18.04/webassembly/Dockerfile"
             }
           ]
         },
@@ -472,14 +489,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/crossdeps/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-crossdeps-20200407092345-3d73ec8"
+                "ubuntu-18.04-crossdeps-20200409132031-3d73ec8"
               ],
-              "digest": "sha256:1b31dd7f03605a7d67c3cabd98e2aca070c3f65ccc43035517409cc19749348e",
+              "digest": "sha256:88a786cbb26eb1350ba672214314f73450424fb1ecbd1cf8bc27521b44d1a53b",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:33:11.8137486Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:29:29.9720217Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/3d73ec85b80848ef21b3b11d861a1e834cba41f0/src/ubuntu/18.04/crossdeps/Dockerfile"
             }
           ]
         },
@@ -488,14 +505,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/cross/arm64/16.04/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-arm64-16.04-20200407092345-68b9c6d"
+                "ubuntu-18.04-cross-arm64-16.04-20200409132031-68b9c6d"
               ],
-              "digest": "sha256:d5dd92385aa2da24356600a66644cb39a0df59b0dcaaa8aa5261161b43a13a7b",
+              "digest": "sha256:748408a463ade6072abdf3b17af4beff95bb127d4df1806be6c6f9d3b161168f",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:45:54.8010066Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:42:17.752281Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm64/16.04/Dockerfile"
             }
           ]
         },
@@ -504,14 +521,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/cross/arm64/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-arm64-20200407092345-68b9c6d"
+                "ubuntu-18.04-cross-arm64-20200409132031-68b9c6d"
               ],
-              "digest": "sha256:234da81920c7144814c248fce919360ce5408910c64361f71ef81e8068342a23",
+              "digest": "sha256:4f297135d81a41d3a3a46568b8d1e8e921d040862bcc451cc8786b4d6f26e5fd",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:59:14.0136531Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:55:27.5353937Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64/Dockerfile"
             }
           ]
         },
@@ -520,14 +537,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/cross/arm64-alpine/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-arm64-alpine-20200407092345-68b9c6d"
+                "ubuntu-18.04-cross-arm64-alpine-20200409132031-68b9c6d"
               ],
-              "digest": "sha256:182a4fd5f8480abd0a0fb6f86acc329032fa3203030758450196730b756c0677",
+              "digest": "sha256:38e195fd4678dddbab6a6ae3d0ea986f1db762143c55d7785223a85ffaa9719c",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T10:09:23.3963577Z",
-              "commitUrl": null
+              "created": "2020-04-09T14:05:55.5745668Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64-alpine/Dockerfile"
             }
           ]
         },
@@ -536,14 +553,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/cross/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-20200407092345-a84b0d2"
+                "ubuntu-18.04-cross-20200409132031-a84b0d2"
               ],
-              "digest": "sha256:eebd823ad6acbdca78185baa4b931f76b54875d65b0b06ab6902f68af550bf46",
+              "digest": "sha256:b11fdc07386dd84b9b6ffab768510b78978956e612d78feeeb46babeb165e424",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T10:23:11.7163737Z",
-              "commitUrl": null
+              "created": "2020-04-09T14:20:20.2764764Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/Dockerfile"
             }
           ]
         },
@@ -552,14 +569,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/cross/arm/16.04/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-arm-16.04-20200407092345-68b9c6d"
+                "ubuntu-18.04-cross-arm-16.04-20200409132031-68b9c6d"
               ],
-              "digest": "sha256:3a50a3fa6f98a28b23224b184f89a3016f7ce4fc2dcb9588af9adc71b5764a1d",
+              "digest": "sha256:3fa883f3eed7ed1112ad030c63ec55ac3cb1f0e3b7981240e59437b7be9db081",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T10:36:32.3782982Z",
-              "commitUrl": null
+              "created": "2020-04-09T14:33:43.0761635Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm/16.04/Dockerfile"
             }
           ]
         },
@@ -568,14 +585,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/cross/freebsd/11/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-freebsd-11-20200407092345-a84b0d2"
+                "ubuntu-18.04-cross-freebsd-11-20200409132031-a84b0d2"
               ],
-              "digest": "sha256:fbb236ff72416bc17c657697a12e63f1c388d3fdd60b1ddf96a5368028c33f14",
+              "digest": "sha256:6883f78460fb4a432029a762895afead5fc8e36a2c0d8a8099b924776bb391a1",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T10:39:32.666236Z",
-              "commitUrl": null
+              "created": "2020-04-09T14:37:07.8937175Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/11/Dockerfile"
             }
           ]
         },
@@ -584,14 +601,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/cross/freebsd/12/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-freebsd-12-20200407092345-a84b0d2"
+                "ubuntu-18.04-cross-freebsd-12-20200409132031-a84b0d2"
               ],
-              "digest": "sha256:e16a27f104ff078bf17aa9cdc8a21c03aba181ca72539a538c22ced39b0d408f",
+              "digest": "sha256:7f7c8349e3fde8348a1522560d9953d8f156c3f6ff2fc52dcbac4ae55b7b180c",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T10:43:03.8882654Z",
-              "commitUrl": null
+              "created": "2020-04-09T14:40:55.7962316Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/12/Dockerfile"
             }
           ]
         },
@@ -717,15 +734,15 @@
             {
               "dockerfile": "src/ubuntu/18.04/amd64/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-20200407092310-85814b7"
+                "ubuntu-18.04-20200409131003-85814b7"
               ],
-              "digest": "sha256:b37aaa2273ad3669af4c6b192a6f027ad46e0eeef7eca13c0eafe72cb8030282",
+              "digest": "sha256:0fbee565db541aae7c35f97351dbcdcb300204e0898c1e1dca126df80e000b6e",
               "baseImageDigest": "ubuntu@sha256:bec5a2727be7fff3d308193cfde3491f8fba1a2ba392b7546b43a051853a341d",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:29:28.9769092Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:15:56.6082165Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/amd64/Dockerfile"
             }
           ]
         },
@@ -768,14 +785,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/debpkg/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-debpkg-20200407092310-cfdd435"
+                "ubuntu-18.04-debpkg-20200409131003-cfdd435"
               ],
-              "digest": "sha256:4d48dba494ea680455fe469ecc2b1c92f17597b96ce8b5506712f42479c00902",
+              "digest": "sha256:17b22ddaaeed674604f4fef0e93f27d66c91b30aa851995598b111e6fb18dd24",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:30:23.0096917Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:16:47.8810957Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cfdd435784925f9e02090857adccacc3ffcba4ef/src/ubuntu/18.04/debpkg/Dockerfile"
             }
           ]
         },
@@ -784,15 +801,15 @@
             {
               "dockerfile": "src/ubuntu/18.04/helix/arm32v7/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-helix-arm32v7-20200407092238-bfcd90a"
+                "ubuntu-18.04-helix-arm32v7-20200409130016-bfcd90a"
               ],
-              "digest": "sha256:62ae8a048599f815782191d9bb6a83740815e77e5886de44d7a9743e25f3f66b",
+              "digest": "sha256:a4ee7390a5a8711633789bd18d6e999cd9bc6d3ef5109e2a8e417d96dd9db460",
               "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-04-07T09:29:36.0964422Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:07:02.2412775Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/helix/arm32v7/Dockerfile"
             }
           ]
         },
@@ -801,15 +818,15 @@
             {
               "dockerfile": "src/ubuntu/18.04/helix/arm64v8/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-helix-arm64v8-20200407092247-bfcd90a"
+                "ubuntu-18.04-helix-arm64v8-20200409130029-bfcd90a"
               ],
-              "digest": "sha256:a363cc396f2d0a72264bb6b9d8244ae8967a506ed38f33a46fa996b8fae1799e",
+              "digest": "sha256:2053b0017640528e9c4041da95481c7da3b8eb379b1a77c25059fbc0c2c53684",
               "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm64",
-              "created": "2020-04-07T09:29:46.3520263Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:07:27.4199512Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/helix/arm64v8/Dockerfile"
             }
           ]
         },
@@ -988,15 +1005,15 @@
             {
               "dockerfile": "src/ubuntu/18.04/arm32v7/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-arm32v7-20200407092246-bfcd90a"
+                "ubuntu-18.04-arm32v7-20200409130018-bfcd90a"
               ],
-              "digest": "sha256:5158acd3762a90a31a9be81554b2b08086839095792dcf67ce2e6348693c9516",
+              "digest": "sha256:173e0251f72229b956d82058fcf70a64d4cb670804c3daa8ea58636655657b08",
               "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-04-07T09:24:56.5357189Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:02:42.5793479Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm32v7/Dockerfile"
             }
           ]
         },
@@ -1005,15 +1022,15 @@
             {
               "dockerfile": "src/ubuntu/18.04/arm64v8/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-arm64v8-20200407092239-bfcd90a"
+                "ubuntu-18.04-arm64v8-20200409130019-bfcd90a"
               ],
-              "digest": "sha256:c828076013bd9551b888928452af170260294d15902912767c0cc3a75f00918c",
+              "digest": "sha256:4642f1287e802fe20cb090b143f1d7f3b1baff216c3a3e6d92fb82ab38dc7b05",
               "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm64",
-              "created": "2020-04-07T09:24:55.3248761Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:02:34.1035656Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm64v8/Dockerfile"
             }
           ]
         },
@@ -1022,14 +1039,14 @@
             {
               "dockerfile": "src/ubuntu/18.04/source-build/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-source-build-20200407092310-ed32d26"
+                "ubuntu-18.04-source-build-20200409131003-ed32d26"
               ],
-              "digest": "sha256:67d538288183625a7901509abfce5d1e7794e66a846a6533cc883fe2644e8a53",
+              "digest": "sha256:761815407f5dac75c86e03ed604522489dd15f72e49a5de733d8e38f87718dbc",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-07T09:30:36.1971671Z",
-              "commitUrl": null
+              "created": "2020-04-09T13:16:57.633939Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/ed32d26b6173cb6050c1734391bcb89f9ed2682d/src/ubuntu/18.04/source-build/Dockerfile"
             }
           ]
         },

--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -7,67 +7,294 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/fedora/30/amd64/Dockerfile",
+              "dockerfile": "src/ubuntu/18.04/amd64/Dockerfile",
               "simpleTags": [
-                "fedora-30-20200409151819-bfcd90a"
+                "ubuntu-18.04-20200409131003-85814b7"
               ],
-              "digest": "sha256:716c61a5ef31d9dfd88517cb6d55a5b416f56fa309ed3059f2eb82e1f07dac97",
-              "baseImageDigest": "fedora@sha256:3a0c8c86d8ac2d1bbcfd08d40d3b757337f7916fb14f40efcb1d1137a4edef45",
+              "digest": "sha256:0fbee565db541aae7c35f97351dbcdcb300204e0898c1e1dca126df80e000b6e",
+              "baseImageDigest": "ubuntu@sha256:bec5a2727be7fff3d308193cfde3491f8fba1a2ba392b7546b43a051853a341d",
               "osType": "Linux",
-              "osVersion": "Fedora 30",
+              "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T15:24:30.3335593Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/fedora/30/amd64/Dockerfile"
+              "created": "2020-04-09T13:15:56.6082165Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/amd64/Dockerfile"
             }
           ]
         },
         {
           "platforms": [
             {
-              "dockerfile": "src/fedora/30/helix/amd64/Dockerfile",
+              "dockerfile": "src/ubuntu/18.04/android/Dockerfile",
               "simpleTags": [
-                "fedora-30-helix-20200409151819-4f8cef7"
+                "ubuntu-18.04-android-20200409132031-1517ea2"
               ],
-              "digest": "sha256:ae3e29670375cd2615d6984eb6f8f4cf47e663a4eca8bc691716fa78f9914a37",
+              "digest": "sha256:829bdc97c3edc10d12a9fbcc9c278bde7185d5b34b454456e446c9f02716c67e",
               "osType": "Linux",
-              "osVersion": "Fedora 30",
+              "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T15:26:55.426846Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4f8cef786242dbb97c6454787f3f125df2ec5865/src/fedora/30/helix/amd64/Dockerfile"
+              "created": "2020-04-09T13:25:30.3031005Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/1517ea28a64f3834dd4c187f2766b36fe47d6a86/src/ubuntu/18.04/android/Dockerfile"
             }
           ]
         },
         {
           "platforms": [
             {
-              "dockerfile": "src/fedora/31/amd64/Dockerfile",
+              "dockerfile": "src/ubuntu/18.04/arm32v7/Dockerfile",
               "simpleTags": [
-                "fedora-31-20200409151813-02f7c7e"
+                "ubuntu-18.04-arm32v7-20200409130018-bfcd90a"
               ],
-              "digest": "sha256:697404c301bbec79b27f6a4560e6d788e14cefe6147b0889453603ed95c69418",
-              "baseImageDigest": "fedora@sha256:c97879f8bebe49744307ea5c77ffc76c7cc97f3ddec72fb9a394bd4e4519b388",
+              "digest": "sha256:173e0251f72229b956d82058fcf70a64d4cb670804c3daa8ea58636655657b08",
+              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
               "osType": "Linux",
-              "osVersion": "Fedora 31",
-              "architecture": "amd64",
-              "created": "2020-04-09T15:21:56.0409387Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/02f7c7e83342b4be0509bbcb088477456286c807/src/fedora/31/amd64/Dockerfile"
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-04-09T13:02:42.5793479Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm32v7/Dockerfile"
             }
           ]
         },
         {
           "platforms": [
             {
-              "dockerfile": "src/fedora/rawhide/amd64/Dockerfile",
+              "dockerfile": "src/ubuntu/18.04/arm64v8/Dockerfile",
               "simpleTags": [
-                "fedora-rawhide-20200409151818-2ad2edd"
+                "ubuntu-18.04-arm64v8-20200409130019-bfcd90a"
               ],
-              "digest": "sha256:1593ed10e3a8ed6c7632eb7f86f72f580709c57fd998c0d7207e0de9a4556525",
-              "baseImageDigest": "fedora@sha256:42e73b6de8615fe67780b2bea86b6ef5177981b9a0f40e86e0e37cf317dd6b77",
+              "digest": "sha256:4642f1287e802fe20cb090b143f1d7f3b1baff216c3a3e6d92fb82ab38dc7b05",
+              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
               "osType": "Linux",
-              "osVersion": "Fedora-rawhide",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-04-09T13:02:34.1035656Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm64v8/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/coredeps/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-coredeps-20200409132031-85814b7"
+              ],
+              "digest": "sha256:84297356fb30d5f7f258bbc9b93f12b036dbdfe3662ee7e204fade6a48d5396d",
+              "baseImageDigest": "mcr.microsoft.com/powershell@sha256:e5eb8e021d1f3b0c7d4343d4c16ec68b284a4a0d5446b6fe2f8b5572f96a5481",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T15:22:07.1586285Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2ad2edd1bfbd300166973089f491f681465fd299/src/fedora/rawhide/amd64/Dockerfile"
+              "created": "2020-04-09T13:23:23.017999Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/coredeps/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm/16.04/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm-16.04-20200409132031-68b9c6d"
+              ],
+              "digest": "sha256:3fa883f3eed7ed1112ad030c63ec55ac3cb1f0e3b7981240e59437b7be9db081",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:33:43.0761635Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm/16.04/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm64-alpine/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm64-alpine-20200409132031-68b9c6d"
+              ],
+              "digest": "sha256:38e195fd4678dddbab6a6ae3d0ea986f1db762143c55d7785223a85ffaa9719c",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:05:55.5745668Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64-alpine/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm64/16.04/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm64-16.04-20200409132031-68b9c6d"
+              ],
+              "digest": "sha256:748408a463ade6072abdf3b17af4beff95bb127d4df1806be6c6f9d3b161168f",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T13:42:17.752281Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm64/16.04/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm64/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm64-20200409132031-68b9c6d"
+              ],
+              "digest": "sha256:4f297135d81a41d3a3a46568b8d1e8e921d040862bcc451cc8786b4d6f26e5fd",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T13:55:27.5353937Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-20200409132031-a84b0d2"
+              ],
+              "digest": "sha256:b11fdc07386dd84b9b6ffab768510b78978956e612d78feeeb46babeb165e424",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:20:20.2764764Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/freebsd/11/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-freebsd-11-20200409132031-a84b0d2"
+              ],
+              "digest": "sha256:6883f78460fb4a432029a762895afead5fc8e36a2c0d8a8099b924776bb391a1",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:37:07.8937175Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/11/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/freebsd/12/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-freebsd-12-20200409132031-a84b0d2"
+              ],
+              "digest": "sha256:7f7c8349e3fde8348a1522560d9953d8f156c3f6ff2fc52dcbac4ae55b7b180c",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:40:55.7962316Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/12/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/crossdeps/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-crossdeps-20200409132031-3d73ec8"
+              ],
+              "digest": "sha256:88a786cbb26eb1350ba672214314f73450424fb1ecbd1cf8bc27521b44d1a53b",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T13:29:29.9720217Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/3d73ec85b80848ef21b3b11d861a1e834cba41f0/src/ubuntu/18.04/crossdeps/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/debpkg/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-debpkg-20200409131003-cfdd435"
+              ],
+              "digest": "sha256:17b22ddaaeed674604f4fef0e93f27d66c91b30aa851995598b111e6fb18dd24",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T13:16:47.8810957Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cfdd435784925f9e02090857adccacc3ffcba4ef/src/ubuntu/18.04/debpkg/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/helix/arm32v7/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-helix-arm32v7-20200409130016-bfcd90a"
+              ],
+              "digest": "sha256:a4ee7390a5a8711633789bd18d6e999cd9bc6d3ef5109e2a8e417d96dd9db460",
+              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-04-09T13:07:02.2412775Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/helix/arm32v7/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-helix-arm64v8-20200409130029-bfcd90a"
+              ],
+              "digest": "sha256:2053b0017640528e9c4041da95481c7da3b8eb379b1a77c25059fbc0c2c53684",
+              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-04-09T13:07:27.4199512Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/helix/arm64v8/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/source-build/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-source-build-20200409131003-ed32d26"
+              ],
+              "digest": "sha256:761815407f5dac75c86e03ed604522489dd15f72e49a5de733d8e38f87718dbc",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T13:16:57.633939Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/ed32d26b6173cb6050c1734391bcb89f9ed2682d/src/ubuntu/18.04/source-build/Dockerfile"
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/webassembly/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-webassembly-20200409132031-f70ea41"
+              ],
+              "digest": "sha256:4bf3a71f74767938c566b85168386d9b38fcae329e8895645c4ee9904deed39f",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-09T13:26:45.4543333Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f70ea4164a3a0d5930d06828274ef9bf6e413209/src/ubuntu/18.04/webassembly/Dockerfile"
             }
           ]
         }

--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -7,67 +7,414 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/ubuntu/18.04/amd64/Dockerfile",
+              "dockerfile": "src/alpine/3.9/amd64/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-20200409131003-85814b7"
+                "alpine-3.9-20200401132659-bfba074"
               ],
-              "digest": "sha256:0fbee565db541aae7c35f97351dbcdcb300204e0898c1e1dca126df80e000b6e",
-              "baseImageDigest": "ubuntu@sha256:bec5a2727be7fff3d308193cfde3491f8fba1a2ba392b7546b43a051853a341d",
+              "digest": "sha256:118a69f4a5312bdc4115db1067cb263c1e5ea7c5e7fada1a4a3fc11d21ed3316",
+              "baseImageDigest": "alpine@sha256:115731bab0862031b44766733890091c17924f9b7781b79997f5f163be262178",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "Alpine 3.9",
               "architecture": "amd64",
-              "created": "2020-04-09T13:15:56.6082165Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/amd64/Dockerfile"
+              "created": "2020-04-01T13:27:38.4021701Z",
+              "commitUrl": null
             }
           ]
         },
         {
           "platforms": [
             {
-              "dockerfile": "src/ubuntu/18.04/android/Dockerfile",
+              "dockerfile": "src/alpine/3.9/WithNode/amd64/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-android-20200409132031-1517ea2"
+                "alpine-3.9-WithNode-20200401132659-0fc54a3"
               ],
-              "digest": "sha256:829bdc97c3edc10d12a9fbcc9c278bde7185d5b34b454456e446c9f02716c67e",
+              "digest": "sha256:08b434b3ce30ac323908bc657b3cd202a6048568e07b7b7f8c7d5edc6f15c7f6",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "Alpine 3.9",
               "architecture": "amd64",
-              "created": "2020-04-09T13:25:30.3031005Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/1517ea28a64f3834dd4c187f2766b36fe47d6a86/src/ubuntu/18.04/android/Dockerfile"
+              "created": "2020-04-01T13:59:56.2757188Z",
+              "commitUrl": null
             }
           ]
         },
         {
           "platforms": [
             {
-              "dockerfile": "src/ubuntu/18.04/arm32v7/Dockerfile",
+              "dockerfile": "src/alpine/3.9/helix/amd64/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-arm32v7-20200409130018-bfcd90a"
+                "alpine-3.9-helix-20200401132716-bfcd90a"
               ],
-              "digest": "sha256:173e0251f72229b956d82058fcf70a64d4cb670804c3daa8ea58636655657b08",
-              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
+              "digest": "sha256:89b7620b5adb2f88f09aceaaa67e7b4e0f92f24b37971e55960de61fddd86f47",
+              "baseImageDigest": "python@sha256:d3953acf09227baf26919dbb4dc3637e8015ce46debbed4cf5444702728cfc16",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "arm32",
-              "created": "2020-04-09T13:02:42.5793479Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm32v7/Dockerfile"
+              "osVersion": "Alpine 3.9",
+              "architecture": "amd64",
+              "created": "2020-04-01T13:28:56.4973969Z",
+              "commitUrl": null
             }
           ]
         },
         {
           "platforms": [
             {
-              "dockerfile": "src/ubuntu/18.04/arm64v8/Dockerfile",
+              "dockerfile": "src/alpine/3.10/helix/amd64/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-arm64v8-20200409130019-bfcd90a"
+                "alpine-3.10-helix-20200401132658-bfcd90a"
               ],
-              "digest": "sha256:4642f1287e802fe20cb090b143f1d7f3b1baff216c3a3e6d92fb82ab38dc7b05",
-              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
+              "digest": "sha256:3fe3f03ab2b08f48214b5264d574054b847c8433e7d8783d58c2c3039fe1aa95",
+              "baseImageDigest": "python@sha256:9706f71cf923afd8b1e72c0ad5af5fe8e9d70240e3fefc6c6a75535f96d49c17",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "arm64",
-              "created": "2020-04-09T13:02:34.1035656Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm64v8/Dockerfile"
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-04-01T13:28:43.8813129Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.11/helix/amd64/Dockerfile",
+              "simpleTags": [
+                "alpine-3.11-helix-20200401132710-bfcd90a"
+              ],
+              "digest": "sha256:b98da5a0347e60a7e4c27771aaddb8242074a735e4d8c10450c3d6b792d7a977",
+              "baseImageDigest": "python@sha256:4a704ebee45695fa91125301e43eee08a85fc984d05cc75650cc66fad7826c56",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-04-01T13:28:59.7932862Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.8/helix/amd64/Dockerfile",
+              "simpleTags": [
+                "alpine-3.8-helix-20200401132659-bfcd90a"
+              ],
+              "digest": "sha256:4841b1f68aa076c008faf76ad2bbeeb4a5756da1713ea48f94f331f937d2501d",
+              "baseImageDigest": "python@sha256:3491d1abd29b3f87ca5cb1afd34bc696855a2403df1ff854da55cb6754af1ff8",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.8",
+              "architecture": "amd64",
+              "created": "2020-04-01T13:28:49.0023813Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/8/Dockerfile",
+              "simpleTags": [
+                "centos-8-20200402192642-9e679d4"
+              ],
+              "digest": "sha256:1bdca10dc8c1882e0bcd91b28dde9b86d6883f944668b42b737fc1d9d1eeea7d",
+              "baseImageDigest": "centos@sha256:fe8d824220415eed5477b63addf40fb06c3b049404242b31982106ac204f6700",
+              "osType": "Linux",
+              "osVersion": "Centos 8",
+              "architecture": "amd64",
+              "created": "2020-04-02T20:04:13.6377766Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/8/source-build/Dockerfile",
+              "simpleTags": [
+                "centos-8-source-build-20200402192642-9e679d4"
+              ],
+              "digest": "sha256:bfc74dc0a23fb9037502c478cab4713b7f23cda5fcaa40d306b9f97ce350bedf",
+              "osType": "Linux",
+              "osVersion": "Centos 8",
+              "architecture": "amd64",
+              "created": "2020-04-02T20:04:27.0008422Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/8/rpmpkg/Dockerfile",
+              "simpleTags": [
+                "centos-8-rpmpkg-20200402192642-daa5116"
+              ],
+              "digest": "sha256:430581cabccf5defcf9c52405e614729da13c10ebcc038856046190b573e449b",
+              "osType": "Linux",
+              "osVersion": "Centos 8",
+              "architecture": "amd64",
+              "created": "2020-04-02T20:11:03.1433752Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/7/Dockerfile",
+              "simpleTags": [
+                "centos-7-359e48e-20200313130914"
+              ],
+              "digest": "sha256:1527247d6ca5a4b398691739c835df7c96fe5d852f08803884f6eb84879e08b1",
+              "baseImageDigest": "centos@sha256:4a701376d03f6b39b8c2a8f4a8e499441b0d567f9ab9d58e4991de4472fb813c",
+              "osType": "Linux",
+              "osVersion": "Centos 7",
+              "architecture": "amd64",
+              "created": "2020-03-13T15:36:09.1107229Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/7/mlnet/Dockerfile",
+              "simpleTags": [
+                "centos-7-mlnet-bfcd90a-20200313130914"
+              ],
+              "digest": "sha256:7cc7c181778662d70071acdf1cc17f3a1f07b2775eb94e8eda25a09e0c8a0dcd",
+              "osType": "Linux",
+              "osVersion": "Centos 7",
+              "architecture": "amd64",
+              "created": "2020-03-13T15:36:46.2750714Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/7/rpmpkg/Dockerfile",
+              "simpleTags": [
+                "centos-7-rpmpkg-19d155e-20200313130914"
+              ],
+              "digest": "sha256:40d5a125fa708e0e12bde3f75f5a59d9f1c16d6e718c1fc41422bd1fd27b0f35",
+              "osType": "Linux",
+              "osVersion": "Centos 7",
+              "architecture": "amd64",
+              "created": "2020-03-13T15:37:26.2004915Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/centos/6/Dockerfile",
+              "simpleTags": [
+                "centos-6-203142e-20200131220151"
+              ],
+              "digest": null,
+              "baseImageDigest": "centos@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7",
+              "osType": "Linux",
+              "osVersion": "Centos 6",
+              "architecture": "amd64",
+              "created": "2020-02-01T00:24:06.2326232Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/stretch-slim/docker-testrunner/Dockerfile",
+              "simpleTags": [
+                "debian-stretch-slim-docker-testrunner-20200331133050-d61254f"
+              ],
+              "digest": "sha256:b6aa114a3428ec1988d38671c6f2172a59b122a8bdd30cce032bf4cbdec72d94",
+              "baseImageDigest": "debian@sha256:1a470b92197dd16a46f7aa9cb308fa91f7d0948e0dccd625a03cbbdf2d4516e6",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "amd64",
+              "created": "2020-03-31T13:31:30.1265672Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/stretch/Dockerfile",
+              "simpleTags": [
+                "debian-stretch-20200331133109-ed32d26"
+              ],
+              "digest": "sha256:df983af5394fe30c2fb3f77829293dbb0201271e9bb980e2d8fc9655ce9193dd",
+              "baseImageDigest": "debian@sha256:344470192d10cf7cf0bedcb183effbe99065829a8dbe68e65e703faf46fc10c1",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "amd64",
+              "created": "2020-03-31T13:33:37.9255109Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/stretch/source-build/Dockerfile",
+              "simpleTags": [
+                "debian-stretch-source-build-20200331133109-ed32d26"
+              ],
+              "digest": "sha256:75f7f8512b12dd07b089f860bca377030e287d3814dbe24bb96748454ccb744b",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "amd64",
+              "created": "2020-03-31T13:33:49.6374387Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/fedora/30/amd64/Dockerfile",
+              "simpleTags": [
+                "fedora-30-bfcd90a-20200324132732"
+              ],
+              "digest": "sha256:7db110d49225f5a13b4da291bda23c13087c11662b8830010fc6f122508ac44c",
+              "baseImageDigest": "fedora@sha256:3a0c8c86d8ac2d1bbcfd08d40d3b757337f7916fb14f40efcb1d1137a4edef45",
+              "osType": "Linux",
+              "osVersion": "Fedora 30",
+              "architecture": "amd64",
+              "created": "2020-03-24T13:31:58.6270408Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/fedora/30/helix/amd64/Dockerfile",
+              "simpleTags": [
+                "fedora-30-helix-4f8cef7-20200324132732"
+              ],
+              "digest": "sha256:6ecde80a0144530b54cc37c23922c6cb239586ecc6dfb0301ee38746825660f9",
+              "osType": "Linux",
+              "osVersion": "Fedora 30",
+              "architecture": "amd64",
+              "created": "2020-03-24T13:34:01.0749262Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/fedora/31/amd64/Dockerfile",
+              "simpleTags": [
+                "fedora-31-02f7c7e-20200324132728"
+              ],
+              "digest": "sha256:9293ce4e38b1cbe7f9f96dc2bd3ee78717d26c2f848e2b0819c0a3d2b3ba8345",
+              "baseImageDigest": "fedora@sha256:c97879f8bebe49744307ea5c77ffc76c7cc97f3ddec72fb9a394bd4e4519b388",
+              "osType": "Linux",
+              "osVersion": "Fedora 31",
+              "architecture": "amd64",
+              "created": "2020-03-24T13:31:06.9915135Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-20200401182342-fe8b85d"
+              ],
+              "digest": "sha256:8dd2278c3b9c3d32c74db9b17d5d90b9c6d9e17a8f255965c3ad48bd78c8daf0",
+              "baseImageDigest": "ubuntu@sha256:e9938f45e51d9ff46e2b05a62e0546d0f07489b7f22fbc5288defe760599e38a",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T18:26:15.4467212Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/debpkg/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-debpkg-20200401182342-cfdd435"
+              ],
+              "digest": "sha256:4a4db9e143b85dd52ac8af303991af9f277479321231956fe51d06144f4df7a1",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T18:26:53.6743189Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/coredeps/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-coredeps-20200401182354-bfcd90a"
+              ],
+              "digest": "sha256:39afe5f7b93083dee97ae68698f0920bb6dbd20ba35ca7c735a3d0f8116f47d5",
+              "baseImageDigest": "mcr.microsoft.com/powershell@sha256:828aaedfbfbf6885800754618a99b7126f5dde4bb51d19a61a22f9a6044f70ee",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T18:25:30.03891Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/crossdeps/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-crossdeps-20200401182354-09ec757"
+              ],
+              "digest": "sha256:2c465138fc419f9102b1c3562dae8db49263437799d48b198ebe6a71958b658b",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T18:26:59.2438539Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/cross/arm64/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-cross-arm64-20200401182354-cfdd435"
+              ],
+              "digest": "sha256:a9e677ce58bbf0a924c4393ff583d3d6b0f302b7c38ae01e72e2517253a495d7",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T18:39:27.9009072Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/cross/arm64-alpine/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-cross-arm64-alpine-20200401182354-406629a"
+              ],
+              "digest": "sha256:71f16062d670764f75043566c89ab72d8046e78ac02c1a90e23e0c45b7d0b9ee",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T18:47:45.7944934Z",
+              "commitUrl": null
             }
           ]
         },
@@ -76,209 +423,31 @@
             {
               "dockerfile": "src/ubuntu/18.04/coredeps/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-coredeps-20200409132031-85814b7"
+                "ubuntu-18.04-coredeps-20200407092345-85814b7"
               ],
-              "digest": "sha256:84297356fb30d5f7f258bbc9b93f12b036dbdfe3662ee7e204fade6a48d5396d",
+              "digest": "sha256:8a8f23460b989f634860c541c2dd7733c3559fa4b79c6d17737aaeb3aa25b175",
               "baseImageDigest": "mcr.microsoft.com/powershell@sha256:e5eb8e021d1f3b0c7d4343d4c16ec68b284a4a0d5446b6fe2f8b5572f96a5481",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T13:23:23.017999Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/coredeps/Dockerfile"
+              "created": "2020-04-07T09:26:38.8211064Z",
+              "commitUrl": null
             }
           ]
         },
         {
           "platforms": [
             {
-              "dockerfile": "src/ubuntu/18.04/cross/arm/16.04/Dockerfile",
+              "dockerfile": "src/ubuntu/18.04/android/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-cross-arm-16.04-20200409132031-68b9c6d"
+                "ubuntu-18.04-android-20200407092345-1517ea2"
               ],
-              "digest": "sha256:3fa883f3eed7ed1112ad030c63ec55ac3cb1f0e3b7981240e59437b7be9db081",
+              "digest": "sha256:c5cb284527f3f73d2b043816ce6a9ed0f4afaaaf01fd8210373fc9602f31d623",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T14:33:43.0761635Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm/16.04/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/cross/arm64-alpine/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-cross-arm64-alpine-20200409132031-68b9c6d"
-              ],
-              "digest": "sha256:38e195fd4678dddbab6a6ae3d0ea986f1db762143c55d7785223a85ffaa9719c",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T14:05:55.5745668Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64-alpine/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/cross/arm64/16.04/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-cross-arm64-16.04-20200409132031-68b9c6d"
-              ],
-              "digest": "sha256:748408a463ade6072abdf3b17af4beff95bb127d4df1806be6c6f9d3b161168f",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T13:42:17.752281Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm64/16.04/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/cross/arm64/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-cross-arm64-20200409132031-68b9c6d"
-              ],
-              "digest": "sha256:4f297135d81a41d3a3a46568b8d1e8e921d040862bcc451cc8786b4d6f26e5fd",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T13:55:27.5353937Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/cross/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-cross-20200409132031-a84b0d2"
-              ],
-              "digest": "sha256:b11fdc07386dd84b9b6ffab768510b78978956e612d78feeeb46babeb165e424",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T14:20:20.2764764Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/cross/freebsd/11/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-cross-freebsd-11-20200409132031-a84b0d2"
-              ],
-              "digest": "sha256:6883f78460fb4a432029a762895afead5fc8e36a2c0d8a8099b924776bb391a1",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T14:37:07.8937175Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/11/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/cross/freebsd/12/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-cross-freebsd-12-20200409132031-a84b0d2"
-              ],
-              "digest": "sha256:7f7c8349e3fde8348a1522560d9953d8f156c3f6ff2fc52dcbac4ae55b7b180c",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T14:40:55.7962316Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/12/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/crossdeps/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-crossdeps-20200409132031-3d73ec8"
-              ],
-              "digest": "sha256:88a786cbb26eb1350ba672214314f73450424fb1ecbd1cf8bc27521b44d1a53b",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T13:29:29.9720217Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/3d73ec85b80848ef21b3b11d861a1e834cba41f0/src/ubuntu/18.04/crossdeps/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/debpkg/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-debpkg-20200409131003-cfdd435"
-              ],
-              "digest": "sha256:17b22ddaaeed674604f4fef0e93f27d66c91b30aa851995598b111e6fb18dd24",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T13:16:47.8810957Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cfdd435784925f9e02090857adccacc3ffcba4ef/src/ubuntu/18.04/debpkg/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/helix/arm32v7/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-helix-arm32v7-20200409130016-bfcd90a"
-              ],
-              "digest": "sha256:a4ee7390a5a8711633789bd18d6e999cd9bc6d3ef5109e2a8e417d96dd9db460",
-              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "arm32",
-              "created": "2020-04-09T13:07:02.2412775Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/helix/arm32v7/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/helix/arm64v8/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-helix-arm64v8-20200409130029-bfcd90a"
-              ],
-              "digest": "sha256:2053b0017640528e9c4041da95481c7da3b8eb379b1a77c25059fbc0c2c53684",
-              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "arm64",
-              "created": "2020-04-09T13:07:27.4199512Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/helix/arm64v8/Dockerfile"
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/ubuntu/18.04/source-build/Dockerfile",
-              "simpleTags": [
-                "ubuntu-18.04-source-build-20200409131003-ed32d26"
-              ],
-              "digest": "sha256:761815407f5dac75c86e03ed604522489dd15f72e49a5de733d8e38f87718dbc",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T13:16:57.633939Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/ed32d26b6173cb6050c1734391bcb89f9ed2682d/src/ubuntu/18.04/source-build/Dockerfile"
+              "created": "2020-04-07T09:28:48.7874208Z",
+              "commitUrl": null
             }
           ]
         },
@@ -287,14 +456,631 @@
             {
               "dockerfile": "src/ubuntu/18.04/webassembly/Dockerfile",
               "simpleTags": [
-                "ubuntu-18.04-webassembly-20200409132031-f70ea41"
+                "ubuntu-18.04-webassembly-20200407092345-059fef0"
               ],
-              "digest": "sha256:4bf3a71f74767938c566b85168386d9b38fcae329e8895645c4ee9904deed39f",
+              "digest": "sha256:d4788c9144c391f41b24c11781f680990a86a210cad66e3c01546d81f2d9df1e",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T13:26:45.4543333Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f70ea4164a3a0d5930d06828274ef9bf6e413209/src/ubuntu/18.04/webassembly/Dockerfile"
+              "created": "2020-04-07T09:30:00.7294167Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/crossdeps/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-crossdeps-20200407092345-3d73ec8"
+              ],
+              "digest": "sha256:1b31dd7f03605a7d67c3cabd98e2aca070c3f65ccc43035517409cc19749348e",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T09:33:11.8137486Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm64/16.04/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm64-16.04-20200407092345-68b9c6d"
+              ],
+              "digest": "sha256:d5dd92385aa2da24356600a66644cb39a0df59b0dcaaa8aa5261161b43a13a7b",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T09:45:54.8010066Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm64/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm64-20200407092345-68b9c6d"
+              ],
+              "digest": "sha256:234da81920c7144814c248fce919360ce5408910c64361f71ef81e8068342a23",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T09:59:14.0136531Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm64-alpine/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm64-alpine-20200407092345-68b9c6d"
+              ],
+              "digest": "sha256:182a4fd5f8480abd0a0fb6f86acc329032fa3203030758450196730b756c0677",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T10:09:23.3963577Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-20200407092345-a84b0d2"
+              ],
+              "digest": "sha256:eebd823ad6acbdca78185baa4b931f76b54875d65b0b06ab6902f68af550bf46",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T10:23:11.7163737Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/arm/16.04/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-arm-16.04-20200407092345-68b9c6d"
+              ],
+              "digest": "sha256:3a50a3fa6f98a28b23224b184f89a3016f7ce4fc2dcb9588af9adc71b5764a1d",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T10:36:32.3782982Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/freebsd/11/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-freebsd-11-20200407092345-a84b0d2"
+              ],
+              "digest": "sha256:fbb236ff72416bc17c657697a12e63f1c388d3fdd60b1ddf96a5368028c33f14",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T10:39:32.666236Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/cross/freebsd/12/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-cross-freebsd-12-20200407092345-a84b0d2"
+              ],
+              "digest": "sha256:e16a27f104ff078bf17aa9cdc8a21c03aba181ca72539a538c22ced39b0d408f",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T10:43:03.8882654Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.8/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "alpine-3.8-helix-arm64v8-20200401132637-bfcd90a"
+              ],
+              "digest": "sha256:1c7a95f465dd4e4e87b05f3632c409d3817dc38f86af475ec606c6d44e301de0",
+              "baseImageDigest": "arm64v8/alpine@sha256:e802987f152d7826cf929ad4999fb3bb956ce7a30966aeb46c749f9120eaf22c",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.8",
+              "architecture": "arm64",
+              "created": "2020-04-01T13:30:41.7759786Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.10/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "alpine-3.10-helix-arm64v8-20200401132634-bfcd90a"
+              ],
+              "digest": "sha256:9bb6e95ca34b9c6479b36c93c9dea323617b81e3cd6fa4cb59f7ddcb78ff5392",
+              "baseImageDigest": "arm64v8/alpine@sha256:4491fd429b8ad188ba5e120782b2bbb704261fd2ef9942fcdee128c5fcc594d5",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "arm64",
+              "created": "2020-04-01T13:30:14.8074942Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.11/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "alpine-3.11-helix-arm64v8-20200401132634-bfcd90a"
+              ],
+              "digest": "sha256:bcc3f0efedc1eeb83c620d65dea8852f520a67e380d260cbfeaae4c9fa3a39e3",
+              "baseImageDigest": "arm64v8/alpine@sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "arm64",
+              "created": "2020-04-01T13:30:18.6132488Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/cross/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-cross-20200401182354-09ec757"
+              ],
+              "digest": "sha256:6937dd986471d098412e3c09ddfdb4c7aa7b7c241fb66cb81d524008cba23a40",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T19:00:45.7058192Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/helix/arm32v7/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-helix-arm32v7-20200401182323-bfcd90a"
+              ],
+              "digest": "sha256:d821f9d26c9ec057cb96e958282d22776285f9aead2db1474a1746120b3e89c1",
+              "baseImageDigest": "arm32v7/ubuntu@sha256:4faa0482a239dd826bab958f1ab22333568fcfa17a6a09c30806e69902878184",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "arm32",
+              "created": "2020-04-01T18:29:06.3373413Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-helix-arm64v8-20200401182336-bfcd90a"
+              ],
+              "digest": "sha256:e3c18ec38e2c2fcf349710d3979d6efb6494916ce36a3fec967cc7dc9e8b77cf",
+              "baseImageDigest": "arm64v8/ubuntu@sha256:c7ca486dce6710697a81e2d08796a865f48c6525a3f81f3aa936a4905c9846be",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "arm64",
+              "created": "2020-04-01T18:29:18.7319841Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/mlnet/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-mlnet-20200401182342-a50a721"
+              ],
+              "digest": "sha256:b0878e758a3a6c068b8e03312b418eae8b051ca2d012798993db7ead3deb5ac7",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "amd64",
+              "created": "2020-04-01T18:27:00.3143213Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/amd64/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-20200407092310-85814b7"
+              ],
+              "digest": "sha256:b37aaa2273ad3669af4c6b192a6f027ad46e0eeef7eca13c0eafe72cb8030282",
+              "baseImageDigest": "ubuntu@sha256:bec5a2727be7fff3d308193cfde3491f8fba1a2ba392b7546b43a051853a341d",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T09:29:28.9769092Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/19.04/helix/amd64/Dockerfile",
+              "simpleTags": [
+                "ubuntu-19.04-helix-amd64-bfcd90a-20200220203759"
+              ],
+              "digest": null,
+              "baseImageDigest": "ubuntu@sha256:2adeae829bf27a3399a0e7db8ae38d5adb89bcaf1bbef378240bc0e6724e8344",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 19.04",
+              "architecture": "amd64",
+              "created": "2020-02-20T20:40:18.6786269Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/19.10/helix/amd64/Dockerfile",
+              "simpleTags": [
+                "ubuntu-19.10-helix-amd64-bfcd90a-20200220203758"
+              ],
+              "digest": null,
+              "baseImageDigest": "ubuntu@sha256:bd5f4f235eb31768b2c5caf1988bbdc182d4fc3cb6ee4aca6c6d74613f256140",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 19.04",
+              "architecture": "amd64",
+              "created": "2020-02-20T20:40:24.7603243Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/debpkg/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-debpkg-20200407092310-cfdd435"
+              ],
+              "digest": "sha256:4d48dba494ea680455fe469ecc2b1c92f17597b96ce8b5506712f42479c00902",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T09:30:23.0096917Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/helix/arm32v7/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-helix-arm32v7-20200407092238-bfcd90a"
+              ],
+              "digest": "sha256:62ae8a048599f815782191d9bb6a83740815e77e5886de44d7a9743e25f3f66b",
+              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-04-07T09:29:36.0964422Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-helix-arm64v8-20200407092247-bfcd90a"
+              ],
+              "digest": "sha256:a363cc396f2d0a72264bb6b9d8244ae8967a506ed38f33a46fa996b8fae1799e",
+              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-04-07T09:29:46.3520263Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/iot/arm32v7/Dockerfile",
+              "simpleTags": [
+                "debian-iot-arm32v7-20200331150018-be5b37d"
+              ],
+              "digest": "sha256:14586daeb05379ce68e94dabe999bb9cb7fd51e6b73340bd997be044148b8cb0",
+              "baseImageDigest": "arm32v7/debian@sha256:6e333bfc4b73914b5bfa9c83eb026ef6cea410ff3ba19d739fd9c598fb3a34b8",
+              "osType": "Linux",
+              "osVersion": "Debian",
+              "architecture": "arm32",
+              "created": "2020-03-31T15:03:19.2572052Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/9/arm32v7/Dockerfile",
+              "simpleTags": [
+                "debian-9-arm32v7-20200331144448-bfcd90a"
+              ],
+              "digest": "sha256:a0a621fcba142ccaece1258c4efbf09cab1214f8aa8152a095582c872f473a48",
+              "baseImageDigest": "arm32v7/debian@sha256:3e684a4812b00349edcf39dfe0689e3d47991e2bae3a0f7267d02cd0701a2028",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "arm32",
+              "created": "2020-03-31T14:47:08.7412579Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/9/helix/arm32v7/Dockerfile",
+              "simpleTags": [
+                "debian-9-helix-arm32v7-20200331144957-bfcd90a"
+              ],
+              "digest": "sha256:52af9e2f5dc23a16c4460768c1beb50598664946c2d1eae7d82aa9a8150a6905",
+              "baseImageDigest": "arm32v7/debian@sha256:3e684a4812b00349edcf39dfe0689e3d47991e2bae3a0f7267d02cd0701a2028",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "arm32",
+              "created": "2020-03-31T14:56:08.7648315Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/9/arm64v8/Dockerfile",
+              "simpleTags": [
+                "debian-9-arm64v8-20200331141752-bfcd90a"
+              ],
+              "digest": "sha256:1aac40aea983c1289df05f1dfef0c2b10030237b2f2d8e60b3e2b3ddb95ab1af",
+              "baseImageDigest": "arm64v8/debian@sha256:7121737d076ee1a7d153580cab7a06e09c99899f88d09036aab3141a840d3414",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "arm64",
+              "created": "2020-03-31T14:20:30.3297863Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/9/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "debian-9-helix-arm64v8-20200331142323-bfcd90a"
+              ],
+              "digest": "sha256:ba936d1cee4e213f84d15eb4e5a233540d0b94a25f0a25588bb043e0ac6e8da8",
+              "baseImageDigest": "arm64v8/debian@sha256:7121737d076ee1a7d153580cab7a06e09c99899f88d09036aab3141a840d3414",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "arm64",
+              "created": "2020-03-31T14:29:43.145231Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/10/helix/amd64/Dockerfile",
+              "simpleTags": [
+                "debian-10-helix-amd64-20200331133052-bfcd90a"
+              ],
+              "digest": "sha256:f483ce35e8a3f87d0729a3bb9f9dfba288948f6ec713eb982d5e3c04f10ba5f8",
+              "baseImageDigest": "debian@sha256:125ab9ab9718f4dba6c3342407bb1923afce4f6b2a12b3a502d818274db9faf9",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-03-31T13:32:38.295888Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/10/helix/arm32v7/Dockerfile",
+              "simpleTags": [
+                "debian-10-helix-arm32v7-20200331143408-bfcd90a"
+              ],
+              "digest": "sha256:79dafd90d13452e9d4da6411fea3e0ab831d5b7b41757bad06075e4b3d346ac9",
+              "baseImageDigest": "arm32v7/debian@sha256:6e333bfc4b73914b5bfa9c83eb026ef6cea410ff3ba19d739fd9c598fb3a34b8",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm32",
+              "created": "2020-03-31T14:39:58.897295Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/debian/10/helix/arm64v8/Dockerfile",
+              "simpleTags": [
+                "debian-10-helix-arm64v8-20200331140648-bfcd90a"
+              ],
+              "digest": "sha256:e23c97c783cdb8f9f9ed5a8bea99d9d13d606a7dcfbb0ad727d90686c07da286",
+              "baseImageDigest": "arm64v8/debian@sha256:08c088d068ced4a3e65b1f11d385ce141e06078da395c6b1c98c97a2a4ff85cb",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm64",
+              "created": "2020-03-31T14:12:49.857181Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/arm32v7/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-arm32v7-20200401182324-bfcd90a"
+              ],
+              "digest": "sha256:969352dcc13de2a3ecab4f7c7d2214f3277fc399144d1aeb95f767270abbcf27",
+              "baseImageDigest": "arm32v7/ubuntu@sha256:4faa0482a239dd826bab958f1ab22333568fcfa17a6a09c30806e69902878184",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "arm32",
+              "created": "2020-04-01T18:25:22.2913109Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/16.04/arm64v8/Dockerfile",
+              "simpleTags": [
+                "ubuntu-16.04-arm64v8-20200401182324-bfcd90a"
+              ],
+              "digest": "sha256:6f17bcb4c70ac7f06867d839d44337fdf000a954338a213b6abf28402be3865a",
+              "baseImageDigest": "arm64v8/ubuntu@sha256:c7ca486dce6710697a81e2d08796a865f48c6525a3f81f3aa936a4905c9846be",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 16.04",
+              "architecture": "arm64",
+              "created": "2020-04-01T18:25:35.3434039Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/arm32v7/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-arm32v7-20200407092246-bfcd90a"
+              ],
+              "digest": "sha256:5158acd3762a90a31a9be81554b2b08086839095792dcf67ce2e6348693c9516",
+              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-04-07T09:24:56.5357189Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/arm64v8/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-arm64v8-20200407092239-bfcd90a"
+              ],
+              "digest": "sha256:c828076013bd9551b888928452af170260294d15902912767c0cc3a75f00918c",
+              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-04-07T09:24:55.3248761Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/ubuntu/18.04/source-build/Dockerfile",
+              "simpleTags": [
+                "ubuntu-18.04-source-build-20200407092310-ed32d26"
+              ],
+              "digest": "sha256:67d538288183625a7901509abfce5d1e7794e66a846a6533cc883fe2644e8a53",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-04-07T09:30:36.1971671Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.9/arm32v7/Dockerfile",
+              "simpleTags": [
+                "alpine-3.9-arm32v7-20200401132634-bfba074"
+              ],
+              "digest": "sha256:89d9e45a292f96189016589f8f70b954515c9f7eaf5c4fcc5cf38a30b3c96f8b",
+              "baseImageDigest": "arm32v7/alpine@sha256:0c6b515386fda00a17e4653f007979825f35e0086e583ddc9b91d3eda941bd1b",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.9",
+              "architecture": "arm32",
+              "created": "2020-04-01T13:27:44.4234295Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.9/arm64v8/Dockerfile",
+              "simpleTags": [
+                "alpine-3.9-arm64v8-20200401132640-bfba074"
+              ],
+              "digest": "sha256:ac9a290b98dfe7bea4a3acf8bca484cae227f95a895bd2c9b7c76cd262e63d6d",
+              "baseImageDigest": "arm64v8/alpine@sha256:cae6522b6a351615e547ae9222c9a05d172bc5c3240eec03072d4e1d0429a17a",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.9",
+              "architecture": "arm64",
+              "created": "2020-04-01T13:27:59.551318Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/nanoserver/1809/helix/amd64/Dockerfile",
+              "simpleTags": [
+                "nanoserver-1809-helix-amd64-08e8e40-20200107182504"
+              ],
+              "digest": null,
+              "baseImageDigest": "mcr.microsoft.com/powershell@sha256:8a4e778616607888d88eb64ca72eab4740b2ecef4c93fccf12e1d13cec204646",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-01-07T18:28:03.9052721Z",
+              "commitUrl": null
             }
           ]
         }

--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -1110,12 +1110,13 @@
       "repo": "dotnet/core/runtime-deps",
       "images": [
         {
+          "productVersion": "2.1.17",
           "manifest": {
-            "digest": "sha256:4e3e90fc5386e88a2399f8573aceabe4af8af6d944f80b00d3f0166eb4de7e91",
-            "created": "2020-03-31T04:16:58.2732081Z",
+            "digest": "sha256:48047d177a687fd8ca680fc6c11889b0faf21a5bbb68855ef4aef625405229b4",
+            "created": "2020-04-09T16:37:33.1378755Z",
             "sharedTags": [
-              "2.1.17",
-              "2.1"
+              "2.1",
+              "2.1.17"
             ]
           },
           "platforms": [
@@ -1125,13 +1126,13 @@
                 "2.1-stretch-slim",
                 "2.1.17-stretch-slim"
               ],
-              "digest": "sha256:f7f31a4c4476cdbb0c631976a2c929b9c01c9afd8e9ba28b045d4b38f828c4d5",
+              "digest": "sha256:8e6b759fe06740b74bc9e4c167e937d4f9127e46190b04b8716dff917cba3a55",
               "baseImageDigest": "amd64/debian@sha256:b4214dd240bb278627dd581a347abaa4bfbcfeae6e27cccb7e281b042dae1858",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "amd64",
-              "created": "2020-03-31T04:09:11.4810894Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:23.9375417Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/stretch-slim/amd64/Dockerfile"
             },
             {
               "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile",
@@ -1139,17 +1140,18 @@
                 "2.1-stretch-slim-arm32v7",
                 "2.1.17-stretch-slim-arm32v7"
               ],
-              "digest": "sha256:9d49e16dfa24aa476abf8dc821f0fb8cf58e37debb1bcbd2ce9d9b679ac65e97",
+              "digest": "sha256:e683956efb6c5c9643c8fae2e8acabf1be44327e0e82628d9fe01ce1bcdbe65b",
               "baseImageDigest": "arm32v7/debian@sha256:1acec4f9c50a79cbcbe0a99bef0820c116910ae3f682693e949aeb50e96f3c11",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "arm32",
-              "created": "2020-03-31T04:16:58.2732081Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:34.3564868Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/bdc1d62860375b94679244c8d295c10afd666b93/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "2.1.17",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/alpine3.10/amd64/Dockerfile",
@@ -1157,17 +1159,18 @@
                 "2.1-alpine3.10",
                 "2.1.17-alpine3.10"
               ],
-              "digest": "sha256:2ff846282e576d0ff7c443fe7ca297a26d76a5b9aeab915dd68935c5173b27ad",
+              "digest": "sha256:15d5d6737d42fea87be7a6ae53d27d7439ea89f75dd0e6ce2e5f2c50b4059d71",
               "baseImageDigest": "amd64/alpine@sha256:de78803598bc4c940fc4591d412bffe488205d5d953f94751c6308deeaaa7eb8",
               "osType": "Linux",
               "osVersion": "Alpine 3.10",
               "architecture": "amd64",
-              "created": "2020-03-30T15:35:22.3486126Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:04.3154131Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/alpine3.10/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "2.1.17",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/alpine3.11/amd64/Dockerfile",
@@ -1177,17 +1180,18 @@
                 "2.1.17-alpine",
                 "2.1.17-alpine3.11"
               ],
-              "digest": "sha256:db79a1ba31d69a575f00e3b8b8abaca483f2d5d0b604c8bd7bb35cd195e0aee3",
+              "digest": "sha256:91ca36b465b3a7fbd146f7eecc62d969e04a509defd3eb74e67281b852de341f",
               "baseImageDigest": "amd64/alpine@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "amd64",
-              "created": "2020-03-30T15:35:27.3635951Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:15.3493708Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/alpine3.11/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "2.1.17",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/bionic/amd64/Dockerfile",
@@ -1195,17 +1199,18 @@
                 "2.1-bionic",
                 "2.1.17-bionic"
               ],
-              "digest": "sha256:2a58e54b449eb67dc2b6eb988bc24eaf37e469c1607f8ba4bed41ce128a86589",
+              "digest": "sha256:e28e2c3c3d62f24693ab69b7aec703c8447ad75665f79ed03aae0af91fd4cf6e",
               "baseImageDigest": "amd64/ubuntu@sha256:e5dd9dbb37df5b731a6688fa49f4003359f6f126958c9c928f937bec69836320",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-03-30T15:35:44.0768919Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:24.9290017Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/bionic/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "2.1.17",
           "platforms": [
             {
               "dockerfile": "2.1/runtime-deps/bionic/arm32v7/Dockerfile",
@@ -1213,23 +1218,24 @@
                 "2.1-bionic-arm32v7",
                 "2.1.17-bionic-arm32v7"
               ],
-              "digest": "sha256:0384847544e1b420a55e6f95bb504c19638a821943abcdcef7db0e7d6bbe84b3",
+              "digest": "sha256:86eb74203c36292a8b8efb21bf150b5278e076b4078e3df6c1b896b3305f6f46",
               "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-03-24T16:47:18.2553557Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:19.3509904Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/bdc1d62860375b94679244c8d295c10afd666b93/2.1/runtime-deps/bionic/arm32v7/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "manifest": {
-            "digest": "sha256:9c6f4004de867399cbbd0d61ddef1f766a770f9402a0a1d34f03dde82c88ea6c",
-            "created": "2020-03-31T04:13:59.9452741Z",
+            "digest": "sha256:b864330ccb4d6413fdcb98be604916021e05edd2beaa29eb90c0facadde75066",
+            "created": "2020-04-09T16:37:33.1378755Z",
             "sharedTags": [
-              "3.1.3",
               "3.1",
+              "3.1.3",
               "latest"
             ]
           },
@@ -1240,13 +1246,13 @@
                 "3.1-buster-slim",
                 "3.1.3-buster-slim"
               ],
-              "digest": "sha256:f1aa33985bd63574e788fde0c14f2e2ed3c030a32592e209d18197846ca3468b",
+              "digest": "sha256:6e83f29c7e6d8c664f6ec6da0f1fd08e51b0019b0a648298e099e1b5360c0636",
               "baseImageDigest": "amd64/debian@sha256:7371081a11cb8d073567eb2479b6fe1b3c2736846948ad5b910904e4c2726302",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-03-31T04:08:27.9037173Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:06.2443499Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/buster-slim/amd64/Dockerfile"
             },
             {
               "dockerfile": "3.1/runtime-deps/buster-slim/arm32v7/Dockerfile",
@@ -1254,13 +1260,13 @@
                 "3.1-buster-slim-arm32v7",
                 "3.1.3-buster-slim-arm32v7"
               ],
-              "digest": "sha256:48c140eed187d322b2fedc96ad87e0bb5dba9ae631d7230f7c8172a2d604245c",
+              "digest": "sha256:3c3e1233666b56cbcbc686744f8bd97b6ca726d66be5ee75f628ece12de04f56",
               "baseImageDigest": "arm32v7/debian@sha256:b8fc15211f5100bb6b5426eb6de112d739f79ef5124e1680b4929b1c43bed7ee",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-03-31T04:13:59.9452741Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:11:27.5063349Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/buster-slim/arm32v7/Dockerfile"
             },
             {
               "dockerfile": "3.1/runtime-deps/buster-slim/arm64v8/Dockerfile",
@@ -1268,17 +1274,18 @@
                 "3.1-buster-slim-arm64v8",
                 "3.1.3-buster-slim-arm64v8"
               ],
-              "digest": "sha256:a5d2107b3408a216ab917d38e792f04536a675cae98824276cadb90228bd4d2e",
+              "digest": "sha256:3f7d00a63d678b7eeaa9d9af02dfd1f276aeb67c6f34867ef03f314dbfe0883a",
               "baseImageDigest": "arm64v8/debian@sha256:a8923bb5ccc91f91e747a0369c7a63e56a9f390a87a8f8d66f2bd46b868d9ddb",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-03-31T04:08:31.9090282Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:18.6612228Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/buster-slim/arm64v8/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/alpine3.10/amd64/Dockerfile",
@@ -1286,17 +1293,18 @@
                 "3.1-alpine3.10",
                 "3.1.3-alpine3.10"
               ],
-              "digest": "sha256:a8bcc02461c6727edc61390c1dd5db0edb51be6d827172e0fb862c6aa8fafee1",
+              "digest": "sha256:1f1836226eae81768303da95e7340f97d364e21a52d165c7a73882d4c2660151",
               "baseImageDigest": "amd64/alpine@sha256:de78803598bc4c940fc4591d412bffe488205d5d953f94751c6308deeaaa7eb8",
               "osType": "Linux",
               "osVersion": "Alpine 3.10",
               "architecture": "amd64",
-              "created": "2020-03-30T15:35:49.3509289Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:16.3096659Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/alpine3.10/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/alpine3.10/arm64v8/Dockerfile",
@@ -1304,17 +1312,18 @@
                 "3.1-alpine3.10-arm64v8",
                 "3.1.3-alpine3.10-arm64v8"
               ],
-              "digest": "sha256:78c7761bb40ef0fca2e1d65c2861972cc23caf19c36d3bfbf99cdb15ce96a4dd",
+              "digest": "sha256:2f0c037c4d86c9c0469a33209087fe1120aa54b1ddd1a7be66d3cb3dbfdda940",
               "baseImageDigest": "arm64v8/alpine@sha256:4491fd429b8ad188ba5e120782b2bbb704261fd2ef9942fcdee128c5fcc594d5",
               "osType": "Linux",
               "osVersion": "Alpine 3.10",
               "architecture": "arm64",
-              "created": "2020-03-24T16:46:55.0583766Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:09:57.131359Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/alpine3.10/arm64v8/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/alpine3.11/amd64/Dockerfile",
@@ -1324,17 +1333,18 @@
                 "3.1.3-alpine",
                 "3.1.3-alpine3.11"
               ],
-              "digest": "sha256:cb898fe24232ff40e06cc1b8663d128ea69dd072128673bb6a19759b6e037914",
+              "digest": "sha256:045e2cd04289462e607912d88f679ad693ee3b97d5f84b2eac1190c68bfcb8ce",
               "baseImageDigest": "amd64/alpine@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "amd64",
-              "created": "2020-03-30T15:35:32.2281862Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:03.2617061Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/alpine3.11/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/alpine3.11/arm64v8/Dockerfile",
@@ -1344,17 +1354,18 @@
                 "3.1.3-alpine-arm64v8",
                 "3.1.3-alpine3.11-arm64v8"
               ],
-              "digest": "sha256:f9d8c1ffbc226b79791ea745a1d30d8c35193152b7e9ed7b85a57bb97f1f31a8",
+              "digest": "sha256:2d2e40742f7ca907b20992e40fc749293d1f9c6dff5a35575ca0a4a1ad6e1f6c",
               "baseImageDigest": "arm64v8/alpine@sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "arm64",
-              "created": "2020-03-24T16:46:59.4676958Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:09:54.5916129Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/alpine3.11/arm64v8/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/bionic/amd64/Dockerfile",
@@ -1362,17 +1373,18 @@
                 "3.1-bionic",
                 "3.1.3-bionic"
               ],
-              "digest": "sha256:afedca77aa9da02693156e62c19b13fcb8e42e6905682f8992febb5792c77353",
+              "digest": "sha256:76ffd5d18e25831ffbfed3ab5e5e157aba401272ec026cc9f4eafe625d1a0666",
               "baseImageDigest": "amd64/ubuntu@sha256:e5dd9dbb37df5b731a6688fa49f4003359f6f126958c9c928f937bec69836320",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-03-30T15:35:59.3355965Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:14.1684167Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/bionic/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/bionic/arm32v7/Dockerfile",
@@ -1380,17 +1392,18 @@
                 "3.1-bionic-arm32v7",
                 "3.1.3-bionic-arm32v7"
               ],
-              "digest": "sha256:3089e86249a97cf7b64aa205ae1cdecd0a738233a32fb43c88e0622f3b9cab33",
+              "digest": "sha256:9c7daa82631727fcea41448d5f2232cfc4d3c1854964ed29e1994abdf2911430",
               "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-03-24T16:47:26.4802289Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:11:30.6078105Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/bionic/arm32v7/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.3",
           "platforms": [
             {
               "dockerfile": "3.1/runtime-deps/bionic/arm64v8/Dockerfile",
@@ -1398,23 +1411,24 @@
                 "3.1-bionic-arm64v8",
                 "3.1.3-bionic-arm64v8"
               ],
-              "digest": "sha256:53761001be89592bf0b07a4d0fb731680b8826a4977eed002c4e77c4b6c68971",
+              "digest": "sha256:f35678364fb4756cb97030131069e7e367aa217a7ab5f75b9c0d427cb3ee3c17",
               "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm64",
-              "created": "2020-03-24T16:47:18.1296755Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:33.1000045Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/bionic/arm64v8/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "5.0.0-preview.2",
           "manifest": {
-            "digest": "sha256:ae385ba7bcf1b4350aaa5d018feddef43a75158f9a8daaaf4b7e4c98fd33f793",
-            "created": "2020-04-03T13:00:06.0390406Z",
+            "digest": "sha256:054eca1cdac6ba388136486d459987435aa870578b116e39d8942c3474a6766e",
+            "created": "2020-04-09T16:37:33.1378755Z",
             "sharedTags": [
-              "5.0.0-preview.2",
-              "5.0"
+              "5.0",
+              "5.0.0-preview.2"
             ]
           },
           "platforms": [
@@ -1424,13 +1438,13 @@
                 "5.0-buster-slim",
                 "5.0.0-preview.2-buster-slim"
               ],
-              "digest": "sha256:97fe2bd3734722319e69bbf5312bb1bc95e1e71884a16d400b8283f2f0bfb6ca",
+              "digest": "sha256:8e247f9d6b546ae7ba236882eb4a8ecf55c59aa0324d4e5c5a0b376330381816",
               "baseImageDigest": "amd64/debian@sha256:7371081a11cb8d073567eb2479b6fe1b3c2736846948ad5b910904e4c2726302",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-04-03T13:00:06.0390406Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:05.8542631Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/5.0/runtime-deps/buster-slim/amd64/Dockerfile"
             },
             {
               "dockerfile": "5.0/runtime-deps/buster-slim/arm32v7/Dockerfile",
@@ -1438,13 +1452,13 @@
                 "5.0-buster-slim-arm32v7",
                 "5.0.0-preview.2-buster-slim-arm32v7"
               ],
-              "digest": "sha256:135f207143d408010515a07c79af94e452602503a6b20e94fe28f6a595e2f95c",
+              "digest": "sha256:f79236db7ad113e7b6c50b925cb12e838c697a4eab506840c797ee09e26039cd",
               "baseImageDigest": "arm32v7/debian@sha256:b8fc15211f5100bb6b5426eb6de112d739f79ef5124e1680b4929b1c43bed7ee",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-04-03T13:00:01.2994677Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:11:35.7531519Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/96b56ab02129eb104fe4d41c94c8fabab0ea9106/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile"
             },
             {
               "dockerfile": "5.0/runtime-deps/buster-slim/arm64v8/Dockerfile",
@@ -1452,17 +1466,18 @@
                 "5.0-buster-slim-arm64v8",
                 "5.0.0-preview.2-buster-slim-arm64v8"
               ],
-              "digest": "sha256:7536545fff8c31ba0cded34b997facefb6225e963ca6faae3ca6b34423e90c68",
+              "digest": "sha256:eeef40380c3a1c2185eefbfc449218c2e940d56eb9eda526d7cf04d7e54c9368",
               "baseImageDigest": "arm64v8/debian@sha256:a8923bb5ccc91f91e747a0369c7a63e56a9f390a87a8f8d66f2bd46b868d9ddb",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-04-03T12:59:57.9074547Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:02.6834351Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/96b56ab02129eb104fe4d41c94c8fabab0ea9106/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "5.0.0-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/alpine3.11/amd64/Dockerfile",
@@ -1472,17 +1487,18 @@
                 "5.0.0-preview.2-alpine",
                 "5.0.0-preview.2-alpine3.11"
               ],
-              "digest": "sha256:9b96a07018483e7c4babde0f556d8259f659601366f979e0943ae6f37a930bd7",
+              "digest": "sha256:775a48122c2b8f61db801c7e4a862d747faebf4e574b3580b256b49f5b913a95",
               "baseImageDigest": "amd64/alpine@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "amd64",
-              "created": "2020-04-03T12:59:34.2062597Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:09:57.1691687Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/5.0/runtime-deps/alpine3.11/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "5.0.0-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/alpine3.11/arm64v8/Dockerfile",
@@ -1492,17 +1508,18 @@
                 "5.0.0-preview.2-alpine-arm64v8",
                 "5.0.0-preview.2-alpine3.11-arm64v8"
               ],
-              "digest": "sha256:c23ee1cee5d9cccee4fd173c1c72bf75db6fd07ca41dfe66c51d63cddad50d03",
+              "digest": "sha256:e166baf3b09da14585ca845a9cbd9f903661434c85a1956d6ddf575551754d7c",
               "baseImageDigest": "arm64v8/alpine@sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "arm64",
-              "created": "2020-04-03T12:59:40.5400625Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:04.0023392Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/96b56ab02129eb104fe4d41c94c8fabab0ea9106/5.0/runtime-deps/alpine3.11/arm64v8/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "5.0.0-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/focal/amd64/Dockerfile",
@@ -1510,17 +1527,18 @@
                 "5.0-focal",
                 "5.0.0-preview.2-focal"
               ],
-              "digest": "sha256:2eb92ef19c34495cc2b8552a51a280d0c37bc27e7c9db72c434d8fc4a82c858d",
+              "digest": "sha256:5f9f047caea7095a6fbbdf13fcb38d11344a78f889014b2987a970cb00a52019",
               "baseImageDigest": "amd64/ubuntu@sha256:8e1c1ee12a539d652c371ee2f4ee66909f4f5fd8002936d8011d958f05faf989",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "amd64",
-              "created": "2020-04-03T12:59:46.1583772Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:13.3868793Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/5.0/runtime-deps/focal/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "5.0.0-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/focal/arm64v8/Dockerfile",
@@ -1528,13 +1546,13 @@
                 "5.0-focal-arm64v8",
                 "5.0.0-preview.2-focal-arm64v8"
               ],
-              "digest": "sha256:87fb81cfd1e791dee9bb04612fbcb5244d9987b0932f9ffb8fc2ebec6fd8cec8",
+              "digest": "sha256:8f2a2906222e53d9be39bbd17da99082ebfd1e9240e64a8cb37db2ff0e75e854",
               "baseImageDigest": "arm64v8/ubuntu@sha256:0551fb19b57011ba165f66399ca0e7e49402aa7cba6ba843a317f48e4cad9e35",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "arm64",
-              "created": "2020-04-03T12:59:45.355857Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:22.7456665Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/7f0b8c422f6f3cbd885a50ed09cf499ee362799c/5.0/runtime-deps/focal/arm64v8/Dockerfile"
             }
           ]
         }
@@ -1607,11 +1625,11 @@
       "images": [
         {
           "manifest": {
-            "digest": "sha256:9cb18b9edc7954e9881a67d260abc4110b397d51e002893fba60374dc8a349f6",
-            "created": "2020-03-24T16:51:44.814037Z",
+            "digest": "sha256:2903c47babfb3f9e9026249aa830aebdb35728ca7609be0881a4a405b1c9651a",
+            "created": "2020-04-09T16:37:33.1378755Z",
             "sharedTags": [
-              "2.1.805",
-              "2.1"
+              "2.1",
+              "2.1.805"
             ]
           },
           "platforms": [
@@ -1663,13 +1681,13 @@
                 "2.1-stretch",
                 "2.1.805-stretch"
               ],
-              "digest": "sha256:fd3baa618b6ffb1aa7305905281a8e899912234c68e04d8186d316d328221a1a",
+              "digest": "sha256:d9c51b5d5e0fb4ac06cc35e0feed06c34658dc409a3d7b1e4128e7c7f3811ea8",
               "baseImageDigest": "amd64/buildpack-deps@sha256:46fc6c5a495b2c589228d4426421073ff943e666971dad451c58e45fb5a469ec",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "amd64",
-              "created": "2020-03-31T04:10:13.8000567Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:11:41.379694Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/sdk/stretch/amd64/Dockerfile"
             },
             {
               "dockerfile": "2.1/sdk/stretch/arm32v7/Dockerfile",
@@ -1677,13 +1695,13 @@
                 "2.1-stretch-arm32v7",
                 "2.1.805-stretch-arm32v7"
               ],
-              "digest": "sha256:7c73fd62bfe89eb8b85771a2a71fbe2166a135e495492a3f994efe36a816d563",
+              "digest": "sha256:a4ee6d28759e68c3e8f276adb08a46e26d5f1710d886382ebe9603cf3a7a8d2f",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:22b43f02e6a100184cb6e6baf435aa67e352b2033bf86465529707a707ef976a",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "arm32",
-              "created": "2020-03-31T08:15:34.9572479Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:13:05.4506726Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/2.1/sdk/stretch/arm32v7/Dockerfile"
             }
           ]
         },
@@ -1724,6 +1742,7 @@
           ]
         },
         {
+          "productVersion": "2.1.805",
           "platforms": [
             {
               "dockerfile": "2.1/sdk/bionic/amd64/Dockerfile",
@@ -1731,17 +1750,18 @@
                 "2.1-bionic",
                 "2.1.805-bionic"
               ],
-              "digest": "sha256:d4eeba2c721f7416394b2da898b31cd1cabbc435b25fa51fa46546dae81aec75",
+              "digest": "sha256:285adb0ab1e5644fb5a3ad1085370bb35a4be5f13c753f71da845a7c8524fed6",
               "baseImageDigest": "amd64/buildpack-deps@sha256:2fca27ce716210dadbc5937d64e26e6c3e0ca877b93e446be48e7dc579feb56b",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-03-30T15:36:52.08217Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:11:34.6830956Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/sdk/bionic/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "2.1.805",
           "platforms": [
             {
               "dockerfile": "2.1/sdk/bionic/arm32v7/Dockerfile",
@@ -1749,23 +1769,23 @@
                 "2.1-bionic-arm32v7",
                 "2.1.805-bionic-arm32v7"
               ],
-              "digest": "sha256:e036cfc307c23aa73536768b1f539295a85d211e03efcdf0b91541f79d28d50a",
+              "digest": "sha256:b80ae7d865e92d69047f7dd6d7d1c964e53c871900ea121db3eaf0839414c2c3",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:7e6e04f39cd0dc85e0b24f200da5cf0c30afbb42000dec34435ca182b138a7d2",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-03-24T16:49:09.0764059Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:12:13.9970317Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/2.1/sdk/bionic/arm32v7/Dockerfile"
             }
           ]
         },
         {
           "manifest": {
-            "digest": "sha256:bf755bf00ee2712af5fb71af0aea57e8e65dc2cc191f28c2d1f95c325f00177f",
-            "created": "2020-03-24T16:56:22.0785728Z",
+            "digest": "sha256:cad1f51e65af52e5551e5182b163326c8fceca93d0dbb9e8de8d85b95748e4e2",
+            "created": "2020-04-09T16:37:33.1378755Z",
             "sharedTags": [
-              "3.1.201",
               "3.1",
+              "3.1.201",
               "latest"
             ]
           },
@@ -1776,13 +1796,13 @@
                 "3.1-buster",
                 "3.1.201-buster"
               ],
-              "digest": "sha256:ffdaf00ea1408bd71e169a90dbab34914c999674a81fcced8ed919f9a8797dda",
+              "digest": "sha256:d81d9ab0253c2c578578b2032955984562684c182e3a15dacc3bbdb31260d4e4",
               "baseImageDigest": "amd64/buildpack-deps@sha256:4898e2f8c0201c39fe3fe4c187d138083c1451c23033ff0e965c7a9874f4651a",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-03-31T04:19:39.5174672Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:46.2826578Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/sdk/buster/amd64/Dockerfile"
             },
             {
               "dockerfile": "3.1/sdk/buster/arm32v7/Dockerfile",
@@ -1790,13 +1810,13 @@
                 "3.1-buster-arm32v7",
                 "3.1.201-buster-arm32v7"
               ],
-              "digest": "sha256:867f527c058f777badd4e67da509ab56fdd905ca44dc247ad2ecd5cd50123fae",
+              "digest": "sha256:fd2276c5621c18aeb48dcd84c348d69fabd60cbdf0a0ffa7b37bbdb355c39fcf",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:d5bc40558cd219c0048949d5aa1dd8b4916ba988fc604e0a82e26fe2ca1ea5f3",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-03-31T04:20:39.2092048Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:12:14.7229349Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/buster/arm32v7/Dockerfile"
             },
             {
               "dockerfile": "3.1/sdk/buster/arm64v8/Dockerfile",
@@ -1804,13 +1824,13 @@
                 "3.1-buster-arm64v8",
                 "3.1.201-buster-arm64v8"
               ],
-              "digest": "sha256:d5d38184853526a3fb69f4326e1c109b75620c309ccecbdfed876f2d6262366a",
+              "digest": "sha256:acf607cac9821dc7590c4a0e76e39d95b37730dbf70edf36b343eb67ff95c5b4",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:8d7c433c44214dc285cf89aa4e2e3a8831e452defca321b73650271724b71988",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-03-31T08:07:49.1092439Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:50.0661302Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/buster/arm64v8/Dockerfile"
             },
             {
               "dockerfile": "3.1/sdk/nanoserver-1809/amd64/Dockerfile",
@@ -1907,6 +1927,7 @@
           ]
         },
         {
+          "productVersion": "3.1.201",
           "platforms": [
             {
               "dockerfile": "3.1/sdk/bionic/amd64/Dockerfile",
@@ -1914,17 +1935,18 @@
                 "3.1-bionic",
                 "3.1.201-bionic"
               ],
-              "digest": "sha256:3f121cda5878fc823f5ae10cddeb32b64a8227f6d7c32e5b4f066d5ccefa1011",
+              "digest": "sha256:2dfe2a9523d681e125f645ed469bf04c46baf62fd5d8268c730af68ec7ecb035",
               "baseImageDigest": "amd64/buildpack-deps@sha256:2fca27ce716210dadbc5937d64e26e6c3e0ca877b93e446be48e7dc579feb56b",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-03-30T15:36:13.9291812Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:37.6969495Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/sdk/bionic/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.201",
           "platforms": [
             {
               "dockerfile": "3.1/sdk/bionic/arm32v7/Dockerfile",
@@ -1932,17 +1954,18 @@
                 "3.1-bionic-arm32v7",
                 "3.1.201-bionic-arm32v7"
               ],
-              "digest": "sha256:40bf64351f2ef63ac7b5d5dfb4ad2661eaee5cc01973c3dcd145db54bc7a2e4f",
+              "digest": "sha256:78638686a5d9aeb5452322f6a614ff5f523e5d6d33ccb213225357cc9dfdae35",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:7e6e04f39cd0dc85e0b24f200da5cf0c30afbb42000dec34435ca182b138a7d2",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-03-24T16:47:45.9005278Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:12:04.799488Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/bionic/arm32v7/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "3.1.201",
           "platforms": [
             {
               "dockerfile": "3.1/sdk/bionic/arm64v8/Dockerfile",
@@ -1950,23 +1973,23 @@
                 "3.1-bionic-arm64v8",
                 "3.1.201-bionic-arm64v8"
               ],
-              "digest": "sha256:b7def06355a3c6c79ebce82b0c00c50368465a4ececb6a099e3701c851b67a4d",
+              "digest": "sha256:651f981d711288c18d3ba2f0212aba02b1ddca3217ab4f386eb1b29d705f1562",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:c1fd085d9e2d43d672e9504fae9d41636f60af0f02e76263ae4ee9ee91366b93",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm64",
-              "created": "2020-03-24T16:47:44.2434051Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:39.329903Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/bionic/arm64v8/Dockerfile"
             }
           ]
         },
         {
           "manifest": {
-            "digest": "sha256:2e61573f786a93342e18e887b564edea64acf47d8d84b18f4fce3467952d2fc5",
-            "created": "2020-04-03T13:04:01.226855Z",
+            "digest": "sha256:6be60ad746b2649e88e20f51bcb67958104980001b6aa98b16c03556ce85c5e2",
+            "created": "2020-04-09T16:37:33.1378755Z",
             "sharedTags": [
-              "5.0.100-preview.2",
-              "5.0"
+              "5.0",
+              "5.0.100-preview.2"
             ]
           },
           "platforms": [
@@ -1976,13 +1999,13 @@
                 "5.0-buster",
                 "5.0.100-preview.2-buster"
               ],
-              "digest": "sha256:3515f953fc7dbf91a5f4de6c1bcc3ab0054d23627df5553414cbad2a21ea9422",
+              "digest": "sha256:421cc050773b268bdb2556920a83b371b9763d0e29ce96d90a8bd8602fc8e33c",
               "baseImageDigest": "amd64/buildpack-deps@sha256:4898e2f8c0201c39fe3fe4c187d138083c1451c23033ff0e965c7a9874f4651a",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-04-03T13:00:09.9643294Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:11:02.3609144Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/buster/amd64/Dockerfile"
             },
             {
               "dockerfile": "5.0/sdk/buster/arm32v7/Dockerfile",
@@ -1990,13 +2013,13 @@
                 "5.0-buster-arm32v7",
                 "5.0.100-preview.2-buster-arm32v7"
               ],
-              "digest": "sha256:188ea80ef0a1687654767f32f4b237ecddb5a823c44716515e90d5aff4fd88c7",
+              "digest": "sha256:916df1ae272d8a70cf9f2aa0e29b2e35d8d54e922a68d34726531f7218f35767",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:d5bc40558cd219c0048949d5aa1dd8b4916ba988fc604e0a82e26fe2ca1ea5f3",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-04-03T13:00:26.3733258Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:38.6513532Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/buster/arm32v7/Dockerfile"
             },
             {
               "dockerfile": "5.0/sdk/buster/arm64v8/Dockerfile",
@@ -2004,13 +2027,13 @@
                 "5.0-buster-arm64v8",
                 "5.0.100-preview.2-buster-arm64v8"
               ],
-              "digest": "sha256:61854764b3acdfdcd404d52236177be5a3083f0e4b0b7d3cd102ccb56b140aad",
+              "digest": "sha256:6148a0cba9feb779c6c9d4453f5844c386b01a2f93f169ff45f797dabefa87bc",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:8d7c433c44214dc285cf89aa4e2e3a8831e452defca321b73650271724b71988",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-04-03T13:00:23.7652224Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:32.9092893Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/buster/arm64v8/Dockerfile"
             },
             {
               "dockerfile": "5.0/sdk/nanoserver-1809/amd64/Dockerfile",
@@ -2076,6 +2099,7 @@
           ]
         },
         {
+          "productVersion": "5.0.100-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/sdk/focal/amd64/Dockerfile",
@@ -2083,17 +2107,18 @@
                 "5.0-focal",
                 "5.0.100-preview.2-focal"
               ],
-              "digest": "sha256:bbedb7b507b3ec7cd80922cc5c202a2890823d22a7685d835448a4ef69681159",
+              "digest": "sha256:8576786f3bf05da76e894a4a1cc1bf561f4549635acb5c8bea7642c80e70d2ac",
               "baseImageDigest": "amd64/buildpack-deps@sha256:2b175c6bbfadc97ed80b8fa4adbd5c59503c8465f50977806489187868bd8618",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "amd64",
-              "created": "2020-04-03T13:00:16.9437727Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:46.0643984Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/focal/amd64/Dockerfile"
             }
           ]
         },
         {
+          "productVersion": "5.0.100-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/sdk/focal/arm64v8/Dockerfile",
@@ -2101,13 +2126,13 @@
                 "5.0-focal-arm64v8",
                 "5.0.100-preview.2-focal-arm64v8"
               ],
-              "digest": "sha256:1e7457d3fcd5a364dc871d2b36a5f9167fcc7aee3a10823b7788a4282cb9bf63",
+              "digest": "sha256:7495b0a30be3b038b12d55fc4d26bb58ab792e8102204386604a69d5b9560088",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:c8a1fd41fb9fa7e3ade560f086b9c33cd4275be0bc870ccfd1d64cf17f28672d",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "arm64",
-              "created": "2020-04-03T13:00:30.3084714Z",
-              "commitUrl": null
+              "created": "2020-04-09T16:10:45.9396393Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/focal/arm64v8/Dockerfile"
             }
           ]
         }

--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -3,101 +3,1119 @@
   "repos": [
     {
       "repo": "dotnet/core/aspnet",
-      "images": []
-    },
-    {
-      "repo": "dotnet/core/runtime",
-      "images": []
-    },
-    {
-      "repo": "dotnet/core/runtime-deps",
       "images": [
         {
-          "productVersion": "2.1.17",
+          "manifest": {
+            "digest": "sha256:ce68e7eb508f22b92f3848767db3e00b032fec271025b1bea447939ea2294143",
+            "created": "2020-03-24T16:47:45.9001549Z",
+            "sharedTags": [
+              "2.1.17",
+              "2.1"
+            ]
+          },
           "platforms": [
             {
-              "dockerfile": "2.1/runtime-deps/alpine3.10/amd64/Dockerfile",
+              "dockerfile": "2.1/aspnet/nanoserver-1809/amd64/Dockerfile",
               "simpleTags": [
-                "2.1-alpine3.10",
-                "2.1.17-alpine3.10"
+                "2.1.17-nanoserver-1809",
+                "2.1-nanoserver-1809"
               ],
-              "digest": "sha256:15d5d6737d42fea87be7a6ae53d27d7439ea89f75dd0e6ce2e5f2c50b4059d71",
-              "baseImageDigest": "amd64/alpine@sha256:de78803598bc4c940fc4591d412bffe488205d5d953f94751c6308deeaaa7eb8",
-              "osType": "Linux",
-              "osVersion": "Alpine 3.10",
+              "digest": "sha256:6e9d850a0e80bd93529d1cc7dd417b93100d38e91b13ed7b57b90da06a5b7c95",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5de6bd32bd453d60c8f549d28845552e89ad3652566e141ac82023b6ba10374d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:04.3154131Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/alpine3.10/amd64/Dockerfile"
+              "created": "2020-03-24T16:47:45.9001549Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/aspnet/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.17-nanoserver-1903",
+                "2.1-nanoserver-1903"
+              ],
+              "digest": "sha256:1b787f2af397b55ad5ac0b8530b754e15911797195656a8a70d89fd4617efb31",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:1ba75187a3768a1dfd6889b311fcda0e40e21da1bfc83521e8c2d527546959be",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:42.2558471Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/aspnet/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.17-nanoserver-1909",
+                "2.1-nanoserver-1909"
+              ],
+              "digest": "sha256:6fe96bb968a0f81eea5de5bfd3802d7257e50143c80c6c3c82ec62c6a666b4c9",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:e78d71661c100cac7790083bd33ca472247ac1b6237f7bc642d9c05831f1e740",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:42.7035073Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/aspnet/stretch-slim/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-stretch-slim",
+                "2.1.17-stretch-slim"
+              ],
+              "digest": "sha256:ee4d02a29eceb56ce5392a53f2a170948012f912e10871297e6ec5d75f3aecd3",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "amd64",
+              "created": "2020-03-31T04:09:28.7608893Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/aspnet/stretch-slim/arm32v7/Dockerfile",
+              "simpleTags": [
+                "2.1-stretch-slim-arm32v7",
+                "2.1.17-stretch-slim-arm32v7"
+              ],
+              "digest": "sha256:08fa9a9dd4104639ba36875c3118117d983fbbebf2fb7622baee99fe8402b06c",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "arm32",
+              "created": "2020-03-31T04:17:35.2613435Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "2.1.17",
           "platforms": [
             {
-              "dockerfile": "2.1/runtime-deps/alpine3.11/amd64/Dockerfile",
+              "dockerfile": "2.1/aspnet/alpine3.10/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-alpine3.10",
+                "2.1.17-alpine3.10"
+              ],
+              "digest": "sha256:3a8edae180474e1f49e4e6b5ffa71ab37191111656824e53e7831ff26163aecb",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:34.9149668Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/aspnet/alpine3.11/amd64/Dockerfile",
               "simpleTags": [
                 "2.1-alpine",
                 "2.1-alpine3.11",
                 "2.1.17-alpine",
                 "2.1.17-alpine3.11"
               ],
-              "digest": "sha256:91ca36b465b3a7fbd146f7eecc62d969e04a509defd3eb74e67281b852de341f",
-              "baseImageDigest": "amd64/alpine@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
+              "digest": "sha256:b934b1e278222b826b8aa58eca38541a5978aa8262dbacc76da97ac84a825595",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:15.3493708Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/alpine3.11/amd64/Dockerfile"
+              "created": "2020-03-30T15:35:46.343968Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "2.1.17",
           "platforms": [
             {
-              "dockerfile": "2.1/runtime-deps/bionic/amd64/Dockerfile",
+              "dockerfile": "2.1/aspnet/bionic/amd64/Dockerfile",
               "simpleTags": [
                 "2.1-bionic",
                 "2.1.17-bionic"
               ],
-              "digest": "sha256:e28e2c3c3d62f24693ab69b7aec703c8447ad75665f79ed03aae0af91fd4cf6e",
-              "baseImageDigest": "amd64/ubuntu@sha256:e5dd9dbb37df5b731a6688fa49f4003359f6f126958c9c928f937bec69836320",
+              "digest": "sha256:06f2b73b385176b8b4cd4cbf5d3b8476e0185e3107a3d235fc90871eb26e4303",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:24.9290017Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/bionic/amd64/Dockerfile"
+              "created": "2020-03-30T15:36:05.0784477Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "2.1.17",
           "platforms": [
             {
-              "dockerfile": "2.1/runtime-deps/bionic/arm32v7/Dockerfile",
+              "dockerfile": "2.1/aspnet/bionic/arm32v7/Dockerfile",
               "simpleTags": [
                 "2.1-bionic-arm32v7",
                 "2.1.17-bionic-arm32v7"
               ],
-              "digest": "sha256:86eb74203c36292a8b8efb21bf150b5278e076b4078e3df6c1b896b3305f6f46",
-              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
+              "digest": "sha256:f8382743cf8361e72df8d286ad8e211763bef841a1b8a41287f5a866b65a8c1c",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-04-09T16:10:19.3509904Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/bdc1d62860375b94679244c8d295c10afd666b93/2.1/runtime-deps/bionic/arm32v7/Dockerfile"
+              "created": "2020-03-24T16:47:57.907297Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "2.1.17",
           "manifest": {
-            "digest": "sha256:48047d177a687fd8ca680fc6c11889b0faf21a5bbb68855ef4aef625405229b4",
-            "created": "2020-04-09T16:37:33.1378755Z",
+            "digest": "sha256:31355469835e6df7538dbf5a4100c095338b51cbe52154aa23ae79d87585d404",
+            "created": "2020-03-24T16:48:54.4395011Z",
             "sharedTags": [
-              "2.1",
-              "2.1.17"
+              "3.1.3",
+              "3.1",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/buster-slim/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-buster-slim",
+                "3.1.3-buster-slim"
+              ],
+              "digest": "sha256:a9e160dbf5ed62c358f18af8c4daf0d7c0c30f203c0dd8dff94a86598c80003b",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-03-31T04:08:39.9243079Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/aspnet/buster-slim/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-buster-slim-arm32v7",
+                "3.1.3-buster-slim-arm32v7"
+              ],
+              "digest": "sha256:166d57afdc13c128853374d53b92378971e3d701a25bb6c9b25e6d65326f4d70",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm32",
+              "created": "2020-03-31T04:14:28.1572398Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/aspnet/buster-slim/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-buster-slim-arm64v8",
+                "3.1.3-buster-slim-arm64v8"
+              ],
+              "digest": "sha256:76a51f7ddd1fa8381a7e71390b13e6db658d84e8a1b8e1220d806015cc635872",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm64",
+              "created": "2020-03-31T04:08:59.4133545Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/aspnet/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.3-nanoserver-1809",
+                "3.1-nanoserver-1809"
+              ],
+              "digest": "sha256:33c4417296ba5c55f04545a1787cc2b9c7532e77a710ec09f13d468d03f9b45c",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:48.25172Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/aspnet/nanoserver-1809/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-nanoserver-1809-arm32v7",
+                "3.1.3-nanoserver-1809-arm32v7"
+              ],
+              "digest": "sha256:52f0bb56dbde63add1f8440b7299103251bab740477e6c7de50f8af9e5f8a1b1",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:48:54.4395011Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/aspnet/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.3-nanoserver-1903",
+                "3.1-nanoserver-1903"
+              ],
+              "digest": "sha256:9c0a235de25b991fb989b8d11001b5e9c929ff5575bf09749b3d5a31e3384c68",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:48.9437141Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/aspnet/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.3-nanoserver-1909",
+                "3.1-nanoserver-1909"
+              ],
+              "digest": "sha256:03e99f0dace0dbb0b0c9177dc356453cab10c6e2973486beb4b1b329346cacb9",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:52.5402215Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/alpine3.10/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine3.10",
+                "3.1.3-alpine3.10"
+              ],
+              "digest": "sha256:a1ca7f6caabc63a551cf43f924c9cb098444f2b29b0ded85fe7499ff7018afbe",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:57.9201349Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/alpine3.10/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine3.10-arm64v8",
+                "3.1.3-alpine3.10-arm64v8"
+              ],
+              "digest": "sha256:977a5320aea93d03da209f49191cd9d548dcc3046002c1677058beeaa213f5aa",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:09.2383656Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine",
+                "3.1-alpine3.11",
+                "3.1.3-alpine",
+                "3.1.3-alpine3.11"
+              ],
+              "digest": "sha256:149dda5f2ce3fcbb9771e2e8ede70c7cc5a635fbed97b9e277c65de5f98cf753",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:40.8209424Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/alpine3.11/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine-arm64v8",
+                "3.1-alpine3.11-arm64v8",
+                "3.1.3-alpine-arm64v8",
+                "3.1.3-alpine3.11-arm64v8"
+              ],
+              "digest": "sha256:f667ed2791f327ec29702d9fb71a83467e708ff14b29cda68b168db5c2bd23b7",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:11.8072704Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/bionic/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic",
+                "3.1.3-bionic"
+              ],
+              "digest": "sha256:aacf242e5f2567bd78531b47175b11887b9e57d2d5b440c7aa2ef616b9130f32",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:36:18.1966026Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/bionic/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm32v7",
+                "3.1.3-bionic-arm32v7"
+              ],
+              "digest": "sha256:21a6da8815bfe104e95862cf5e83f7a3a21d8190830f486a38ae2c11646f34e8",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:47:59.5194522Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/aspnet/bionic/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm64v8",
+                "3.1.3-bionic-arm64v8"
+              ],
+              "digest": "sha256:3e2dccff7847c4ee172b38b547f620533405c70241effc3761c51acb1e0b4e8a",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:51.645661Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:bb228446a490394abf5b4b818bb780fb5bf038e7ff94a8d7de4aa1b2fd8100f5",
+            "created": "2020-04-03T13:00:16.9454949Z",
+            "sharedTags": [
+              "5.0.0-preview.2",
+              "5.0"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "5.0/aspnet/buster-slim/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-buster-slim",
+                "5.0.0-preview.2-buster-slim"
+              ],
+              "digest": "sha256:ed7b5a3121a540cbe5a922b00cd37d1b7a5aebaffc39c8484c9c06a039221bf4",
+              "baseImageDigest": "buildpack-deps@sha256:97a35a331a026498c212c01a01b8de2a4ea2ce067b9b4bb53b83009cf4464736",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:00:19.0002431Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/aspnet/buster-slim/arm32v7/Dockerfile",
+              "simpleTags": [
+                "5.0-buster-slim-arm32v7",
+                "5.0.0-preview.2-buster-slim-arm32v7"
+              ],
+              "digest": "sha256:667d43bf4ce731490fec978c19808a4ca8b3736574ade6f6c97b1adf100246b0",
+              "baseImageDigest": "arm32v7/buildpack-deps@sha256:4ac832906cfefa506b47d8b2846a376f45a68ca6e825e137e879a3bc6606d757",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm32",
+              "created": "2020-04-03T13:00:23.2354097Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/aspnet/buster-slim/arm64v8/Dockerfile",
+              "simpleTags": [
+                "5.0-buster-slim-arm64v8",
+                "5.0.0-preview.2-buster-slim-arm64v8"
+              ],
+              "digest": "sha256:3278076a3e675e116757b6217e7316908f37f4f202ed1baad3922098b4a4d6df",
+              "baseImageDigest": "arm64v8/buildpack-deps@sha256:5b6902de71aeb27fac30158acc5284b156033da3515844839f4bf3025c9dbffa",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm64",
+              "created": "2020-04-03T13:00:17.0635232Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/aspnet/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.0-preview.2-nanoserver-1809",
+                "5.0-nanoserver-1809"
+              ],
+              "digest": "sha256:bf5cb4286760d321de394a110dc34538f444657d7ae98c9f68fa49d6d5e262ef",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:00:16.9454949Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/aspnet/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.0-preview.2-nanoserver-1903",
+                "5.0-nanoserver-1903"
+              ],
+              "digest": "sha256:c182885794c5e6bf942af2fe8167949c3fbae96919d1699745123d689b97d107",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:00:10.5373135Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/aspnet/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.0-preview.2-nanoserver-1909",
+                "5.0-nanoserver-1909"
+              ],
+              "digest": "sha256:f0fee37a6dd499de2d750213adeb1a97540de2e8ec9658362896f82f296112cd",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:00:14.3422584Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/aspnet/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-alpine",
+                "5.0-alpine3.11",
+                "5.0.0-preview.2-alpine",
+                "5.0.0-preview.2-alpine3.11"
+              ],
+              "digest": "sha256:afc246f2e7c70b82027506f7932680c0d4aa602b8dc713d597d78cdd59e68713",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-04-03T12:59:42.1915176Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/aspnet/alpine3.11/arm64v8/Dockerfile",
+              "simpleTags": [
+                "5.0-alpine-arm64v8",
+                "5.0-alpine3.11-arm64v8",
+                "5.0.0-preview.2-alpine-arm64v8",
+                "5.0.0-preview.2-alpine3.11-arm64v8"
+              ],
+              "digest": "sha256:53d6b1f092bd20945a14fabd2adcecf432f34758f06485271084b66b494ed9df",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "arm64",
+              "created": "2020-04-03T12:59:54.9040166Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/aspnet/focal/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-focal",
+                "5.0.0-preview.2-focal"
+              ],
+              "digest": "sha256:38897e627a859b67195e7b93a76b11e38f025d7586d23c72af09a23688f22fdc",
+              "baseImageDigest": "buildpack-deps@sha256:d251ffae7d919481135bfdc3873e9510c993bc5addc36e41983143508853f4f4",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 20.04",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:00:00.0002009Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/aspnet/focal/arm64v8/Dockerfile",
+              "simpleTags": [
+                "5.0-focal-arm64v8",
+                "5.0.0-preview.2-focal-arm64v8"
+              ],
+              "digest": "sha256:ff1b903ab4c2a475728c22c6ceae17e03485dfb0ab20ac1402c2cac28f5e2d84",
+              "baseImageDigest": "arm64v8/buildpack-deps@sha256:ed9c12af416d915dc120820658d31316ea718277acfc04ae7a6e9277320bb0fc",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 20.04",
+              "architecture": "arm64",
+              "created": "2020-04-03T13:00:03.5156972Z",
+              "commitUrl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "repo": "dotnet/core/runtime",
+      "images": [
+        {
+          "manifest": {
+            "digest": "sha256:aa02c90bc61396e0d59b018e33ed29c1dac9c5716adf0b62ebd8a0afaafe0095",
+            "created": "2020-03-24T16:47:26.9158152Z",
+            "sharedTags": [
+              "2.1.17",
+              "2.1"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.17-nanoserver-1809",
+                "2.1-nanoserver-1809"
+              ],
+              "digest": "sha256:ce882da33af561fec168d89413b0de7e72000e26051d7e5f5ed5a5315fe83010",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5de6bd32bd453d60c8f549d28845552e89ad3652566e141ac82023b6ba10374d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:24.4562984Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/runtime/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.17-nanoserver-1903",
+                "2.1-nanoserver-1903"
+              ],
+              "digest": "sha256:93a6d6cdf734e468d87fd04e23ed15d41c5d820ceac4797b181a485bbd2746af",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:1ba75187a3768a1dfd6889b311fcda0e40e21da1bfc83521e8c2d527546959be",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:26.658118Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/runtime/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.17-nanoserver-1909",
+                "2.1-nanoserver-1909"
+              ],
+              "digest": "sha256:baa549566b14b20fc6a750e348baffd6ba662963f52f5a7084dc0db7e7ae3de6",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:e78d71661c100cac7790083bd33ca472247ac1b6237f7bc642d9c05831f1e740",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:26.9158152Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/runtime/stretch-slim/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-stretch-slim",
+                "2.1.17-stretch-slim"
+              ],
+              "digest": "sha256:093c6255ad6d6984bd804a5f4421208b953783acc55239658cd65bb7e6ba92fe",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "amd64",
+              "created": "2020-03-31T04:09:21.2992577Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/runtime/stretch-slim/arm32v7/Dockerfile",
+              "simpleTags": [
+                "2.1-stretch-slim-arm32v7",
+                "2.1.17-stretch-slim-arm32v7"
+              ],
+              "digest": "sha256:774b04836dce2180099d2e1f757bf6cc03ca46095b2e7a12022370f85ef43156",
+              "osType": "Linux",
+              "osVersion": "Debian 9",
+              "architecture": "arm32",
+              "created": "2020-03-31T04:17:23.8172925Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime/alpine3.10/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-alpine3.10",
+                "2.1.17-alpine3.10"
+              ],
+              "digest": "sha256:e14c29a0167c68a46ac5a07c93a629c6a74b67ae7cadc778a8ef117af0d4b485",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:27.2260392Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-alpine",
+                "2.1-alpine3.11",
+                "2.1.17-alpine",
+                "2.1.17-alpine3.11"
+              ],
+              "digest": "sha256:f7e2910cb88b7535383184723d97de0b29cacc192d9610ef6496549b338cb2e1",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:37.7213924Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime/bionic/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-bionic",
+                "2.1.17-bionic"
+              ],
+              "digest": "sha256:1cff9047a614eff09fffe1f97647a9a5b25e8d794f5d58ca8998d63b4034f267",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:57.4691971Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/runtime/bionic/arm32v7/Dockerfile",
+              "simpleTags": [
+                "2.1-bionic-arm32v7",
+                "2.1.17-bionic-arm32v7"
+              ],
+              "digest": "sha256:f81ff2a88b5c26c03d37fa078b77a2e02b5af3d353257b485a0e306aa667226d",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:47:47.9553428Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:9f2916ef6522918eca16d16bac251f5af196a44f46caf7954ba6cd504c1d4ec4",
+            "created": "2020-03-24T16:48:15.6945374Z",
+            "sharedTags": [
+              "3.1.3",
+              "3.1",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/buster-slim/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-buster-slim",
+                "3.1.3-buster-slim"
+              ],
+              "digest": "sha256:173eb5374472f5250365b6ce75735afac31d0a878af808b98a412689b77f3394",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-03-31T04:08:36.3411552Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/runtime/buster-slim/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-buster-slim-arm32v7",
+                "3.1.3-buster-slim-arm32v7"
+              ],
+              "digest": "sha256:0fca2f7aa8cf0d14d7f7066f178a6304925d4e9b2230d97a39e1e08caa055748",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm32",
+              "created": "2020-03-31T04:14:21.7692088Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/runtime/buster-slim/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-buster-slim-arm64v8",
+                "3.1.3-buster-slim-arm64v8"
+              ],
+              "digest": "sha256:83def8c239df89d4a11157ea3bc168591544d58676efbe5a35128997de7002b5",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm64",
+              "created": "2020-03-31T04:08:54.0412854Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/runtime/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.3-nanoserver-1809",
+                "3.1-nanoserver-1809"
+              ],
+              "digest": "sha256:6dd8d5df56f9774b628ee14960581540b47763d13e3233dd49c32830350b9e8b",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5de6bd32bd453d60c8f549d28845552e89ad3652566e141ac82023b6ba10374d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:21.1771751Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/runtime/nanoserver-1809/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-nanoserver-1809-arm32v7",
+                "3.1.3-nanoserver-1809-arm32v7"
+              ],
+              "digest": "sha256:490bccb2f8840d72c1ad690d4d1e2a16c62dd274a0e0cc9d45ca72beb3c3436a",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:8b73c776dc0ed5b35595da20f50d0454809ae081a7acc9eb847bd76405ea0c61",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:48:15.6945374Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/runtime/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.3-nanoserver-1903",
+                "3.1-nanoserver-1903"
+              ],
+              "digest": "sha256:41bf90ab3013d48246d76a5202238065a059866675214284f9077cfab5d30d72",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:1ba75187a3768a1dfd6889b311fcda0e40e21da1bfc83521e8c2d527546959be",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:23.4554426Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/runtime/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.3-nanoserver-1909",
+                "3.1-nanoserver-1909"
+              ],
+              "digest": "sha256:118dbb26c2dacce14c0cb37d14727d29ae386e45ffb202a49372929716a7e44b",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:e78d71661c100cac7790083bd33ca472247ac1b6237f7bc642d9c05831f1e740",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:47:27.9157426Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/alpine3.10/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine3.10",
+                "3.1.3-alpine3.10"
+              ],
+              "digest": "sha256:7b5a2e5c040990b5dd1e33f1273d08c81ba40d4582cefa808885c662bd3f83a5",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:53.7906657Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/alpine3.10/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine3.10-arm64v8",
+                "3.1.3-alpine3.10-arm64v8"
+              ],
+              "digest": "sha256:d35077821d01d07ca2aec5c1b48ad7603359847e6901894efa2e27948a86e60d",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:03.2585058Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine",
+                "3.1-alpine3.11",
+                "3.1.3-alpine",
+                "3.1.3-alpine3.11"
+              ],
+              "digest": "sha256:fba9eff383737bc4bdc61a498b0dce65153cb545215c3a5fab7143b8a48d1e7c",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:36.976081Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/alpine3.11/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine-arm64v8",
+                "3.1-alpine3.11-arm64v8",
+                "3.1.3-alpine-arm64v8",
+                "3.1.3-alpine3.11-arm64v8"
+              ],
+              "digest": "sha256:9d7763e1b4b0fae9a8a5b0ff33bfd7d77b64d666da47e852dad5277599972791",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:06.263482Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/bionic/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic",
+                "3.1.3-bionic"
+              ],
+              "digest": "sha256:a990b827bc0396c22d9aa2114580cd3f493b851df839678d647c2fc431e3e52e",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:36:12.7467813Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/bionic/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm32v7",
+                "3.1.3-bionic-arm32v7"
+              ],
+              "digest": "sha256:c1edc1c97e8373c28041eec19ba0eb299c35fb7b109ffb20b80c87e9746b8379",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:47:53.6038095Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime/bionic/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm64v8",
+                "3.1.3-bionic-arm64v8"
+              ],
+              "digest": "sha256:529bb5201eca5832b05a7cac194d5650df3bc4bcec40740bb9cf2970bb16946f",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:46.3416372Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:0dd10ca8d45288dea24b0b230f9e394fb0024011cee0d492081258e8887ef7ac",
+            "created": "2020-04-03T12:59:48.6192966Z",
+            "sharedTags": [
+              "5.0.0-preview.2",
+              "5.0"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime/buster-slim/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-buster-slim",
+                "5.0.0-preview.2-buster-slim"
+              ],
+              "digest": "sha256:554cdf4ba79a3d5750460decb7fd9fcc274dd35e0344d9dae482aec9e3531db1",
+              "baseImageDigest": "buildpack-deps@sha256:97a35a331a026498c212c01a01b8de2a4ea2ce067b9b4bb53b83009cf4464736",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:00:15.1074444Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/runtime/buster-slim/arm32v7/Dockerfile",
+              "simpleTags": [
+                "5.0-buster-slim-arm32v7",
+                "5.0.0-preview.2-buster-slim-arm32v7"
+              ],
+              "digest": "sha256:94aaaf672ea64f711438ba0fbefe17ea08efc40778a429364c4481db9bb47865",
+              "baseImageDigest": "arm32v7/buildpack-deps@sha256:4ac832906cfefa506b47d8b2846a376f45a68ca6e825e137e879a3bc6606d757",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm32",
+              "created": "2020-04-03T13:00:14.9954216Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/runtime/buster-slim/arm64v8/Dockerfile",
+              "simpleTags": [
+                "5.0-buster-slim-arm64v8",
+                "5.0.0-preview.2-buster-slim-arm64v8"
+              ],
+              "digest": "sha256:a1a48031cae9da0e84b8a2f02be6d4bdf2942067027b10b63ef6e1e771784c46",
+              "baseImageDigest": "arm64v8/buildpack-deps@sha256:5b6902de71aeb27fac30158acc5284b156033da3515844839f4bf3025c9dbffa",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm64",
+              "created": "2020-04-03T13:00:10.2909748Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/runtime/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.0-preview.2-nanoserver-1809",
+                "5.0-nanoserver-1809"
+              ],
+              "digest": "sha256:e40dec335cc2770d8e73232c5b81cef7b13844625617d76b1cd1f75720dced45",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5de6bd32bd453d60c8f549d28845552e89ad3652566e141ac82023b6ba10374d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-04-03T12:59:48.6192966Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/runtime/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.0-preview.2-nanoserver-1903",
+                "5.0-nanoserver-1903"
+              ],
+              "digest": "sha256:60e61161facb32a525abcaff381c6551c628e05111abbf2fe01dbe3170571c93",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:1ba75187a3768a1dfd6889b311fcda0e40e21da1bfc83521e8c2d527546959be",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-04-03T12:59:45.5223298Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/runtime/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.0-preview.2-nanoserver-1909",
+                "5.0-nanoserver-1909"
+              ],
+              "digest": "sha256:9e36287df3ca981c029fd885655e943221e7aa1677c38c1afd85bdd130b0b23a",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:e78d71661c100cac7790083bd33ca472247ac1b6237f7bc642d9c05831f1e740",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-04-03T12:59:47.3755399Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-alpine",
+                "5.0-alpine3.11",
+                "5.0.0-preview.2-alpine",
+                "5.0.0-preview.2-alpine3.11"
+              ],
+              "digest": "sha256:27f3375e7fab1b7b709786a0de8b253bc601c1ad36a3fbc127af80222ccf00cd",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-04-03T12:59:38.451921Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime/alpine3.11/arm64v8/Dockerfile",
+              "simpleTags": [
+                "5.0-alpine-arm64v8",
+                "5.0-alpine3.11-arm64v8",
+                "5.0.0-preview.2-alpine-arm64v8",
+                "5.0.0-preview.2-alpine3.11-arm64v8"
+              ],
+              "digest": "sha256:c8d29f9f97e45668103cece2c14107b194a7267b88718147a15670b69a03ea04",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "arm64",
+              "created": "2020-04-03T12:59:48.9520575Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime/focal/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-focal",
+                "5.0.0-preview.2-focal"
+              ],
+              "digest": "sha256:8845d69be86aad2d59262cff524a8ac8428ce95fba14d53f6b94bbc1b816b770",
+              "baseImageDigest": "buildpack-deps@sha256:d251ffae7d919481135bfdc3873e9510c993bc5addc36e41983143508853f4f4",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 20.04",
+              "architecture": "amd64",
+              "created": "2020-04-03T12:59:55.5706161Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime/focal/arm64v8/Dockerfile",
+              "simpleTags": [
+                "5.0-focal-arm64v8",
+                "5.0.0-preview.2-focal-arm64v8"
+              ],
+              "digest": "sha256:da9c1863b6b96b7a62f8e0bc39589f0ebad6d008fc0fd754e622f016735cd228",
+              "baseImageDigest": "arm64v8/buildpack-deps@sha256:ed9c12af416d915dc120820658d31316ea718277acfc04ae7a6e9277320bb0fc",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 20.04",
+              "architecture": "arm64",
+              "created": "2020-04-03T12:59:56.9193789Z",
+              "commitUrl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "repo": "dotnet/core/runtime-deps",
+      "images": [
+        {
+          "manifest": {
+            "digest": "sha256:4e3e90fc5386e88a2399f8573aceabe4af8af6d944f80b00d3f0166eb4de7e91",
+            "created": "2020-03-31T04:16:58.2732081Z",
+            "sharedTags": [
+              "2.1.17",
+              "2.1"
             ]
           },
           "platforms": [
@@ -107,13 +1125,13 @@
                 "2.1-stretch-slim",
                 "2.1.17-stretch-slim"
               ],
-              "digest": "sha256:8e6b759fe06740b74bc9e4c167e937d4f9127e46190b04b8716dff917cba3a55",
+              "digest": "sha256:f7f31a4c4476cdbb0c631976a2c929b9c01c9afd8e9ba28b045d4b38f828c4d5",
               "baseImageDigest": "amd64/debian@sha256:b4214dd240bb278627dd581a347abaa4bfbcfeae6e27cccb7e281b042dae1858",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:23.9375417Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/runtime-deps/stretch-slim/amd64/Dockerfile"
+              "created": "2020-03-31T04:09:11.4810894Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile",
@@ -121,161 +1139,97 @@
                 "2.1-stretch-slim-arm32v7",
                 "2.1.17-stretch-slim-arm32v7"
               ],
-              "digest": "sha256:e683956efb6c5c9643c8fae2e8acabf1be44327e0e82628d9fe01ce1bcdbe65b",
+              "digest": "sha256:9d49e16dfa24aa476abf8dc821f0fb8cf58e37debb1bcbd2ce9d9b679ac65e97",
               "baseImageDigest": "arm32v7/debian@sha256:1acec4f9c50a79cbcbe0a99bef0820c116910ae3f682693e949aeb50e96f3c11",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "arm32",
-              "created": "2020-04-09T16:10:34.3564868Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/bdc1d62860375b94679244c8d295c10afd666b93/2.1/runtime-deps/stretch-slim/arm32v7/Dockerfile"
+              "created": "2020-03-31T04:16:58.2732081Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.3",
           "platforms": [
             {
-              "dockerfile": "3.1/runtime-deps/alpine3.10/amd64/Dockerfile",
+              "dockerfile": "2.1/runtime-deps/alpine3.10/amd64/Dockerfile",
               "simpleTags": [
-                "3.1-alpine3.10",
-                "3.1.3-alpine3.10"
+                "2.1-alpine3.10",
+                "2.1.17-alpine3.10"
               ],
-              "digest": "sha256:1f1836226eae81768303da95e7340f97d364e21a52d165c7a73882d4c2660151",
+              "digest": "sha256:2ff846282e576d0ff7c443fe7ca297a26d76a5b9aeab915dd68935c5173b27ad",
               "baseImageDigest": "amd64/alpine@sha256:de78803598bc4c940fc4591d412bffe488205d5d953f94751c6308deeaaa7eb8",
               "osType": "Linux",
               "osVersion": "Alpine 3.10",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:16.3096659Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/alpine3.10/amd64/Dockerfile"
+              "created": "2020-03-30T15:35:22.3486126Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.3",
           "platforms": [
             {
-              "dockerfile": "3.1/runtime-deps/alpine3.10/arm64v8/Dockerfile",
+              "dockerfile": "2.1/runtime-deps/alpine3.11/amd64/Dockerfile",
               "simpleTags": [
-                "3.1-alpine3.10-arm64v8",
-                "3.1.3-alpine3.10-arm64v8"
+                "2.1-alpine",
+                "2.1-alpine3.11",
+                "2.1.17-alpine",
+                "2.1.17-alpine3.11"
               ],
-              "digest": "sha256:2f0c037c4d86c9c0469a33209087fe1120aa54b1ddd1a7be66d3cb3dbfdda940",
-              "baseImageDigest": "arm64v8/alpine@sha256:4491fd429b8ad188ba5e120782b2bbb704261fd2ef9942fcdee128c5fcc594d5",
-              "osType": "Linux",
-              "osVersion": "Alpine 3.10",
-              "architecture": "arm64",
-              "created": "2020-04-09T16:09:57.131359Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/alpine3.10/arm64v8/Dockerfile"
-            }
-          ]
-        },
-        {
-          "productVersion": "3.1.3",
-          "platforms": [
-            {
-              "dockerfile": "3.1/runtime-deps/alpine3.11/amd64/Dockerfile",
-              "simpleTags": [
-                "3.1-alpine",
-                "3.1-alpine3.11",
-                "3.1.3-alpine",
-                "3.1.3-alpine3.11"
-              ],
-              "digest": "sha256:045e2cd04289462e607912d88f679ad693ee3b97d5f84b2eac1190c68bfcb8ce",
+              "digest": "sha256:db79a1ba31d69a575f00e3b8b8abaca483f2d5d0b604c8bd7bb35cd195e0aee3",
               "baseImageDigest": "amd64/alpine@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:03.2617061Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/alpine3.11/amd64/Dockerfile"
+              "created": "2020-03-30T15:35:27.3635951Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.3",
           "platforms": [
             {
-              "dockerfile": "3.1/runtime-deps/alpine3.11/arm64v8/Dockerfile",
+              "dockerfile": "2.1/runtime-deps/bionic/amd64/Dockerfile",
               "simpleTags": [
-                "3.1-alpine-arm64v8",
-                "3.1-alpine3.11-arm64v8",
-                "3.1.3-alpine-arm64v8",
-                "3.1.3-alpine3.11-arm64v8"
+                "2.1-bionic",
+                "2.1.17-bionic"
               ],
-              "digest": "sha256:2d2e40742f7ca907b20992e40fc749293d1f9c6dff5a35575ca0a4a1ad6e1f6c",
-              "baseImageDigest": "arm64v8/alpine@sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31",
-              "osType": "Linux",
-              "osVersion": "Alpine 3.11",
-              "architecture": "arm64",
-              "created": "2020-04-09T16:09:54.5916129Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/alpine3.11/arm64v8/Dockerfile"
-            }
-          ]
-        },
-        {
-          "productVersion": "3.1.3",
-          "platforms": [
-            {
-              "dockerfile": "3.1/runtime-deps/bionic/amd64/Dockerfile",
-              "simpleTags": [
-                "3.1-bionic",
-                "3.1.3-bionic"
-              ],
-              "digest": "sha256:76ffd5d18e25831ffbfed3ab5e5e157aba401272ec026cc9f4eafe625d1a0666",
+              "digest": "sha256:2a58e54b449eb67dc2b6eb988bc24eaf37e469c1607f8ba4bed41ce128a86589",
               "baseImageDigest": "amd64/ubuntu@sha256:e5dd9dbb37df5b731a6688fa49f4003359f6f126958c9c928f937bec69836320",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:14.1684167Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/bionic/amd64/Dockerfile"
+              "created": "2020-03-30T15:35:44.0768919Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.3",
           "platforms": [
             {
-              "dockerfile": "3.1/runtime-deps/bionic/arm32v7/Dockerfile",
+              "dockerfile": "2.1/runtime-deps/bionic/arm32v7/Dockerfile",
               "simpleTags": [
-                "3.1-bionic-arm32v7",
-                "3.1.3-bionic-arm32v7"
+                "2.1-bionic-arm32v7",
+                "2.1.17-bionic-arm32v7"
               ],
-              "digest": "sha256:9c7daa82631727fcea41448d5f2232cfc4d3c1854964ed29e1994abdf2911430",
+              "digest": "sha256:0384847544e1b420a55e6f95bb504c19638a821943abcdcef7db0e7d6bbe84b3",
               "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-04-09T16:11:30.6078105Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/bionic/arm32v7/Dockerfile"
+              "created": "2020-03-24T16:47:18.2553557Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.3",
-          "platforms": [
-            {
-              "dockerfile": "3.1/runtime-deps/bionic/arm64v8/Dockerfile",
-              "simpleTags": [
-                "3.1-bionic-arm64v8",
-                "3.1.3-bionic-arm64v8"
-              ],
-              "digest": "sha256:f35678364fb4756cb97030131069e7e367aa217a7ab5f75b9c0d427cb3ee3c17",
-              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "arm64",
-              "created": "2020-04-09T16:10:33.1000045Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/bionic/arm64v8/Dockerfile"
-            }
-          ]
-        },
-        {
-          "productVersion": "3.1.3",
           "manifest": {
-            "digest": "sha256:b864330ccb4d6413fdcb98be604916021e05edd2beaa29eb90c0facadde75066",
-            "created": "2020-04-09T16:37:33.1378755Z",
+            "digest": "sha256:9c6f4004de867399cbbd0d61ddef1f766a770f9402a0a1d34f03dde82c88ea6c",
+            "created": "2020-03-31T04:13:59.9452741Z",
             "sharedTags": [
-              "3.1",
               "3.1.3",
+              "3.1",
               "latest"
             ]
           },
@@ -286,13 +1240,13 @@
                 "3.1-buster-slim",
                 "3.1.3-buster-slim"
               ],
-              "digest": "sha256:6e83f29c7e6d8c664f6ec6da0f1fd08e51b0019b0a648298e099e1b5360c0636",
+              "digest": "sha256:f1aa33985bd63574e788fde0c14f2e2ed3c030a32592e209d18197846ca3468b",
               "baseImageDigest": "amd64/debian@sha256:7371081a11cb8d073567eb2479b6fe1b3c2736846948ad5b910904e4c2726302",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:06.2443499Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/runtime-deps/buster-slim/amd64/Dockerfile"
+              "created": "2020-03-31T04:08:27.9037173Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "3.1/runtime-deps/buster-slim/arm32v7/Dockerfile",
@@ -300,13 +1254,13 @@
                 "3.1-buster-slim-arm32v7",
                 "3.1.3-buster-slim-arm32v7"
               ],
-              "digest": "sha256:3c3e1233666b56cbcbc686744f8bd97b6ca726d66be5ee75f628ece12de04f56",
+              "digest": "sha256:48c140eed187d322b2fedc96ad87e0bb5dba9ae631d7230f7c8172a2d604245c",
               "baseImageDigest": "arm32v7/debian@sha256:b8fc15211f5100bb6b5426eb6de112d739f79ef5124e1680b4929b1c43bed7ee",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-04-09T16:11:27.5063349Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/buster-slim/arm32v7/Dockerfile"
+              "created": "2020-03-31T04:13:59.9452741Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "3.1/runtime-deps/buster-slim/arm64v8/Dockerfile",
@@ -314,66 +1268,153 @@
                 "3.1-buster-slim-arm64v8",
                 "3.1.3-buster-slim-arm64v8"
               ],
-              "digest": "sha256:3f7d00a63d678b7eeaa9d9af02dfd1f276aeb67c6f34867ef03f314dbfe0883a",
+              "digest": "sha256:a5d2107b3408a216ab917d38e792f04536a675cae98824276cadb90228bd4d2e",
               "baseImageDigest": "arm64v8/debian@sha256:a8923bb5ccc91f91e747a0369c7a63e56a9f390a87a8f8d66f2bd46b868d9ddb",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-04-09T16:10:18.6612228Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/4759558a6116582ee7484887f2fe8c168b854b52/3.1/runtime-deps/buster-slim/arm64v8/Dockerfile"
+              "created": "2020-03-31T04:08:31.9090282Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.0-preview.2",
           "platforms": [
             {
-              "dockerfile": "5.0/runtime-deps/alpine3.11/amd64/Dockerfile",
+              "dockerfile": "3.1/runtime-deps/alpine3.10/amd64/Dockerfile",
               "simpleTags": [
-                "5.0-alpine",
-                "5.0-alpine3.11",
-                "5.0.0-preview.2-alpine",
-                "5.0.0-preview.2-alpine3.11"
+                "3.1-alpine3.10",
+                "3.1.3-alpine3.10"
               ],
-              "digest": "sha256:775a48122c2b8f61db801c7e4a862d747faebf4e574b3580b256b49f5b913a95",
+              "digest": "sha256:a8bcc02461c6727edc61390c1dd5db0edb51be6d827172e0fb862c6aa8fafee1",
+              "baseImageDigest": "amd64/alpine@sha256:de78803598bc4c940fc4591d412bffe488205d5d953f94751c6308deeaaa7eb8",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:49.3509289Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime-deps/alpine3.10/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine3.10-arm64v8",
+                "3.1.3-alpine3.10-arm64v8"
+              ],
+              "digest": "sha256:78c7761bb40ef0fca2e1d65c2861972cc23caf19c36d3bfbf99cdb15ce96a4dd",
+              "baseImageDigest": "arm64v8/alpine@sha256:4491fd429b8ad188ba5e120782b2bbb704261fd2ef9942fcdee128c5fcc594d5",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:46:55.0583766Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime-deps/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine",
+                "3.1-alpine3.11",
+                "3.1.3-alpine",
+                "3.1.3-alpine3.11"
+              ],
+              "digest": "sha256:cb898fe24232ff40e06cc1b8663d128ea69dd072128673bb6a19759b6e037914",
               "baseImageDigest": "amd64/alpine@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "amd64",
-              "created": "2020-04-09T16:09:57.1691687Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/5.0/runtime-deps/alpine3.11/amd64/Dockerfile"
+              "created": "2020-03-30T15:35:32.2281862Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.0-preview.2",
           "platforms": [
             {
-              "dockerfile": "5.0/runtime-deps/alpine3.11/arm64v8/Dockerfile",
+              "dockerfile": "3.1/runtime-deps/alpine3.11/arm64v8/Dockerfile",
               "simpleTags": [
-                "5.0-alpine-arm64v8",
-                "5.0-alpine3.11-arm64v8",
-                "5.0.0-preview.2-alpine-arm64v8",
-                "5.0.0-preview.2-alpine3.11-arm64v8"
+                "3.1-alpine-arm64v8",
+                "3.1-alpine3.11-arm64v8",
+                "3.1.3-alpine-arm64v8",
+                "3.1.3-alpine3.11-arm64v8"
               ],
-              "digest": "sha256:e166baf3b09da14585ca845a9cbd9f903661434c85a1956d6ddf575551754d7c",
+              "digest": "sha256:f9d8c1ffbc226b79791ea745a1d30d8c35193152b7e9ed7b85a57bb97f1f31a8",
               "baseImageDigest": "arm64v8/alpine@sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31",
               "osType": "Linux",
               "osVersion": "Alpine 3.11",
               "architecture": "arm64",
-              "created": "2020-04-09T16:10:04.0023392Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/96b56ab02129eb104fe4d41c94c8fabab0ea9106/5.0/runtime-deps/alpine3.11/arm64v8/Dockerfile"
+              "created": "2020-03-24T16:46:59.4676958Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.0-preview.2",
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime-deps/bionic/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic",
+                "3.1.3-bionic"
+              ],
+              "digest": "sha256:afedca77aa9da02693156e62c19b13fcb8e42e6905682f8992febb5792c77353",
+              "baseImageDigest": "amd64/ubuntu@sha256:e5dd9dbb37df5b731a6688fa49f4003359f6f126958c9c928f937bec69836320",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:35:59.3355965Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime-deps/bionic/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm32v7",
+                "3.1.3-bionic-arm32v7"
+              ],
+              "digest": "sha256:3089e86249a97cf7b64aa205ae1cdecd0a738233a32fb43c88e0622f3b9cab33",
+              "baseImageDigest": "arm32v7/ubuntu@sha256:3b029ac9aa8eb5dffd43bb7326891cf64f9c228b3960cec55a56605d2ae2ad42",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:47:26.4802289Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/runtime-deps/bionic/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm64v8",
+                "3.1.3-bionic-arm64v8"
+              ],
+              "digest": "sha256:53761001be89592bf0b07a4d0fb731680b8826a4977eed002c4e77c4b6c68971",
+              "baseImageDigest": "arm64v8/ubuntu@sha256:12b9106d200061c8eb2179c984e63cc17d5a4e7a34f6e9ad03360b8efe492e96",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:18.1296755Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
           "manifest": {
-            "digest": "sha256:054eca1cdac6ba388136486d459987435aa870578b116e39d8942c3474a6766e",
-            "created": "2020-04-09T16:37:33.1378755Z",
+            "digest": "sha256:ae385ba7bcf1b4350aaa5d018feddef43a75158f9a8daaaf4b7e4c98fd33f793",
+            "created": "2020-04-03T13:00:06.0390406Z",
             "sharedTags": [
-              "5.0",
-              "5.0.0-preview.2"
+              "5.0.0-preview.2",
+              "5.0"
             ]
           },
           "platforms": [
@@ -383,13 +1424,13 @@
                 "5.0-buster-slim",
                 "5.0.0-preview.2-buster-slim"
               ],
-              "digest": "sha256:8e247f9d6b546ae7ba236882eb4a8ecf55c59aa0324d4e5c5a0b376330381816",
+              "digest": "sha256:97fe2bd3734722319e69bbf5312bb1bc95e1e71884a16d400b8283f2f0bfb6ca",
               "baseImageDigest": "amd64/debian@sha256:7371081a11cb8d073567eb2479b6fe1b3c2736846948ad5b910904e4c2726302",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:05.8542631Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/5.0/runtime-deps/buster-slim/amd64/Dockerfile"
+              "created": "2020-04-03T13:00:06.0390406Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "5.0/runtime-deps/buster-slim/arm32v7/Dockerfile",
@@ -397,13 +1438,13 @@
                 "5.0-buster-slim-arm32v7",
                 "5.0.0-preview.2-buster-slim-arm32v7"
               ],
-              "digest": "sha256:f79236db7ad113e7b6c50b925cb12e838c697a4eab506840c797ee09e26039cd",
+              "digest": "sha256:135f207143d408010515a07c79af94e452602503a6b20e94fe28f6a595e2f95c",
               "baseImageDigest": "arm32v7/debian@sha256:b8fc15211f5100bb6b5426eb6de112d739f79ef5124e1680b4929b1c43bed7ee",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-04-09T16:11:35.7531519Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/96b56ab02129eb104fe4d41c94c8fabab0ea9106/5.0/runtime-deps/buster-slim/arm32v7/Dockerfile"
+              "created": "2020-04-03T13:00:01.2994677Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "5.0/runtime-deps/buster-slim/arm64v8/Dockerfile",
@@ -411,18 +1452,57 @@
                 "5.0-buster-slim-arm64v8",
                 "5.0.0-preview.2-buster-slim-arm64v8"
               ],
-              "digest": "sha256:eeef40380c3a1c2185eefbfc449218c2e940d56eb9eda526d7cf04d7e54c9368",
+              "digest": "sha256:7536545fff8c31ba0cded34b997facefb6225e963ca6faae3ca6b34423e90c68",
               "baseImageDigest": "arm64v8/debian@sha256:a8923bb5ccc91f91e747a0369c7a63e56a9f390a87a8f8d66f2bd46b868d9ddb",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-04-09T16:10:02.6834351Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/96b56ab02129eb104fe4d41c94c8fabab0ea9106/5.0/runtime-deps/buster-slim/arm64v8/Dockerfile"
+              "created": "2020-04-03T12:59:57.9074547Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.0-preview.2",
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime-deps/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-alpine",
+                "5.0-alpine3.11",
+                "5.0.0-preview.2-alpine",
+                "5.0.0-preview.2-alpine3.11"
+              ],
+              "digest": "sha256:9b96a07018483e7c4babde0f556d8259f659601366f979e0943ae6f37a930bd7",
+              "baseImageDigest": "amd64/alpine@sha256:cb8a924afdf0229ef7515d9e5b3024e23b3eb03ddbba287f4a19c6ac90b8d221",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-04-03T12:59:34.2062597Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "5.0/runtime-deps/alpine3.11/arm64v8/Dockerfile",
+              "simpleTags": [
+                "5.0-alpine-arm64v8",
+                "5.0-alpine3.11-arm64v8",
+                "5.0.0-preview.2-alpine-arm64v8",
+                "5.0.0-preview.2-alpine3.11-arm64v8"
+              ],
+              "digest": "sha256:c23ee1cee5d9cccee4fd173c1c72bf75db6fd07ca41dfe66c51d63cddad50d03",
+              "baseImageDigest": "arm64v8/alpine@sha256:597bd5c319cc09d6bb295b4ef23cac50ec7c373fff5fe923cfd246ec09967b31",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "arm64",
+              "created": "2020-04-03T12:59:40.5400625Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/focal/amd64/Dockerfile",
@@ -430,18 +1510,17 @@
                 "5.0-focal",
                 "5.0.0-preview.2-focal"
               ],
-              "digest": "sha256:5f9f047caea7095a6fbbdf13fcb38d11344a78f889014b2987a970cb00a52019",
+              "digest": "sha256:2eb92ef19c34495cc2b8552a51a280d0c37bc27e7c9db72c434d8fc4a82c858d",
               "baseImageDigest": "amd64/ubuntu@sha256:8e1c1ee12a539d652c371ee2f4ee66909f4f5fd8002936d8011d958f05faf989",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:13.3868793Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/5.0/runtime-deps/focal/amd64/Dockerfile"
+              "created": "2020-04-03T12:59:46.1583772Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.0-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/runtime-deps/focal/arm64v8/Dockerfile",
@@ -449,13 +1528,75 @@
                 "5.0-focal-arm64v8",
                 "5.0.0-preview.2-focal-arm64v8"
               ],
-              "digest": "sha256:8f2a2906222e53d9be39bbd17da99082ebfd1e9240e64a8cb37db2ff0e75e854",
+              "digest": "sha256:87fb81cfd1e791dee9bb04612fbcb5244d9987b0932f9ffb8fc2ebec6fd8cec8",
               "baseImageDigest": "arm64v8/ubuntu@sha256:0551fb19b57011ba165f66399ca0e7e49402aa7cba6ba843a317f48e4cad9e35",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "arm64",
-              "created": "2020-04-09T16:10:22.7456665Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/7f0b8c422f6f3cbd885a50ed09cf499ee362799c/5.0/runtime-deps/focal/arm64v8/Dockerfile"
+              "created": "2020-04-03T12:59:45.355857Z",
+              "commitUrl": null
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "repo": "dotnet/core/samples",
+      "images": [
+        {
+          "manifest": {
+            "digest": "sha256:be51cb56c9bdfbdcc2ea6aa1c69a33addfbabf9f9f174cdcc021e0f5410e323c",
+            "created": "0001-01-01T06:00:00Z",
+            "sharedTags": [
+              "dotnetapp",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "simpleTags": [
+                "dotnetapp-buster-slim",
+                "dotnetapp-buster-slim-arm64v8",
+                "dotnetapp-nanoserver-1809",
+                "dotnetapp-nanoserver-1903",
+                "dotnetapp-nanoserver-1909"
+              ],
+              "digest": "sha256:18da146f244d5f415100b717cbf5112c69ee04c07c5cc274be293da4f48d72bd",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:318e18f1616bb2e85f489bf6caca8d9934a5610178df2f0fff8e9bf4ba34091f",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-03-31T08:07:51.3178675Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:b03dba91aad40298f312383b8f359a38254ebc62bb49c85562916fcd1af07f91",
+            "created": "0001-01-01T06:00:00Z",
+            "sharedTags": [
+              "aspnetapp"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "simpleTags": [
+                "aspnetapp-buster-slim",
+                "aspnetapp-buster-slim-arm64v8",
+                "aspnetapp-nanoserver-1809",
+                "aspnetapp-nanoserver-1903",
+                "aspnetapp-nanoserver-1909"
+              ],
+              "digest": "sha256:d5e7990d8b5ee3cbd49001dbc43b6f2c57efaa45d87d6875153fbd2cc21a4ba6",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:7ec5aaee0d88954394eee20762270bfbf56c938172e81bd415274d633a2c515f",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-03-31T08:08:03.4337705Z",
+              "commitUrl": null
             }
           ]
         }
@@ -465,67 +1606,70 @@
       "repo": "dotnet/core/sdk",
       "images": [
         {
-          "productVersion": "2.1.805",
-          "platforms": [
-            {
-              "dockerfile": "2.1/sdk/bionic/amd64/Dockerfile",
-              "simpleTags": [
-                "2.1-bionic",
-                "2.1.805-bionic"
-              ],
-              "digest": "sha256:285adb0ab1e5644fb5a3ad1085370bb35a4be5f13c753f71da845a7c8524fed6",
-              "baseImageDigest": "amd64/buildpack-deps@sha256:2fca27ce716210dadbc5937d64e26e6c3e0ca877b93e446be48e7dc579feb56b",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "amd64",
-              "created": "2020-04-09T16:11:34.6830956Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/sdk/bionic/amd64/Dockerfile"
-            }
-          ]
-        },
-        {
-          "productVersion": "2.1.805",
-          "platforms": [
-            {
-              "dockerfile": "2.1/sdk/bionic/arm32v7/Dockerfile",
-              "simpleTags": [
-                "2.1-bionic-arm32v7",
-                "2.1.805-bionic-arm32v7"
-              ],
-              "digest": "sha256:b80ae7d865e92d69047f7dd6d7d1c964e53c871900ea121db3eaf0839414c2c3",
-              "baseImageDigest": "arm32v7/buildpack-deps@sha256:7e6e04f39cd0dc85e0b24f200da5cf0c30afbb42000dec34435ca182b138a7d2",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "arm32",
-              "created": "2020-04-09T16:12:13.9970317Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/2.1/sdk/bionic/arm32v7/Dockerfile"
-            }
-          ]
-        },
-        {
-          "productVersion": "2.1.805",
           "manifest": {
-            "digest": "sha256:2903c47babfb3f9e9026249aa830aebdb35728ca7609be0881a4a405b1c9651a",
-            "created": "2020-04-09T16:37:33.1378755Z",
+            "digest": "sha256:9cb18b9edc7954e9881a67d260abc4110b397d51e002893fba60374dc8a349f6",
+            "created": "2020-03-24T16:51:44.814037Z",
             "sharedTags": [
-              "2.1",
-              "2.1.805"
+              "2.1.805",
+              "2.1"
             ]
           },
           "platforms": [
+            {
+              "dockerfile": "2.1/sdk/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.805-nanoserver-1809",
+                "2.1-nanoserver-1809"
+              ],
+              "digest": "sha256:448acdf32f08e727f7396321cec445755f1295844d2d2124ba06a278406377e8",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5de6bd32bd453d60c8f549d28845552e89ad3652566e141ac82023b6ba10374d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:51:13.1709267Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/sdk/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.805-nanoserver-1903",
+                "2.1-nanoserver-1903"
+              ],
+              "digest": "sha256:e80e8516883c9388693649d35a358674d48cb4012243f6d48f49984ece699ba6",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:1ba75187a3768a1dfd6889b311fcda0e40e21da1bfc83521e8c2d527546959be",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:51:35.7308682Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "2.1/sdk/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1.805-nanoserver-1909",
+                "2.1-nanoserver-1909"
+              ],
+              "digest": "sha256:fb18ce11583a81dd751b08aa2e0b914b0fd01da91b547a623e39e5bac6daf21c",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:e78d71661c100cac7790083bd33ca472247ac1b6237f7bc642d9c05831f1e740",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:51:44.814037Z",
+              "commitUrl": null
+            },
             {
               "dockerfile": "2.1/sdk/stretch/amd64/Dockerfile",
               "simpleTags": [
                 "2.1-stretch",
                 "2.1.805-stretch"
               ],
-              "digest": "sha256:d9c51b5d5e0fb4ac06cc35e0feed06c34658dc409a3d7b1e4128e7c7f3811ea8",
+              "digest": "sha256:fd3baa618b6ffb1aa7305905281a8e899912234c68e04d8186d316d328221a1a",
               "baseImageDigest": "amd64/buildpack-deps@sha256:46fc6c5a495b2c589228d4426421073ff943e666971dad451c58e45fb5a469ec",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "amd64",
-              "created": "2020-04-09T16:11:41.379694Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/2.1/sdk/stretch/amd64/Dockerfile"
+              "created": "2020-03-31T04:10:13.8000567Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "2.1/sdk/stretch/arm32v7/Dockerfile",
@@ -533,81 +1677,95 @@
                 "2.1-stretch-arm32v7",
                 "2.1.805-stretch-arm32v7"
               ],
-              "digest": "sha256:a4ee6d28759e68c3e8f276adb08a46e26d5f1710d886382ebe9603cf3a7a8d2f",
+              "digest": "sha256:7c73fd62bfe89eb8b85771a2a71fbe2166a135e495492a3f994efe36a816d563",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:22b43f02e6a100184cb6e6baf435aa67e352b2033bf86465529707a707ef976a",
               "osType": "Linux",
               "osVersion": "Debian 9",
               "architecture": "arm32",
-              "created": "2020-04-09T16:13:05.4506726Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/2.1/sdk/stretch/arm32v7/Dockerfile"
+              "created": "2020-03-31T08:15:34.9572479Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.201",
           "platforms": [
             {
-              "dockerfile": "3.1/sdk/bionic/amd64/Dockerfile",
+              "dockerfile": "2.1/sdk/alpine3.10/amd64/Dockerfile",
               "simpleTags": [
-                "3.1-bionic",
-                "3.1.201-bionic"
+                "2.1-alpine3.10",
+                "2.1.805-alpine3.10"
               ],
-              "digest": "sha256:2dfe2a9523d681e125f645ed469bf04c46baf62fd5d8268c730af68ec7ecb035",
+              "digest": "sha256:21e0f31582de22e69b87c3fc9bfbb0878bceddf0c508bc74cadaff1e23c62e4d",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:36:49.7608631Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/sdk/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-alpine",
+                "2.1-alpine3.11",
+                "2.1.805-alpine",
+                "2.1.805-alpine3.11"
+              ],
+              "digest": "sha256:fde6baee640db6764a719e3901e3935756fff603cae1703f8a9d654d7986df80",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:37:04.8399526Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "2.1/sdk/bionic/amd64/Dockerfile",
+              "simpleTags": [
+                "2.1-bionic",
+                "2.1.805-bionic"
+              ],
+              "digest": "sha256:d4eeba2c721f7416394b2da898b31cd1cabbc435b25fa51fa46546dae81aec75",
               "baseImageDigest": "amd64/buildpack-deps@sha256:2fca27ce716210dadbc5937d64e26e6c3e0ca877b93e446be48e7dc579feb56b",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:37.6969495Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/sdk/bionic/amd64/Dockerfile"
+              "created": "2020-03-30T15:36:52.08217Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.201",
           "platforms": [
             {
-              "dockerfile": "3.1/sdk/bionic/arm32v7/Dockerfile",
+              "dockerfile": "2.1/sdk/bionic/arm32v7/Dockerfile",
               "simpleTags": [
-                "3.1-bionic-arm32v7",
-                "3.1.201-bionic-arm32v7"
+                "2.1-bionic-arm32v7",
+                "2.1.805-bionic-arm32v7"
               ],
-              "digest": "sha256:78638686a5d9aeb5452322f6a614ff5f523e5d6d33ccb213225357cc9dfdae35",
+              "digest": "sha256:e036cfc307c23aa73536768b1f539295a85d211e03efcdf0b91541f79d28d50a",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:7e6e04f39cd0dc85e0b24f200da5cf0c30afbb42000dec34435ca182b138a7d2",
               "osType": "Linux",
               "osVersion": "Ubuntu 18.04",
               "architecture": "arm32",
-              "created": "2020-04-09T16:12:04.799488Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/bionic/arm32v7/Dockerfile"
+              "created": "2020-03-24T16:49:09.0764059Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "3.1.201",
-          "platforms": [
-            {
-              "dockerfile": "3.1/sdk/bionic/arm64v8/Dockerfile",
-              "simpleTags": [
-                "3.1-bionic-arm64v8",
-                "3.1.201-bionic-arm64v8"
-              ],
-              "digest": "sha256:651f981d711288c18d3ba2f0212aba02b1ddca3217ab4f386eb1b29d705f1562",
-              "baseImageDigest": "arm64v8/buildpack-deps@sha256:c1fd085d9e2d43d672e9504fae9d41636f60af0f02e76263ae4ee9ee91366b93",
-              "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
-              "architecture": "arm64",
-              "created": "2020-04-09T16:10:39.329903Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/bionic/arm64v8/Dockerfile"
-            }
-          ]
-        },
-        {
-          "productVersion": "3.1.201",
           "manifest": {
-            "digest": "sha256:cad1f51e65af52e5551e5182b163326c8fceca93d0dbb9e8de8d85b95748e4e2",
-            "created": "2020-04-09T16:37:33.1378755Z",
+            "digest": "sha256:bf755bf00ee2712af5fb71af0aea57e8e65dc2cc191f28c2d1f95c325f00177f",
+            "created": "2020-03-24T16:56:22.0785728Z",
             "sharedTags": [
-              "3.1",
               "3.1.201",
+              "3.1",
               "latest"
             ]
           },
@@ -618,13 +1776,13 @@
                 "3.1-buster",
                 "3.1.201-buster"
               ],
-              "digest": "sha256:d81d9ab0253c2c578578b2032955984562684c182e3a15dacc3bbdb31260d4e4",
+              "digest": "sha256:ffdaf00ea1408bd71e169a90dbab34914c999674a81fcced8ed919f9a8797dda",
               "baseImageDigest": "amd64/buildpack-deps@sha256:4898e2f8c0201c39fe3fe4c187d138083c1451c23033ff0e965c7a9874f4651a",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:46.2826578Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d68460ceab4fe635d95a28bfca410db1a1d57caa/3.1/sdk/buster/amd64/Dockerfile"
+              "created": "2020-03-31T04:19:39.5174672Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "3.1/sdk/buster/arm32v7/Dockerfile",
@@ -632,13 +1790,13 @@
                 "3.1-buster-arm32v7",
                 "3.1.201-buster-arm32v7"
               ],
-              "digest": "sha256:fd2276c5621c18aeb48dcd84c348d69fabd60cbdf0a0ffa7b37bbdb355c39fcf",
+              "digest": "sha256:867f527c058f777badd4e67da509ab56fdd905ca44dc247ad2ecd5cd50123fae",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:d5bc40558cd219c0048949d5aa1dd8b4916ba988fc604e0a82e26fe2ca1ea5f3",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-04-09T16:12:14.7229349Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/buster/arm32v7/Dockerfile"
+              "created": "2020-03-31T04:20:39.2092048Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "3.1/sdk/buster/arm64v8/Dockerfile",
@@ -646,24 +1804,169 @@
                 "3.1-buster-arm64v8",
                 "3.1.201-buster-arm64v8"
               ],
-              "digest": "sha256:acf607cac9821dc7590c4a0e76e39d95b37730dbf70edf36b343eb67ff95c5b4",
+              "digest": "sha256:d5d38184853526a3fb69f4326e1c109b75620c309ccecbdfed876f2d6262366a",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:8d7c433c44214dc285cf89aa4e2e3a8831e452defca321b73650271724b71988",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-04-09T16:10:50.0661302Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5e9b849a900c69edfe78f6e0f3519009de4ab471/3.1/sdk/buster/arm64v8/Dockerfile"
+              "created": "2020-03-31T08:07:49.1092439Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/sdk/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.201-nanoserver-1809",
+                "3.1-nanoserver-1809"
+              ],
+              "digest": "sha256:155ee8d4ad48caeab4bb47a82e5d1b5aee3f7df0a4ad238590ee66c18ae7bb7c",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5de6bd32bd453d60c8f549d28845552e89ad3652566e141ac82023b6ba10374d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:50:04.2347248Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/sdk/nanoserver-1809/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-nanoserver-1809-arm32v7",
+                "3.1.201-nanoserver-1809-arm32v7"
+              ],
+              "digest": "sha256:e3150b799f61b2891b259bbab2555c78e73c5ca1abefa6e1c5dd53e1657062e3",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:8b73c776dc0ed5b35595da20f50d0454809ae081a7acc9eb847bd76405ea0c61",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:56:22.0785728Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/sdk/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.201-nanoserver-1903",
+                "3.1-nanoserver-1903"
+              ],
+              "digest": "sha256:57e0651e4aa1e24546ab5c76e68e4d362a9608afe3b639a05d7e3136371aed48",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:1ba75187a3768a1dfd6889b311fcda0e40e21da1bfc83521e8c2d527546959be",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:50:39.8464937Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "3.1/sdk/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1.201-nanoserver-1909",
+                "3.1-nanoserver-1909"
+              ],
+              "digest": "sha256:d7b5969c4d83d8e7e9aee91b59cabfcd86f09f9bb42620758a26f00fc1143f23",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:e78d71661c100cac7790083bd33ca472247ac1b6237f7bc642d9c05831f1e740",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-03-24T16:50:10.9851473Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.100-preview.2",
+          "platforms": [
+            {
+              "dockerfile": "3.1/sdk/alpine3.10/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine3.10",
+                "3.1.201-alpine3.10"
+              ],
+              "digest": "sha256:33e66f16cf43967c200d49c42329d5d377d7f08fe4b901976201183ebdd23ace",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.10",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:36:25.8553208Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/sdk/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-alpine",
+                "3.1-alpine3.11",
+                "3.1.201-alpine",
+                "3.1.201-alpine3.11"
+              ],
+              "digest": "sha256:e841ccabd7df91acc3869e3edb7f82b282b6585e5a9b828651a3b03a10062297",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:36:07.8074607Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/sdk/bionic/amd64/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic",
+                "3.1.201-bionic"
+              ],
+              "digest": "sha256:3f121cda5878fc823f5ae10cddeb32b64a8227f6d7c32e5b4f066d5ccefa1011",
+              "baseImageDigest": "amd64/buildpack-deps@sha256:2fca27ce716210dadbc5937d64e26e6c3e0ca877b93e446be48e7dc579feb56b",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "amd64",
+              "created": "2020-03-30T15:36:13.9291812Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/sdk/bionic/arm32v7/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm32v7",
+                "3.1.201-bionic-arm32v7"
+              ],
+              "digest": "sha256:40bf64351f2ef63ac7b5d5dfb4ad2661eaee5cc01973c3dcd145db54bc7a2e4f",
+              "baseImageDigest": "arm32v7/buildpack-deps@sha256:7e6e04f39cd0dc85e0b24f200da5cf0c30afbb42000dec34435ca182b138a7d2",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm32",
+              "created": "2020-03-24T16:47:45.9005278Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "3.1/sdk/bionic/arm64v8/Dockerfile",
+              "simpleTags": [
+                "3.1-bionic-arm64v8",
+                "3.1.201-bionic-arm64v8"
+              ],
+              "digest": "sha256:b7def06355a3c6c79ebce82b0c00c50368465a4ececb6a099e3701c851b67a4d",
+              "baseImageDigest": "arm64v8/buildpack-deps@sha256:c1fd085d9e2d43d672e9504fae9d41636f60af0f02e76263ae4ee9ee91366b93",
+              "osType": "Linux",
+              "osVersion": "Ubuntu 18.04",
+              "architecture": "arm64",
+              "created": "2020-03-24T16:47:44.2434051Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
           "manifest": {
-            "digest": "sha256:6be60ad746b2649e88e20f51bcb67958104980001b6aa98b16c03556ce85c5e2",
-            "created": "2020-04-09T16:37:33.1378755Z",
+            "digest": "sha256:2e61573f786a93342e18e887b564edea64acf47d8d84b18f4fce3467952d2fc5",
+            "created": "2020-04-03T13:04:01.226855Z",
             "sharedTags": [
-              "5.0",
-              "5.0.100-preview.2"
+              "5.0.100-preview.2",
+              "5.0"
             ]
           },
           "platforms": [
@@ -673,13 +1976,13 @@
                 "5.0-buster",
                 "5.0.100-preview.2-buster"
               ],
-              "digest": "sha256:421cc050773b268bdb2556920a83b371b9763d0e29ce96d90a8bd8602fc8e33c",
+              "digest": "sha256:3515f953fc7dbf91a5f4de6c1bcc3ab0054d23627df5553414cbad2a21ea9422",
               "baseImageDigest": "amd64/buildpack-deps@sha256:4898e2f8c0201c39fe3fe4c187d138083c1451c23033ff0e965c7a9874f4651a",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "amd64",
-              "created": "2020-04-09T16:11:02.3609144Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/buster/amd64/Dockerfile"
+              "created": "2020-04-03T13:00:09.9643294Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "5.0/sdk/buster/arm32v7/Dockerfile",
@@ -687,13 +1990,13 @@
                 "5.0-buster-arm32v7",
                 "5.0.100-preview.2-buster-arm32v7"
               ],
-              "digest": "sha256:916df1ae272d8a70cf9f2aa0e29b2e35d8d54e922a68d34726531f7218f35767",
+              "digest": "sha256:188ea80ef0a1687654767f32f4b237ecddb5a823c44716515e90d5aff4fd88c7",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:d5bc40558cd219c0048949d5aa1dd8b4916ba988fc604e0a82e26fe2ca1ea5f3",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm32",
-              "created": "2020-04-09T16:10:38.6513532Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/buster/arm32v7/Dockerfile"
+              "created": "2020-04-03T13:00:26.3733258Z",
+              "commitUrl": null
             },
             {
               "dockerfile": "5.0/sdk/buster/arm64v8/Dockerfile",
@@ -701,18 +2004,78 @@
                 "5.0-buster-arm64v8",
                 "5.0.100-preview.2-buster-arm64v8"
               ],
-              "digest": "sha256:6148a0cba9feb779c6c9d4453f5844c386b01a2f93f169ff45f797dabefa87bc",
+              "digest": "sha256:61854764b3acdfdcd404d52236177be5a3083f0e4b0b7d3cd102ccb56b140aad",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:8d7c433c44214dc285cf89aa4e2e3a8831e452defca321b73650271724b71988",
               "osType": "Linux",
               "osVersion": "Debian 10",
               "architecture": "arm64",
-              "created": "2020-04-09T16:10:32.9092893Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/buster/arm64v8/Dockerfile"
+              "created": "2020-04-03T13:00:23.7652224Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/sdk/nanoserver-1809/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.100-preview.2-nanoserver-1809",
+                "5.0-nanoserver-1809"
+              ],
+              "digest": "sha256:b208e366679def9ec82ec29c496bbbde481a4e2df8bab01b08aa02b7c20d9612",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5de6bd32bd453d60c8f549d28845552e89ad3652566e141ac82023b6ba10374d",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:02:24.426087Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/sdk/nanoserver-1903/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.100-preview.2-nanoserver-1903",
+                "5.0-nanoserver-1903"
+              ],
+              "digest": "sha256:341ac38114c77e6d7165dbfcffbb1d126bd2ba42fa5204e9fd713ad3881031f3",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:1ba75187a3768a1dfd6889b311fcda0e40e21da1bfc83521e8c2d527546959be",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:04:01.226855Z",
+              "commitUrl": null
+            },
+            {
+              "dockerfile": "5.0/sdk/nanoserver-1909/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0.100-preview.2-nanoserver-1909",
+                "5.0-nanoserver-1909"
+              ],
+              "digest": "sha256:58b9f7172da6c6179e62de6a3f7d7d0a1d20b1227331e62b3985d564c3b2244c",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:e78d71661c100cac7790083bd33ca472247ac1b6237f7bc642d9c05831f1e740",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:02:20.8907104Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.100-preview.2",
+          "platforms": [
+            {
+              "dockerfile": "5.0/sdk/alpine3.11/amd64/Dockerfile",
+              "simpleTags": [
+                "5.0-alpine",
+                "5.0-alpine3.11",
+                "5.0.100-preview.2-alpine",
+                "5.0.100-preview.2-alpine3.11"
+              ],
+              "digest": "sha256:c05cf8b966a5158ca9c3f3490bdadb70ef970d3be52ad58db6ccf11a7277a5d7",
+              "osType": "Linux",
+              "osVersion": "Alpine 3.11",
+              "architecture": "amd64",
+              "created": "2020-04-03T13:00:12.2144576Z",
+              "commitUrl": null
+            }
+          ]
+        },
+        {
           "platforms": [
             {
               "dockerfile": "5.0/sdk/focal/amd64/Dockerfile",
@@ -720,18 +2083,17 @@
                 "5.0-focal",
                 "5.0.100-preview.2-focal"
               ],
-              "digest": "sha256:8576786f3bf05da76e894a4a1cc1bf561f4549635acb5c8bea7642c80e70d2ac",
+              "digest": "sha256:bbedb7b507b3ec7cd80922cc5c202a2890823d22a7685d835448a4ef69681159",
               "baseImageDigest": "amd64/buildpack-deps@sha256:2b175c6bbfadc97ed80b8fa4adbd5c59503c8465f50977806489187868bd8618",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "amd64",
-              "created": "2020-04-09T16:10:46.0643984Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/focal/amd64/Dockerfile"
+              "created": "2020-04-03T13:00:16.9437727Z",
+              "commitUrl": null
             }
           ]
         },
         {
-          "productVersion": "5.0.100-preview.2",
           "platforms": [
             {
               "dockerfile": "5.0/sdk/focal/arm64v8/Dockerfile",
@@ -739,13 +2101,13 @@
                 "5.0-focal-arm64v8",
                 "5.0.100-preview.2-focal-arm64v8"
               ],
-              "digest": "sha256:7495b0a30be3b038b12d55fc4d26bb58ab792e8102204386604a69d5b9560088",
+              "digest": "sha256:1e7457d3fcd5a364dc871d2b36a5f9167fcc7aee3a10823b7788a4282cb9bf63",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:c8a1fd41fb9fa7e3ade560f086b9c33cd4275be0bc870ccfd1d64cf17f28672d",
               "osType": "Linux",
               "osVersion": "Ubuntu 20.04",
               "architecture": "arm64",
-              "created": "2020-04-09T16:10:45.9396393Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/5d883f27746e05286129098d4ce196cf8042cb2e/5.0/sdk/focal/arm64v8/Dockerfile"
+              "created": "2020-04-03T13:00:30.3084714Z",
+              "commitUrl": null
             }
           ]
         }


### PR DESCRIPTION
The image info files are getting corrupted by builds that only build a partial set of the images that are represented within the image info file.  The publish of the image info ends up clearing out anything that wasn't part of the build.  I've reverted the changes to these files back to their original state and then manually added back the content for the new images that were recently published.

Related: https://github.com/dotnet/docker-tools/pull/475