### PR TITLE
Fix MSBuild release-branch RI automation

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1573,13 +1573,13 @@
     // For details on how the triggerpath globbing syntax works, see: https://github.com/dotnet/versions/issues/558
     {
       "triggerPaths": [
-        "https://github.com/microsoft/msbuild/blob/vs16./**/*"
+        "https://github.com/dotnet/msbuild/blob/vs16./**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
         "vsoSourceBranch": "master",
         "vsoBuildParameters": {
-          "GithubRepoOwner": "microsoft",
+          "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
           "BaseBranch": "master"


### PR DESCRIPTION
Accounting for the microsoft->dotnet org move.

@MattGal I missed this one, sorry.

cc @BenVillalobos