### PR TITLE
Flow ASP.NET `release/5.0-rc2` into `release/5.0`

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1005,14 +1005,13 @@
         }
       }
     },
-    // Automate opening PRs to merge aspnet release/3.1 branches back to master.
+    // Automate opening PRs to merge aspnet release/3.1 branches back to master and main.
     {
       "triggerPaths": [
         "https://github.com/dotnet/aspnetcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*",
         "https://github.com/dotnet/blazor/blob/release/3.1//**/*",
         "https://github.com/dotnet/ef6/blob/release/6.4//**/*",
-        "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/extensions/blob/release/3.1//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
@@ -1026,10 +1025,24 @@
         }
       }
     },
-    // Automate opening PRs to merge aspnet release/5.0-previewN branches back to master.
     {
       "triggerPaths": [
-        "https://github.com/dotnet/aspnetcore-tooling/blob/release/5.0//**/*",
+        "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "main"
+        }
+      }
+    },
+    // Automate opening PRs to merge extensions release/5.0-previewN branches back to master.
+    {
+      "triggerPaths": [
         "https://github.com/dotnet/extensions/blob/release/5.0//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
@@ -1043,7 +1056,7 @@
         }
       }
     },
-    // Automate opening PRs to merge aspnet release/5.0-rc2 branches back to master.
+    // Automate opening PRs to merge aspnet release/5.0-rc2 branches back to release/5.0.
     {
       "triggerPaths": [
         "https://github.com/dotnet/aspnetcore/blob/release/5.0-rc2//**/*",
@@ -1056,14 +1069,28 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/5.0"
+        }
+      }
+    },
+    // Automate opening PRs to merge aspnet release/5.0 branches back to master and main.
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/aspnetcore/blob/release/5.0//**/*",
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "master",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
           "BaseBranch": "master"
         }
       }
     },
-    // Automate opening PRs to merge aspnet release/5.0 branches back to release/5.0-rc2.
     {
       "triggerPaths": [
-        "https://github.com/dotnet/aspnetcore/blob/release/5.0//**/*",
         "https://github.com/dotnet/efcore/blob/release/5.0//**/*",
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
@@ -1073,7 +1100,7 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/5.0-rc2"
+          "BaseBranch": "main"
         }
       }
     },


### PR DESCRIPTION
- also correct efcore-related automation to use 'main' branch where appropriate