### PR TITLE
Add dotnet/insertions-client for mirroring

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -698,6 +698,7 @@
         "https://github.com/dotnet/dotnet-docker/blob/nightly/**/*",
         "https://github.com/dotnet/fsharp/blob/master/**/*",
         "https://github.com/dotnet/fsharp/blob/release/**/*",
+        "https://github.com/dotnet/insertions-client/blob/master/**/*",
         "https://github.com/dotnet/installer/blob/master/**/*",
         "https://github.com/dotnet/installer/blob/release/**/*",
         "https://github.com/dotnet/install-scripts/blob/master/**/*",


### PR DESCRIPTION
We have a new repo `dotnet/insertions-client` that needs to be mirrored into dnceng/internal