### PR TITLE
Fixing up samples image info

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -1563,8 +1563,110 @@
       "images": [
         {
           "manifest": {
-            "digest": "sha256:be51cb56c9bdfbdcc2ea6aa1c69a33addfbabf9f9f174cdcc021e0f5410e323c",
-            "created": "0001-01-01T06:00:00Z",
+            "digest": "sha256:ea94be298f14323a8244d3b20748f0862ec345cb9f84e3a679b0cf90c3e19c44",
+            "created": "2020-04-09T15:25:39.4784676Z",
+            "sharedTags": [
+              "aspnetapp"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "simpleTags": [
+                "aspnetapp-buster-slim"
+              ],
+              "digest": "sha256:62efb7186f5f4b348a9ea942780782deecb17b5445d06844b71feac5d48b0d20",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:31355469835e6df7538dbf5a4100c095338b51cbe52154aa23ae79d87585d404",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:48:46.4109596Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/aspnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "simpleTags": [
+                "aspnetapp-nanoserver-1809"
+              ],
+              "digest": "sha256:a53b91c87234d8daebb23de1ddfd93096b34feec2c043c349c2b12e4338d692d",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:31355469835e6df7538dbf5a4100c095338b51cbe52154aa23ae79d87585d404",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:48:34.9986404Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/aspnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "simpleTags": [
+                "aspnetapp-nanoserver-1903"
+              ],
+              "digest": "sha256:543820e6ff925458e9986c5d624b75654007acac720e333f1ea10f867c23eaae",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:31355469835e6df7538dbf5a4100c095338b51cbe52154aa23ae79d87585d404",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:48:42.0017975Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/aspnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "simpleTags": [
+                "aspnetapp-nanoserver-1909"
+              ],
+              "digest": "sha256:759b0b6bfe4405c48520a97945157fdbc7696829ef63e48d1fe840bd4953df2c",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:31355469835e6df7538dbf5a4100c095338b51cbe52154aa23ae79d87585d404",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:48:45.9661306Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/aspnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "simpleTags": [
+                "aspnetapp-buster-slim-arm64v8"
+              ],
+              "digest": "sha256:8cd9b021e31c01c8d0d07796fe99c63b770ced788589be0260cd15b46dbea27d",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:31355469835e6df7538dbf5a4100c095338b51cbe52154aa23ae79d87585d404",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm64",
+              "created": "2020-04-09T14:49:00.2702649Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/aspnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile.debian-arm32",
+              "simpleTags": [
+                "aspnetapp-buster-slim-arm32v7"
+              ],
+              "digest": "sha256:72bdcc26171ca056a3da5088b76745d5b4dc59ec4e57cf1dce28bb258cdee8c0",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:166d57afdc13c128853374d53b92378971e3d701a25bb6c9b25e6d65326f4d70",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm32",
+              "created": "2020-04-09T14:48:51.8713831Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/aspnetapp/Dockerfile.debian-arm32"
+            },
+            {
+              "dockerfile": "samples/aspnetapp/Dockerfile.nanoserver-arm32",
+              "simpleTags": [
+                "aspnetapp-nanoserver-1809-arm32v7"
+              ],
+              "digest": "sha256:7ff2632e2f1a261eec0fba882d0fabab66b982090afa38341da8e09feed9402f",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:52f0bb56dbde63add1f8440b7299103251bab740477e6c7de50f8af9e5f8a1b1",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "arm32",
+              "created": "2020-04-09T14:57:52.3816017Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/aspnetapp/Dockerfile.nanoserver-arm32"
+            }
+          ]
+        },
+        {
+          "manifest": {
+            "digest": "sha256:c60dc1674d80cb30b7b830c229cb48cbd1591e9e7297f0350410e67ccdb88103",
+            "created": "2020-04-09T15:25:39.4784676Z",
             "sharedTags": [
               "dotnetapp",
               "latest"
@@ -1574,47 +1676,93 @@
             {
               "dockerfile": "samples/dotnetapp/Dockerfile",
               "simpleTags": [
-                "dotnetapp-buster-slim",
-                "dotnetapp-buster-slim-arm64v8",
-                "dotnetapp-nanoserver-1809",
-                "dotnetapp-nanoserver-1903",
+                "dotnetapp-buster-slim"
+              ],
+              "digest": "sha256:c288da06bb6fb4f26fdd97599ebb9716ea78b97ed14210cedbd3d036d73f1e14",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:9f2916ef6522918eca16d16bac251f5af196a44f46caf7954ba6cd504c1d4ec4",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:48:26.3026131Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/dotnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "simpleTags": [
+                "dotnetapp-nanoserver-1809"
+              ],
+              "digest": "sha256:ab3133707019aea04fdb85f9687ec2a3bf5c315090b5b02f37ac4861b1fae0df",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:9f2916ef6522918eca16d16bac251f5af196a44f46caf7954ba6cd504c1d4ec4",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:48:29.7689468Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/dotnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "simpleTags": [
+                "dotnetapp-nanoserver-1903"
+              ],
+              "digest": "sha256:45228286a834dafe7e54e4c4725b446bea59b968ffea618fc632661db6d75c42",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:9f2916ef6522918eca16d16bac251f5af196a44f46caf7954ba6cd504c1d4ec4",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1903",
+              "architecture": "amd64",
+              "created": "2020-04-09T14:48:35.3007141Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/dotnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile",
+              "simpleTags": [
                 "dotnetapp-nanoserver-1909"
               ],
-              "digest": "sha256:18da146f244d5f415100b717cbf5112c69ee04c07c5cc274be293da4f48d72bd",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:318e18f1616bb2e85f489bf6caca8d9934a5610178df2f0fff8e9bf4ba34091f",
-              "osType": "Linux",
-              "osVersion": "Debian 10",
+              "digest": "sha256:1bbd3b284b43c4b4b1ec6f44f5f43386b6ef7615619eb50e7d78ab1e1b6a4dcb",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:9f2916ef6522918eca16d16bac251f5af196a44f46caf7954ba6cd504c1d4ec4",
+              "osType": "Windows",
+              "osVersion": "Windows Server, version 1909",
               "architecture": "amd64",
-              "created": "2020-03-31T08:07:51.3178675Z",
-              "commitUrl": null
-            }
-          ]
-        },
-        {
-          "manifest": {
-            "digest": "sha256:b03dba91aad40298f312383b8f359a38254ebc62bb49c85562916fcd1af07f91",
-            "created": "0001-01-01T06:00:00Z",
-            "sharedTags": [
-              "aspnetapp"
-            ]
-          },
-          "platforms": [
+              "created": "2020-04-09T14:48:39.0634783Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/dotnetapp/Dockerfile"
+            },
             {
-              "dockerfile": "samples/aspnetapp/Dockerfile",
+              "dockerfile": "samples/dotnetapp/Dockerfile",
               "simpleTags": [
-                "aspnetapp-buster-slim",
-                "aspnetapp-buster-slim-arm64v8",
-                "aspnetapp-nanoserver-1809",
-                "aspnetapp-nanoserver-1903",
-                "aspnetapp-nanoserver-1909"
+                "dotnetapp-buster-slim-arm64v8"
               ],
-              "digest": "sha256:d5e7990d8b5ee3cbd49001dbc43b6f2c57efaa45d87d6875153fbd2cc21a4ba6",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/core/aspnet@sha256:7ec5aaee0d88954394eee20762270bfbf56c938172e81bd415274d633a2c515f",
+              "digest": "sha256:8ce02c8c161dee92dc97044ca167130adf687a1744ddd485401baf2908f761a0",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:9f2916ef6522918eca16d16bac251f5af196a44f46caf7954ba6cd504c1d4ec4",
               "osType": "Linux",
               "osVersion": "Debian 10",
-              "architecture": "amd64",
-              "created": "2020-03-31T08:08:03.4337705Z",
-              "commitUrl": null
+              "architecture": "arm64",
+              "created": "2020-04-09T14:48:47.9813899Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/dotnetapp/Dockerfile"
+            },
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile.debian-arm32",
+              "simpleTags": [
+                "dotnetapp-buster-slim-arm32v7"
+              ],
+              "digest": "sha256:e148277814687f959d0077d089d9f27cb40552a035775740818aa8dd0b85261b",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:0fca2f7aa8cf0d14d7f7066f178a6304925d4e9b2230d97a39e1e08caa055748",
+              "osType": "Linux",
+              "osVersion": "Debian 10",
+              "architecture": "arm32",
+              "created": "2020-04-09T14:48:51.9276797Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/dotnetapp/Dockerfile.debian-arm32"
+            },
+            {
+              "dockerfile": "samples/dotnetapp/Dockerfile.nanoserver-arm32",
+              "simpleTags": [
+                "dotnetapp-nanoserver-1809-arm32v7"
+              ],
+              "digest": "sha256:f5c0bfe77167c9cf2f1f617ad9151cadaae43113aad692fda95fc2d01d294ee8",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime@sha256:490bccb2f8840d72c1ad690d4d1e2a16c62dd274a0e0cc9d45ca72beb3c3436a",
+              "osType": "Windows",
+              "osVersion": "Windows Server 2019",
+              "architecture": "arm32",
+              "created": "2020-04-09T14:58:44.62106Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/17c1eec582e84ba9cbea5641cd9cc13fe1a41c39/samples/dotnetapp/Dockerfile.nanoserver-arm32"
             }
           ]
         }


### PR DESCRIPTION
After the https://github.com/dotnet/versions/blob/master/build-info/docker/image-info.dotnet-dotnet-docker-master.json file got corrupted yesterday, I had attempted to restore and update it with current content in https://github.com/dotnet/versions/pull/588.  But in those changes, I didn't correctly update the content for the sample images.  This is causing the base image checking system to think the samples need to get rebuilt when they do not need to be.  These changes fix up the content so that things are up-to-date with the actual images that are currently published.