### PR TITLE
Add placeholder image info for docker-tools

### DIFF
--- a/build-info/docker/image-info.dotnet-docker-tools-master.json
+++ b/build-info/docker/image-info.dotnet-docker-tools-master.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "1.0",
+  "repos": [
+    {
+      "repo": "dotnet/test",
+      "images": [
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a placeholder file so that builds can successfully resolve an image info file for the docker-tools repo in order to validate the "publish image info" task.

Related: https://github.com/dotnet/docker-tools/issues/474