### PR TITLE
Move MSBuild to its new dotnet home

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -601,6 +601,9 @@
         "https://github.com/dotnet/machinelearning/blob/master/**/*",
         "https://github.com/dotnet/machinelearning/blob/release/**/*",
         "https://github.com/dotnet/machinelearning/blob/features/**/*",
+        "https://github.com/dotnet/msbuild/blob/vs/**/*",
+        "https://github.com/dotnet/msbuild/blob/master/**/*",
+        "https://github.com/dotnet/msbuild/blob/exp/**/*",
         "https://github.com/dotnet/source-build/blob/master/**/*",
         "https://github.com/dotnet/source-build/blob/release/**/*",
         "https://github.com/dotnet/standard/blob/master/**/*",
@@ -610,8 +613,6 @@
         "https://github.com/dotnet/uwp-setup/blob/rel/**/*",
         "https://github.com/dotnet/xliff-tasks/blob/master/**/*",
         "https://github.com/dotnet/xliff-tasks/blob/release/**/*",
-        "https://github.com/Microsoft/msbuild/blob/vs/**/*",
-        "https://github.com/Microsoft/msbuild/blob/master/**/*",
         "https://github.com/Microsoft/visualfsharp/dev/**/*",
         "https://github.com/Microsoft/visualfsharp/master/**/*"
       ],
@@ -713,6 +714,8 @@
         "https://github.com/dotnet/llvm-project/blob/release/**/*",
         "https://github.com/dotnet/metadata-tools/blob/master/**/*",
         "https://github.com/dotnet/metadata-tools/blob/release/**/*",
+        "https://github.com/dotnet/msbuild/blob/master/**/*",
+        "https://github.com/dotnet/msbuild/blob/vs/**/*",
         "https://github.com/dotnet/msbuild-language-service/blob/master/**/*",
         "https://github.com/dotnet/msbuild-language-service/blob/release/**/*",
         "https://github.com/dotnet/org-policy/blob/master/**/*",
@@ -783,8 +786,6 @@
         "https://github.com/dotnet/xliff-tasks/blob/master/**/*",
         "https://github.com/dotnet/xliff-tasks/blob/release/**/*",
         "https://github.com/Microsoft/dotnet-framework-docker/blob/master/**/*",
-        "https://github.com/Microsoft/msbuild/blob/master/**/*",
-        "https://github.com/Microsoft/msbuild/blob/release/**/*",
         "https://github.com/Microsoft/clrmd/blob/master/**/*",
         "https://github.com/Microsoft/clrmd/blob/release/**/*",
         "https://github.com/microsoft/reverse-proxy/blob/master/**/*",
@@ -1523,8 +1524,7 @@
         //"https://github.com/dotnet/winforms/blob/release/3.1/**/*",
         "https://github.com/dotnet/winforms/blob/release/5.0/**/*",
         //"https://github.com/dotnet/wpf/blob/release/3.1/**/*",
-        "https://github.com/dotnet/wpf/blob/release/5.0/**/*",
-        "https://github.com/Microsoft/msbuild/blob/release/**/*"
+        "https://github.com/dotnet/wpf/blob/release/5.0/**/*"
       ],
       "action": "github-dnceng-azdo-internal-merge-mirror",
       "actionArguments": {


### PR DESCRIPTION
Also added `exp/*` to devdiv mirror so we can continue to use the experimental-branch-to-official-build-to-VS-insertion-PR flow.

@MattGal