### PR TITLE
Fix SBRP release branch repo mirror: typo

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -735,7 +735,7 @@
         "https://github.com/dotnet/source-build/blob/master/**/*",
         "https://github.com/dotnet/source-build/blob/release/**/*",
         "https://github.com/dotnet/source-build-reference-packages/blob/master/**/*",
-        "https://github.com/dotnet/source-build-reference-pacakges/blob/release/**/*",
+        "https://github.com/dotnet/source-build-reference-packages/blob/release/**/*",
         "https://github.com/dotnet/source-indexer/blob/master/**/*",
         "https://github.com/dotnet/sourcelink/blob/master/**/*",
         "https://github.com/dotnet/sourcelink/blob/release/**/*",


### PR DESCRIPTION
For https://github.com/dotnet/source-build/issues/1634