### PR TITLE
Convert Docker image info files to new osVersion format

### DIFF
--- a/build-info/docker/image-info.dotnet-docker-tools-master-imagebuilder.json
+++ b/build-info/docker/image-info.dotnet-docker-tools-master-imagebuilder.json
@@ -47,7 +47,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/image-builder@sha256:755dfd06aae57b83951dd85f371989829377a703bb3550b69595f57171435648",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:2b783310e6c82de737e893abd53ae238ca56b5a96e2861558fb9a111d6691ddb",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-23T13:54:31.3509792Z",
               "commitUrl": "https://github.com/dotnet/docker-tools/blob/38bc667d2578111c83d03e12bd90db3f11df3080/Dockerfile.windows"

--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -624,7 +624,7 @@
               "digest": "sha256:55e11ea9ba534c09d93aeb1f9141169a18bf7e36a4291f2902dde2c386782d05",
               "baseImageDigest": "mcr.microsoft.com/powershell@sha256:8a4e778616607888d88eb64ca72eab4740b2ecef4c93fccf12e1d13cec204646",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-08-04T01:50:59.4713891Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/nanoserver/1809/helix/amd64/Dockerfile"
@@ -1304,7 +1304,7 @@
               "digest": "sha256:a8898a642e91903f90c83d05f4a18e60e2c375b6f744a768eb7d121097600fad",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:921bed01c2a023310bdbaa288edebd82c4910e536ff206b87e9cbe703ca27505",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-08-04T01:50:43.01719Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-master-samples.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master-samples.json
@@ -34,7 +34,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:a107bf5d8eb8a2e2f50ee160dfd35a5ad9f1b0d71bb441a00aa303916c448ad5",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:c7a62424519d45e1a4d75968eddbc295725be88e78cd17b0f1bdcd1f916862a0",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-18T04:09:33.2393264Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/aspnetapp/Dockerfile"
@@ -47,7 +47,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:e0f87e83dcb0541010e08214f50930a8ab8e0c0f2e57f0168e8a9cb49e8d490f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:c7a62424519d45e1a4d75968eddbc295725be88e78cd17b0f1bdcd1f916862a0",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-18T04:09:43.8927451Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/aspnetapp/Dockerfile"
@@ -60,7 +60,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:fdc7de48eb5d94456c9731783fce64c8a80096f42375478c13d4ad7156f63520",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:c7a62424519d45e1a4d75968eddbc295725be88e78cd17b0f1bdcd1f916862a0",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-18T04:39:57.0839241Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/aspnetapp/Dockerfile"
@@ -73,7 +73,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:8588c73962c2ae7e9ab88aa8da46410fe3a899b4097d7f2adda6244df16750ac",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:c7a62424519d45e1a4d75968eddbc295725be88e78cd17b0f1bdcd1f916862a0",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-18T04:09:52.928173Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/aspnetapp/Dockerfile"
@@ -137,7 +137,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:147b18f9e7b641d36e3a5d887b2e955ff2b1056f738d448095f694bed221950d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:0ffc67290fa5de7c3e623a9e1b3cc4f7cb83c9603793ebc2f3dd58ebd39139a3",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-18T04:09:36.321958Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/dotnetapp/Dockerfile"
@@ -150,7 +150,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:a08138b1eca96a9730c1512a0c281880a4a8dd45943ab67763a680826451ed62",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:0ffc67290fa5de7c3e623a9e1b3cc4f7cb83c9603793ebc2f3dd58ebd39139a3",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-18T04:09:36.5637806Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/dotnetapp/Dockerfile"
@@ -163,7 +163,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:779a12d528e8874debe60b1025d18f40b8dd8d453b71c9d20bc2b8f9a70f3cbf",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:0ffc67290fa5de7c3e623a9e1b3cc4f7cb83c9603793ebc2f3dd58ebd39139a3",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-18T04:09:38.79456Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/dotnetapp/Dockerfile"
@@ -176,7 +176,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:aebd3125a280e0dca4b04e204dcc388b1fe0fbac2f32b8eab476c7390942db92",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:0ffc67290fa5de7c3e623a9e1b3cc4f7cb83c9603793ebc2f3dd58ebd39139a3",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-18T04:09:43.9429376Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/dotnetapp/Dockerfile"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -120,7 +120,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:61d5ecd9d4d95eeed3021a1cc6c33315de15b69b56c5ad4c7c4f1cba00b76933",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:23.0620849Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile"
@@ -134,7 +134,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:bec4648073d4b843958ab19ab23965a8b7790703cdcba9760cfa3410533e21c6",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:13.6016703Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile"
@@ -148,7 +148,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:45cb88ccf40a961198692be4377257c8bbc470efe9a37d030a93121757093765",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:33.4964735Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile"
@@ -162,7 +162,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:11cf4e4c14b9410c4c9d7644aadf3711dbc122901bc2ba7b9e3fad391690cd8a",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:31.5591899Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile"
@@ -176,7 +176,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:38454242d200f10887be3eeb9d26be28f857d39029e8fc6780603a793a8214a7",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:05.534497Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/dc2246b615011cc1bbfd0a1b6406a75a57c261db/src/aspnet/2.1/nanoserver-2009/amd64/Dockerfile"
@@ -370,7 +370,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:9949196bbda40b1f822ef8763b4d10c42f39d49360bcefbbd6584bd1045e03a8",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:a38b570c5311dffd348d91d34bf00f9a7c50a7dc0287cdc9345f56a8f0ddc70c",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:38.3416358Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile"
@@ -384,7 +384,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:e68387d3adca91e5894c0ff213522e0eb0593b1b32455b224afd561eb3424f56",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:3e4e71f9ffea34cdb90cbb936b739eab9b47cd77d7a0eb73d1e7415d36874a1c",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:44.6335768Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-1903/amd64/Dockerfile"
@@ -398,7 +398,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:7552f9b45920ca39aebfe0f03a7a33a2322c9981260f2ad8098fc947d725e607",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:d3964d40aef07818cbf03055fea7d3f2f59d6643ac82878f57eda7c2780c2217",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:58.9538959Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-1909/amd64/Dockerfile"
@@ -412,7 +412,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:6b343cc89e2373701f6f1746369012e2e97fd50a97f15fe468b235bc5a9a2961",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:e71b40bf5aad2924cf9582eebd6bc4b12bddc9fdd3e2bbcae0a0e10fea410b2d",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:58.5871247Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-2004/amd64/Dockerfile"
@@ -426,7 +426,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:4cf5b81e0277a7ee6329d04e6b8fddb8111b0a96d4f393f86e7d4be8e10b3f98",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:14bae528cbdb724e97746f8822037a6909a19644880b37ab5b4eb405bb1ef6b5",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:23.4068476Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-2009/amd64/Dockerfile"
@@ -640,7 +640,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:07f40b226a46ac87de06877dc2df6abeabd9e87c06a51dabdde48ed3de6a9023",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:51aa6048bc0fd7c224ad2343d222f9209204817a097b867e26ce45c86f76c925",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:34.9683096Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile"
@@ -654,7 +654,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:806f012ea2138dea380af0934f1f8f91eab76746f0105f4126f1893e502d0117",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:1d82a9b7c7bebe54dd0d15b8887c300a400d64eacb6e529adec1e536ae791cdb",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:17.2449935Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile"
@@ -668,7 +668,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:af29a75f6e2a1556dbd9d8b204437a7137982c7de54cbe511e37a0a469ee530c",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:eca8e3a2b8ab4968fd9bfbc5f04f977f7cb537b0fab5451ac97525b2098f3d3f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:34.1589332Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile"
@@ -682,7 +682,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:1a656dee0e51d98047b2517b6b5702fb0cb42550b9206b96b69b3c32c02ee602",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:186b035d70c4807ae61f9a2060e169dec4bb8eea02bdfcdd1226f8eb47028b8a",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:20.9620506Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-2009/amd64/Dockerfile"
@@ -756,7 +756,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:9ff3d142f5e36f085667f118d38a8b7da4ad7501b3aeb50c6178e680779a00ac",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:aeee0ee60aeed440afd8e42878d456972ef6d2f879b79d868967a35ed175db30",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:15.566704Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile"
@@ -884,7 +884,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:8a556c2943082b3f89f3edfc03a0cc899147d9a0df7d993869b0174a9a7d690e",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:20.9592919Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile"
@@ -898,7 +898,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:147f388237ba558e118d3e1213719d16fcfef149a0423069965b27054abe4ad4",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:50.8138655Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile"
@@ -912,7 +912,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:9ee05a0ebc0a4446ae400c105a3a468ec236e0d3e57ae419770d0d50147cb06e",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:27.2946983Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile"
@@ -926,7 +926,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:77c800ac2d2d2817331d2d22972b22ea4b051cb84eb1ec0b15daa8e91b29de20",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:25.6038134Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile"
@@ -940,7 +940,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:93507a85dd71cc7bfe42005e08fc34406f015a3aff720fd86ec29d8528eadb7a",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:04.8155144Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/dc2246b615011cc1bbfd0a1b6406a75a57c261db/src/runtime/2.1/nanoserver-2009/amd64/Dockerfile"
@@ -1134,7 +1134,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:a38b570c5311dffd348d91d34bf00f9a7c50a7dc0287cdc9345f56a8f0ddc70c",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:18.6103183Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile"
@@ -1148,7 +1148,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:3e4e71f9ffea34cdb90cbb936b739eab9b47cd77d7a0eb73d1e7415d36874a1c",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:26.3496968Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-1903/amd64/Dockerfile"
@@ -1162,7 +1162,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:d3964d40aef07818cbf03055fea7d3f2f59d6643ac82878f57eda7c2780c2217",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:42.6730097Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-1909/amd64/Dockerfile"
@@ -1176,7 +1176,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:e71b40bf5aad2924cf9582eebd6bc4b12bddc9fdd3e2bbcae0a0e10fea410b2d",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:39.919193Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-2004/amd64/Dockerfile"
@@ -1190,7 +1190,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:14bae528cbdb724e97746f8822037a6909a19644880b37ab5b4eb405bb1ef6b5",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:06.4041336Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-2009/amd64/Dockerfile"
@@ -1404,7 +1404,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:51aa6048bc0fd7c224ad2343d222f9209204817a097b867e26ce45c86f76c925",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:14.270511Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile"
@@ -1418,7 +1418,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:1d82a9b7c7bebe54dd0d15b8887c300a400d64eacb6e529adec1e536ae791cdb",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:57.2867407Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile"
@@ -1432,7 +1432,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:eca8e3a2b8ab4968fd9bfbc5f04f977f7cb537b0fab5451ac97525b2098f3d3f",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:10.0044545Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile"
@@ -1446,7 +1446,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:186b035d70c4807ae61f9a2060e169dec4bb8eea02bdfcdd1226f8eb47028b8a",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:01.4957919Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-2009/amd64/Dockerfile"
@@ -1520,7 +1520,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:aeee0ee60aeed440afd8e42878d456972ef6d2f879b79d868967a35ed175db30",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:edc9fec17216c0d3a20c3c59d1051a0378062aed3c0cf5bb8c4e165bf8f6ee8a",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T18:15:05.1409245Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile"
@@ -2109,7 +2109,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:10d1b5259d1baf340634b5a24920cf0008e940a259fef66516123924ee44b5ad",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:44.961036Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile"
@@ -2123,7 +2123,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:44706b13cacd02c158470e9eb358244ebfee8f85b35678d6d70b92c9f8e6764c",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:22:19.2171813Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile"
@@ -2137,7 +2137,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:b34d478ce52cb8ce031a88835d25a1fa79ab7875eee1d5c36f5799995a2653de",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:40.1598043Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile"
@@ -2151,7 +2151,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:7bd771b751fb383cb3d2250e48369e52942b546597b1b97ad95d8b33c8bed2cc",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:45.0278545Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile"
@@ -2165,7 +2165,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:7d17c37355fee87451c20af362373f4b38bab28ca26aa49a01dcc0057c1c598c",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:36.6376845Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/dc2246b615011cc1bbfd0a1b6406a75a57c261db/src/sdk/2.1/nanoserver-2009/amd64/Dockerfile"
@@ -2339,7 +2339,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:aeab6d06ece872b88e59c4da0a98aa64e637aa979a161923658c5f7ef74b9699",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:9949196bbda40b1f822ef8763b4d10c42f39d49360bcefbbd6584bd1045e03a8",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:45.552537Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile"
@@ -2353,7 +2353,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:39e84fab75569c2bf2a927072a4916370dc832d94063816cc41c5920a3737410",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:e68387d3adca91e5894c0ff213522e0eb0593b1b32455b224afd561eb3424f56",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:58.1486335Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-1903/amd64/Dockerfile"
@@ -2367,7 +2367,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:2e7fc356e857f355cf4f03aa6969148ae744555bc13ab81d6b26dbe2fff83ad4",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:7552f9b45920ca39aebfe0f03a7a33a2322c9981260f2ad8098fc947d725e607",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:02.2915328Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-1909/amd64/Dockerfile"
@@ -2381,7 +2381,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:c64c8553ebb03073cbf7c8a21d3ef44d5aac9c4429f87a9587f740c38720e180",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:6b343cc89e2373701f6f1746369012e2e97fd50a97f15fe468b235bc5a9a2961",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:18:06.9107967Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-2004/amd64/Dockerfile"
@@ -2395,7 +2395,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:c252f8ea1836126e23e8891477303d58d9070f78268bbb9690469573d81e2c6b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:4cf5b81e0277a7ee6329d04e6b8fddb8111b0a96d4f393f86e7d4be8e10b3f98",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:18:34.7276363Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-2009/amd64/Dockerfile"
@@ -2594,7 +2594,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:83fe27472d87bc33aa44aa860f294362a7ead300a9271518177288f0362f4c13",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:07f40b226a46ac87de06877dc2df6abeabd9e87c06a51dabdde48ed3de6a9023",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:57.5805047Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile"
@@ -2608,7 +2608,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:7ea2ac2ba47a47f8a9a30ce8cd280d7112d536c1f3cfa959b557bc50ef83af52",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:806f012ea2138dea380af0934f1f8f91eab76746f0105f4126f1893e502d0117",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:37.6102306Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile"
@@ -2622,7 +2622,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:38b47e571445cd5de39845f82d88c55c89c178ac308d5eea653ea563956e79ed",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:af29a75f6e2a1556dbd9d8b204437a7137982c7de54cbe511e37a0a469ee530c",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:03.277482Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile"
@@ -2636,7 +2636,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:0c7646498882e1e2ae59a31944db634f2994747de507467ffd30db26f68eb2e2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:1a656dee0e51d98047b2517b6b5702fb0cb42550b9206b96b69b3c32c02ee602",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:18:50.4066087Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/nanoserver-2009/amd64/Dockerfile"
@@ -2710,7 +2710,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:9a933afba7ebddc048f33a2c6c4bbfad3272413e6ddddc95e888b8e7cbb207fb",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:9ff3d142f5e36f085667f118d38a8b7da4ad7501b3aeb50c6178e680779a00ac",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:43.1621774Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
@@ -120,7 +120,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:8e0c505751ef2d8cfab0fb0e136f6dacf41933bbcb0d0ebe0baa276345be3dda",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:11.6135665Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-1809/amd64/Dockerfile"
@@ -134,7 +134,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:54b9c38a61de6263ad592cd869153585330eba850a9a2b34ec44670e17807b27",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:24:51.0031673Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-1903/amd64/Dockerfile"
@@ -148,7 +148,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:aa11cdbd08abf10337578ff6425c3b73f2cf3b8dd448a8ed4993a021af924b6d",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:18:13.3985756Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-1909/amd64/Dockerfile"
@@ -162,7 +162,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:a52bbb2d0d3876cf43425c78b167f511bf49c00567f0576c4baf2763cd97688b",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:18:02.5084963Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/aspnet/2.1/nanoserver-2004/amd64/Dockerfile"
@@ -176,7 +176,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:dff58abf67f4992fc5bdbd31b6d188b8ec74d114601b20f4049b9ad48fa9482d",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:54.9631579Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/dc2246b615011cc1bbfd0a1b6406a75a57c261db/src/aspnet/2.1/nanoserver-2009/amd64/Dockerfile"
@@ -370,7 +370,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:0834837211298f636ab82d6ab257cd872b7232982c0df5f90a35751c4d0911dc",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:72d94b3ee7f980046a79506d5b0287accc48e6a9849fc430175c1149368d39b9",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:45.4159541Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-1809/amd64/Dockerfile"
@@ -384,7 +384,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5da49f94867ec3a9a3096749a3ebc13e791833b30b3969d56cb6de2023baedb9",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:130c46fe4cf9c75b048155dc29dd9a0edf6c39d98eb650366b621e9247705381",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:22:33.3202418Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-1903/amd64/Dockerfile"
@@ -398,7 +398,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:11323601726cfd8cfe8053296fec0484322211606439ee61123b9c09ff1a4216",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:2d8f9c0b7973bb759116ff623e245b9de5335980a70d78f6ac8bc6f774fc900d",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:17:16.850373Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-1909/amd64/Dockerfile"
@@ -412,7 +412,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:0f6a91604b6c7372def1c89e7099caa196a7fbf924ea63581291ee214961073f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:7d596fc5948bc7ad5de1f59f5363e0cfcdc9d06d707aef7a79d24795e8a90380",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:48.1691901Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-2004/amd64/Dockerfile"
@@ -426,7 +426,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:80be24be6fd78fe94ecc36012dac7e363088e6aeeb48abd1b080824e713f48c3",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:54606ddb77c918ad9c8e0682e995871f6a4e6d0515af040a785b608ada943658",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:09.2126287Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/nanoserver-2009/amd64/Dockerfile"
@@ -597,7 +597,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:8c51bd5a9ec4231529a4fc35ca06bb16ebfc16a54458eec0a9665891f3ffe67f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:0bfa0d540ee750e78cf4f7a2e61d6c6753291b0a091414353d34fefd6b7f6bda",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:03.6550324Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-1809/amd64/Dockerfile"
@@ -611,7 +611,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:ddd546546a4a3763326be2cf78bcb7a589e66cd2f6e0d02dc6f6057155f88b65",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:7e07c927c2dd5aecf9f84db6580ca352321b83c2e7e7ab616af916d9595edd1b",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:26.0900461Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-1909/amd64/Dockerfile"
@@ -625,7 +625,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:9f406704b945e9ec2ebdb04b632959bfb70f5ade97348f560fe7eaa206b7d501",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:71bc113a4151dadd51da34bdc13fdf1baa07479c4e4b1ebf15eaa4c9a88bbe74",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:38.9462815Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-2004/amd64/Dockerfile"
@@ -639,7 +639,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:f425728189363f46d645451f463f95b9e4a48a3887a6c9b66f856215f90ca0a2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:5532dfe9e6e2b67a481efa74eefff2f7ac6049b74caedcb461f58eda84f65161",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:27.6700134Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/nanoserver-2009/amd64/Dockerfile"
@@ -713,7 +713,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:502bfd4bd442d90451571c6426e0b46531a71e7559bdc845598ff0184c47f820",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:941a8b93cdedde5cb73a51a925876f912fe7b94bca0c36779709ee13ab07f7bf",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:21.1000208Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/windowsservercore-ltsc2019/amd64/Dockerfile"
@@ -916,7 +916,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:bf75070e29023066af70dd0ba11e2e2aa3bbe053fe2e136383d1721ffbe21e0f",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:20.3267125Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-1809/amd64/Dockerfile"
@@ -930,7 +930,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:410523233e034436f8926a5f87b1e5ebbe67baf964720ccdc1965a5908cf8889",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:27:02.5746897Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-1903/amd64/Dockerfile"
@@ -944,7 +944,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:c13d44c7b51bddb699ef76e215313d0db9a4d66372a512805a03e7ae7aa8fe83",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:03.9552107Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-1909/amd64/Dockerfile"
@@ -958,7 +958,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:e6615e306e5ba8ca4d753c9113591a672d58b1f2ec7ecaead477d2de82c4c308",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:38.2150856Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/runtime/2.1/nanoserver-2004/amd64/Dockerfile"
@@ -972,7 +972,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:fd60b1256fa4f90555c991da9ea674ff9848fd4cc238c02e65bb7d055070a4a2",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:30.0282306Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/dc2246b615011cc1bbfd0a1b6406a75a57c261db/src/runtime/2.1/nanoserver-2009/amd64/Dockerfile"
@@ -1166,7 +1166,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:72d94b3ee7f980046a79506d5b0287accc48e6a9849fc430175c1149368d39b9",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:27.5354295Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-1809/amd64/Dockerfile"
@@ -1180,7 +1180,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:130c46fe4cf9c75b048155dc29dd9a0edf6c39d98eb650366b621e9247705381",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:22:16.0417371Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-1903/amd64/Dockerfile"
@@ -1194,7 +1194,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:2d8f9c0b7973bb759116ff623e245b9de5335980a70d78f6ac8bc6f774fc900d",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:16:59.2428541Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-1909/amd64/Dockerfile"
@@ -1208,7 +1208,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:7d596fc5948bc7ad5de1f59f5363e0cfcdc9d06d707aef7a79d24795e8a90380",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:28.8004109Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-2004/amd64/Dockerfile"
@@ -1222,7 +1222,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:54606ddb77c918ad9c8e0682e995871f6a4e6d0515af040a785b608ada943658",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:50.3460404Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/nanoserver-2009/amd64/Dockerfile"
@@ -1393,7 +1393,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:0bfa0d540ee750e78cf4f7a2e61d6c6753291b0a091414353d34fefd6b7f6bda",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:18:42.184156Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-1809/amd64/Dockerfile"
@@ -1407,7 +1407,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:7e07c927c2dd5aecf9f84db6580ca352321b83c2e7e7ab616af916d9595edd1b",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:20:05.6252492Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-1909/amd64/Dockerfile"
@@ -1421,7 +1421,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:71bc113a4151dadd51da34bdc13fdf1baa07479c4e4b1ebf15eaa4c9a88bbe74",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:16.3710841Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-2004/amd64/Dockerfile"
@@ -1435,7 +1435,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:5532dfe9e6e2b67a481efa74eefff2f7ac6049b74caedcb461f58eda84f65161",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:06.7998825Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/nanoserver-2009/amd64/Dockerfile"
@@ -1509,7 +1509,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:941a8b93cdedde5cb73a51a925876f912fe7b94bca0c36779709ee13ab07f7bf",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:edc9fec17216c0d3a20c3c59d1051a0378062aed3c0cf5bb8c4e165bf8f6ee8a",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T18:21:10.6515427Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/windowsservercore-ltsc2019/amd64/Dockerfile"
@@ -2141,7 +2141,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:0bbf051762fe289502c03381afa25aa65863380e9c444c5ce024f7ac062d7513",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:6fb87453ff19b5ff1e98377042aab75979a29c171718756e095b41a5fbae4840",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:24:02.8352412Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-1809/amd64/Dockerfile"
@@ -2155,7 +2155,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:7630cf9bbc7e70a16d47a5a31d398364c40b848bd93bb8988ff54aeda429b45f",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:389f5e50deb3ee14e26246b19d8184ae7db6e879730249bd2a968fe8c7667a42",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:31:21.930265Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-1903/amd64/Dockerfile"
@@ -2169,7 +2169,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:cdc9a06768c2dffb3924de25f0a1902f03ff3315022c95f07d2b07eeb828de38",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:c67d1ce94282e597567fc0c32ffe033cf0a6ad1a1c146b64f72798533b330946",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:25:03.4944321Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-1909/amd64/Dockerfile"
@@ -2183,7 +2183,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:30b47a70ec8a9da2ee9c1990d65a9fb924f095a185d0bd0df5621edf54111c37",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:24facb04f7045893caf494e499ac356e282d87be736c8b5d7144f8bbd40e1908",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:26:15.7144129Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/nanoserver-2004/amd64/Dockerfile"
@@ -2197,7 +2197,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:efb2df5bb7a549f7808df17c7b01b0d328b0fec5bd70d6552b541474058bad02",
               "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:5ec1ac5f68581db3e9196c477a9687203f420b3bf802e03fcda592ea1c623729",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:25:27.166666Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/dc2246b615011cc1bbfd0a1b6406a75a57c261db/src/sdk/2.1/nanoserver-2009/amd64/Dockerfile"
@@ -2371,7 +2371,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:11cdadc45dbe23a590699f5a50596d6f1b95045ff32eefb3b4688fc441789219",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:0834837211298f636ab82d6ab257cd872b7232982c0df5f90a35751c4d0911dc",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-10T18:22:57.3787032Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-1809/amd64/Dockerfile"
@@ -2385,7 +2385,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:5ecf9e97e8f02769d12fbf20d2ff76c19f3834b36337886a55e4e6f6f9f1a707",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5da49f94867ec3a9a3096749a3ebc13e791833b30b3969d56cb6de2023baedb9",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "nanoserver-1903",
               "architecture": "amd64",
               "created": "2020-11-10T18:24:46.4581283Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-1903/amd64/Dockerfile"
@@ -2399,7 +2399,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:149779b0723ea41c91255531ac1145f0d3a00566dc546318a704dfa6a0dc7593",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:11323601726cfd8cfe8053296fec0484322211606439ee61123b9c09ff1a4216",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-10T18:19:33.7182472Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-1909/amd64/Dockerfile"
@@ -2413,7 +2413,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:f8c38d15e99f56859040d74498463716bca6ca9e69e034b5d3e2efa3b5e99255",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:0f6a91604b6c7372def1c89e7099caa196a7fbf924ea63581291ee214961073f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-10T18:22:58.5636696Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-2004/amd64/Dockerfile"
@@ -2427,7 +2427,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:0187dbeabc17d9a53e2d455418316ccba72a6130247f5916eadc1f0b22b46998",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:80be24be6fd78fe94ecc36012dac7e363088e6aeeb48abd1b080824e713f48c3",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-10T18:23:21.0384778Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/nanoserver-2009/amd64/Dockerfile"
@@ -2583,7 +2583,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:62997e1f79dcf62c6917d7ba54e5d7ab6e3cf2602c02ba452cad9bf4445ddf95",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:8c51bd5a9ec4231529a4fc35ca06bb16ebfc16a54458eec0a9665891f3ffe67f",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "nanoserver-1809",
               "architecture": "amd64",
               "created": "2020-11-18T13:45:59.7823242Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/nanoserver-1809/amd64/Dockerfile"
@@ -2597,7 +2597,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:9d6d72b4c8138b9997b7d03e680a19fea5fdf7ec3d19bc521943c408c0377ed5",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:ddd546546a4a3763326be2cf78bcb7a589e66cd2f6e0d02dc6f6057155f88b65",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "nanoserver-1909",
               "architecture": "amd64",
               "created": "2020-11-18T13:45:04.4097898Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/nanoserver-1909/amd64/Dockerfile"
@@ -2611,7 +2611,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:89b7b0947c114c2bd9e5ca3eb5f41470836fbb2644fadb2ecc74efc6cbba76e5",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:9f406704b945e9ec2ebdb04b632959bfb70f5ade97348f560fe7eaa206b7d501",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "nanoserver-2004",
               "architecture": "amd64",
               "created": "2020-11-18T13:45:05.2037587Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/nanoserver-2004/amd64/Dockerfile"
@@ -2625,7 +2625,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:8b5b193c0abb1e98db90cb2860cfac388d8d1673f9524409de5eda071ba771ca",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:f425728189363f46d645451f463f95b9e4a48a3887a6c9b66f856215f90ca0a2",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "nanoserver-2009",
               "architecture": "amd64",
               "created": "2020-11-18T13:45:02.0307655Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/nanoserver-2009/amd64/Dockerfile"
@@ -2699,7 +2699,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:186ed7d07fd8c5f426736919181b92f51a2ce337e1e8f79b432bba2f5920866a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:502bfd4bd442d90451571c6426e0b46531a71e7559bdc845598ff0184c47f820",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-18T13:44:16.3743171Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/windowsservercore-ltsc2019/amd64/Dockerfile"

--- a/build-info/docker/image-info.microsoft-dotnet-framework-docker-master-samples.json
+++ b/build-info/docker/image-info.microsoft-dotnet-framework-docker-master-samples.json
@@ -21,7 +21,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:e17ea4121a39a8f53ec2c8b41309006cf25c75f87fb585278730600873bec367",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:fe324e34d8b9a7d10f30023a791043c735206e59eda1cdcaa8bf49b497ba94fc",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T21:39:08.0909473Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/aspnetapp/Dockerfile"
@@ -34,7 +34,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:e66736e21e8af988c0cf3180b8fdc3adc68c023182847f0a2f334b4f6b5ddfed",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:fe324e34d8b9a7d10f30023a791043c735206e59eda1cdcaa8bf49b497ba94fc",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T21:37:12.1372971Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/aspnetapp/Dockerfile"
@@ -47,7 +47,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:0c1839741cfbc158e887675ce6f2da1902326eb2fa17df15fc42ec9d2dff686c",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:fe324e34d8b9a7d10f30023a791043c735206e59eda1cdcaa8bf49b497ba94fc",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T21:42:54.965326Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/aspnetapp/Dockerfile"
@@ -60,7 +60,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:e23389ce8ae1b2897df1275ee2a6212f41e5bedde640e51c7b7e38afafac7a7f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:fe324e34d8b9a7d10f30023a791043c735206e59eda1cdcaa8bf49b497ba94fc",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T21:36:06.3070144Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/aspnetapp/Dockerfile"
@@ -73,7 +73,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:4f49c78e54a3af2f3db5917ca2636329cf4e2628bbaccd7ee24f0ff08403c1c2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:fe324e34d8b9a7d10f30023a791043c735206e59eda1cdcaa8bf49b497ba94fc",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T21:34:31.933706Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/aspnetapp/Dockerfile"
@@ -86,7 +86,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:1c57c742b9a1440f2b7c600d12010df9914565912244a2adfb6b5f15a3d026fe",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:fe324e34d8b9a7d10f30023a791043c735206e59eda1cdcaa8bf49b497ba94fc",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T21:34:23.8568393Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/aspnetapp/Dockerfile"
@@ -111,7 +111,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:c8687899ab415c1ff547521f75a5723d3b84f5f9a799c3f34dd778e32f0b598c",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T21:38:45.7446635Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/dotnetapp/Dockerfile"
@@ -124,7 +124,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:6e2ee9ca85832b169cdc9116849ff27ac891064ec1199e2019c7749ab850019d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T21:36:48.949541Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/dotnetapp/Dockerfile"
@@ -137,7 +137,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:95290f4092871cb7d1a8fb0278486fcb0eb9923423d5680a9be08237f30b85fb",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T21:43:05.80952Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/dotnetapp/Dockerfile"
@@ -150,7 +150,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:de311def5176d7defd6a3c86814a2a8bd1cc5e11e71aa43135b101651ae2e0f7",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T21:35:20.4374706Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/dotnetapp/Dockerfile"
@@ -163,7 +163,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:7ea0d2270888745bef22721bacb67e4e3d30ab7144fe51ada92324f69331d96b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T21:34:22.598888Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/dotnetapp/Dockerfile"
@@ -176,7 +176,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:3ba27ff4c76ccf5babfdc9c141754fac09e04fe4e459bff7b09a2625fbe9c0b8",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T21:34:20.2296789Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/dotnetapp/Dockerfile"
@@ -200,7 +200,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:3d666e41f22a86d11e4d4a930be3bbd899e488b6f3fe00cbf04cfd85bd452e9b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T21:37:28.9085581Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
@@ -213,7 +213,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:27e30fd14879f1e9cfc5459cb16336d079344b8da69a6e26f48d9d62864d3d0f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T21:35:58.7659838Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
@@ -226,7 +226,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:89d40d3158e42d37d64d6d321fbf05715d36c1e4d56e810136d42f97b5235e83",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T21:34:29.4798784Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
@@ -239,7 +239,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:e08413fe717efa58332105e1d87d17d2df86abd051e5c0cae4a4650c16dff84a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T21:35:24.8915016Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
@@ -252,7 +252,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:8281a94d7f98a4edd10b30a5e2ff3d6b7945cfbe890504efb07d9ddf9a46cdc1",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T21:33:33.2653116Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
@@ -265,7 +265,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:9885b05d92c9d4a0f19b64b7a2d27ffc8ecdfdd0b3398856000e5371fafcfa0d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:b09cb884dd7541f2895e6d86870110a652fc9a7bd99a3ba4d3cad1c9360ff9f8",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T21:33:26.7732816Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.client"
@@ -289,7 +289,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:a039e36094b94e0a5bd6c525fd52b88c40c8eebbd4b973496ee6c8898494a95a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:75f98b27dc6fa2ae3ee5e3cf2854705a6ac1a047652db9ce801e7ef7ba57f1c9",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T21:38:29.2054753Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
@@ -302,7 +302,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:1b2a8d4082153ac7144ee03ca8a32b942871788773d2a7dc091dfebb8e39600c",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:75f98b27dc6fa2ae3ee5e3cf2854705a6ac1a047652db9ce801e7ef7ba57f1c9",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T21:37:08.8002186Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
@@ -315,7 +315,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:57e4a1a77c54c7eb81e06ee3a2365fbfd4454de66a40b3e6c2fca662bbe6a152",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:75f98b27dc6fa2ae3ee5e3cf2854705a6ac1a047652db9ce801e7ef7ba57f1c9",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T21:35:32.2100217Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
@@ -328,7 +328,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:abb63e5b93495ef547df5ecf253b79f3e95cfe876d9736a9236c1f6cc6954235",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:75f98b27dc6fa2ae3ee5e3cf2854705a6ac1a047652db9ce801e7ef7ba57f1c9",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T21:35:41.3224696Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
@@ -341,7 +341,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:8fcc14eb357f734514fe965ebf656d958744e3e65082fedfe202d8c4f070b663",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:75f98b27dc6fa2ae3ee5e3cf2854705a6ac1a047652db9ce801e7ef7ba57f1c9",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T21:34:06.3283454Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"
@@ -354,7 +354,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/samples@sha256:34621f81319d8b28a0543a96a21eea1172e5184e19b674cfc635177c56c82f81",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:75f98b27dc6fa2ae3ee5e3cf2854705a6ac1a047652db9ce801e7ef7ba57f1c9",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T21:33:59.9537941Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/d2b68d441d71df7615eeb8482419c2f975aa462e/samples/wcfapp/Dockerfile.web"

--- a/build-info/docker/image-info.microsoft-dotnet-framework-docker-master.json
+++ b/build-info/docker/image-info.microsoft-dotnet-framework-docker-master.json
@@ -24,7 +24,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:08008038e76ddc0c2578c1c865bc6041275a225aa4feabd8013717509434dec4",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:5774729b038388a8d647466211939b8588158130587e969d34bffb39f7961d12",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T19:41:18.8252582Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/3.5/windowsservercore-1903/Dockerfile"
@@ -38,7 +38,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:7e068833c08f0973de4931076d892eb8c17c5a8b2f4ce5e7ee5dc3cf131e7dd1",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:4ee77da693b932f5597221b3f03ed12e481ece47bedd5f7d478b0c52490f593f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T19:41:25.1569878Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/3.5/windowsservercore-1909/Dockerfile"
@@ -54,7 +54,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:af5c20b74d727ace447c2db58e911b6b851e32162656d64127fc268fb67572f7",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:c6c5a9f4c113b26f777337cec7a3fdbc0e1204f80d73838e504c6ec6c4be9a3c",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T19:32:34.0578755Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/3.5/windowsservercore-2004/Dockerfile"
@@ -68,7 +68,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:a662e122a1fb7da540bcba0ee79f23ac509d3881b1ba1db7410b7525ea97c3f6",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:faf58033cfa1421ad79983ac8093fb5b2eea7f6719bb9ba831f37481ea1d4417",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T19:33:38.8970514Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/a425cb4ccc1ec00ca26ee1c784c9ca82a1d0dd0e/src/aspnet/3.5/windowsservercore-2009/Dockerfile"
@@ -82,7 +82,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:9361791d3d1849b307118a1a4c4a33b985dc3d5b9aaaaf6ab889a41dae22c0a0",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:e2a57c90e0279103106c75b8092c6c888a1dc627eed2d8779e3e52f1df78dd02",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:25:34.4814359Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/bc16dd0038a58a141ecbfebd053b21249994f8c2/src/aspnet/3.5/windowsservercore-ltsc2016/Dockerfile"
@@ -96,7 +96,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:ed3c5a9bdca40d38cb32172ad7cc22d32dba273ae1d9d453ec4597d68e428dad",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:bdecb13eb2869dfa31b0e4fd9387612ab173a0ec9f0123369dffa6f47d2601eb",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:48:34.7128233Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/b84ca3464bb98cfb89c724fa6158bb66355332e9/src/aspnet/3.5/windowsservercore-ltsc2019/Dockerfile"
@@ -122,7 +122,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:068d9662a41241de0e9e61bfae9716589fea96d1400fa514ba215cac53710a66",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:823ba1f33c5c28c161bb2874f367e1aa2446a2c52c148143041dc22da237fcc0",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:31:01.4108101Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/bc16dd0038a58a141ecbfebd053b21249994f8c2/src/aspnet/4.6.2/windowsservercore-ltsc2016/Dockerfile"
@@ -148,7 +148,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:58272f7a79c151128f6b0b8b7a50ac1dd2622ba2b74c86e0291a08a8282fb705",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:ba68e9bc63b1dd0d49f0b2ce1d9aaac193d71676d82ccc2aa7f24a07f1f971fe",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:59:55.7786674Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/bc16dd0038a58a141ecbfebd053b21249994f8c2/src/aspnet/4.7/windowsservercore-ltsc2016/Dockerfile"
@@ -174,7 +174,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:8c8d508065fe469d375c4ebc92f98541f4bc89e7b7ca484c85ceb1293188bbbd",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:6b6c19b89b9a0f4e7b4123802678974877f2345c14ae27413c41e08e29a7728a",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:02:05.0156733Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/bc16dd0038a58a141ecbfebd053b21249994f8c2/src/aspnet/4.7.1/windowsservercore-ltsc2016/Dockerfile"
@@ -200,7 +200,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:36eba66d4ab8d62042341343d6326d9372931e68cc450f8dc05af01594a673b3",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:5d61c824bd31a61387584975e782ff34aecfac40af43a2b58da5ba5ac7654e10",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:59:05.4356867Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/b84ca3464bb98cfb89c724fa6158bb66355332e9/src/aspnet/4.7.2/windowsservercore-ltsc2016/Dockerfile"
@@ -214,7 +214,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:2ed5fe61908a7e5b91e807c0f0d1bc91e8a8dc1562841219a25b3b5b02335acb",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:f2286a65fb06be37b3e4e1e848c935204607306e1d8712629a35db51b163ddd9",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:20:43.680989Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/4.7.2/windowsservercore-ltsc2019/Dockerfile"
@@ -241,7 +241,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:0ce9e45629f183fd3982ba7507fec3927918414daead67e0658934eaefcbfe17",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:2785d5fa5198bb0564a50ab3c97608a23a42d51fe8b76d3667f63508258d907b",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T19:32:35.8671535Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/4.8/windowsservercore-1903/Dockerfile"
@@ -255,7 +255,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:f46ee16a28075899c9dada4e2b884d29d20dad8219b0eca67a675b116d4a0ee4",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:260388533c894a98722f89ac42716c1579d3cb0fdfd9a35f69115eeeadb16350",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T19:32:32.3333161Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/4.8/windowsservercore-1909/Dockerfile"
@@ -269,7 +269,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:0d3a63d54dc013fc4412a494806f0c8c63599ffc7881bec38d8c58cc3e8c5107",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:10767c2bf04924f62faaa916643c0a76c4ee6111647734bb47d4e7ac58cccc9f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T19:26:37.2224816Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/4.8/windowsservercore-2004/Dockerfile"
@@ -283,7 +283,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:01212505598214a35ed3420e2dd872cf3719b908910cc987f86a2bd2aa29f7c0",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:de5ce0b02ed9e7acca097899578498ca09a95c15c3978ed70e850f2f1ad1df4f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T19:26:13.0393262Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/a425cb4ccc1ec00ca26ee1c784c9ca82a1d0dd0e/src/aspnet/4.8/windowsservercore-2009/Dockerfile"
@@ -297,7 +297,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:568f9deecdc69e13dbfda34ed581f4e2eb42dcfae5fdf7e7f7931608c8310833",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:1ff6bf05b00b78cae3aa5225d0577402f91135e26b39f1f7c8e6ce9059b434a9",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:09:11.0314494Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/bc16dd0038a58a141ecbfebd053b21249994f8c2/src/aspnet/4.8/windowsservercore-ltsc2016/Dockerfile"
@@ -311,7 +311,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:778b5bb7839f483f869b016fdb66400525093fbe0f75878a2950472e6c58573e",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:bfc6c9dd77473be518e4c63171d6d06baf300d873756d2f3c10d21a4defb2978",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:41:00.7933825Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/aspnet/4.8/windowsservercore-ltsc2019/Dockerfile"
@@ -343,7 +343,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:5774729b038388a8d647466211939b8588158130587e969d34bffb39f7961d12",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:26255e0459e7fabb75c0f7a6a6b074d85d921cc44b058f5cdacbcc5f50a0645c",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T19:20:48.5947941Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/3.5/windowsservercore-1903/Dockerfile"
@@ -357,7 +357,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:4ee77da693b932f5597221b3f03ed12e481ece47bedd5f7d478b0c52490f593f",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:03e6a4642d789e7e2f6378d733874175838a05d03a9cac29df8975e09acb8385",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T19:20:54.3778834Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/3.5/windowsservercore-1909/Dockerfile"
@@ -373,7 +373,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:c6c5a9f4c113b26f777337cec7a3fdbc0e1204f80d73838e504c6ec6c4be9a3c",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:824f13d21b1304afb74de25f9c2b0ebb634e8ae8ec025e1c86a915017d2e82c7",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T19:16:03.7348087Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/3.5/windowsservercore-2004/Dockerfile"
@@ -387,7 +387,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:faf58033cfa1421ad79983ac8093fb5b2eea7f6719bb9ba831f37481ea1d4417",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:967fb7b55e016559164c157c1c8a84bef250cb11716aec37a7b498dfa38980bf",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T19:16:28.4377387Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/3.5/windowsservercore-2009/Dockerfile"
@@ -401,7 +401,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:e2a57c90e0279103106c75b8092c6c888a1dc627eed2d8779e3e52f1df78dd02",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:6e9f0324e710bc74b53b0ea3fdb7e8bb5dcf0a20d8114210d0a5eba7b74bd095",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:51:47.5811342Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/3.5/windowsservercore-ltsc2016/Dockerfile"
@@ -415,7 +415,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:bdecb13eb2869dfa31b0e4fd9387612ab173a0ec9f0123369dffa6f47d2601eb",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:edc9fec17216c0d3a20c3c59d1051a0378062aed3c0cf5bb8c4e165bf8f6ee8a",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:20:12.2469515Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/3.5/windowsservercore-ltsc2019/Dockerfile"
@@ -441,7 +441,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:823ba1f33c5c28c161bb2874f367e1aa2446a2c52c148143041dc22da237fcc0",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:6e9f0324e710bc74b53b0ea3fdb7e8bb5dcf0a20d8114210d0a5eba7b74bd095",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:26:40.3886189Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/5d8e932818fcf188618f18eab4c978cbd1e6a0e6/src/runtime/4.6.2/windowsservercore-ltsc2016/Dockerfile"
@@ -467,7 +467,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:ba68e9bc63b1dd0d49f0b2ce1d9aaac193d71676d82ccc2aa7f24a07f1f971fe",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:6e9f0324e710bc74b53b0ea3fdb7e8bb5dcf0a20d8114210d0a5eba7b74bd095",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:55:44.5469932Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.7/windowsservercore-ltsc2016/Dockerfile"
@@ -493,7 +493,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:6b6c19b89b9a0f4e7b4123802678974877f2345c14ae27413c41e08e29a7728a",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:6e9f0324e710bc74b53b0ea3fdb7e8bb5dcf0a20d8114210d0a5eba7b74bd095",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:57:43.7140503Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.7.1/windowsservercore-ltsc2016/Dockerfile"
@@ -519,7 +519,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:5d61c824bd31a61387584975e782ff34aecfac40af43a2b58da5ba5ac7654e10",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:6e9f0324e710bc74b53b0ea3fdb7e8bb5dcf0a20d8114210d0a5eba7b74bd095",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:54:59.6620946Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.7.2/windowsservercore-ltsc2016/Dockerfile"
@@ -533,7 +533,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:f2286a65fb06be37b3e4e1e848c935204607306e1d8712629a35db51b163ddd9",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:edc9fec17216c0d3a20c3c59d1051a0378062aed3c0cf5bb8c4e165bf8f6ee8a",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:17:09.5468825Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.7.2/windowsservercore-ltsc2019/Dockerfile"
@@ -560,7 +560,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:2785d5fa5198bb0564a50ab3c97608a23a42d51fe8b76d3667f63508258d907b",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:26255e0459e7fabb75c0f7a6a6b074d85d921cc44b058f5cdacbcc5f50a0645c",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T19:16:44.9320187Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.8/windowsservercore-1903/Dockerfile"
@@ -574,7 +574,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:260388533c894a98722f89ac42716c1579d3cb0fdfd9a35f69115eeeadb16350",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:03e6a4642d789e7e2f6378d733874175838a05d03a9cac29df8975e09acb8385",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T19:16:51.8108504Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.8/windowsservercore-1909/Dockerfile"
@@ -588,7 +588,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:10767c2bf04924f62faaa916643c0a76c4ee6111647734bb47d4e7ac58cccc9f",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:824f13d21b1304afb74de25f9c2b0ebb634e8ae8ec025e1c86a915017d2e82c7",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T19:13:20.8892589Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.8/windowsservercore-2004/Dockerfile"
@@ -602,7 +602,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:de5ce0b02ed9e7acca097899578498ca09a95c15c3978ed70e850f2f1ad1df4f",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:967fb7b55e016559164c157c1c8a84bef250cb11716aec37a7b498dfa38980bf",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T19:13:17.7090779Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.8/windowsservercore-2009/Dockerfile"
@@ -616,7 +616,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:1ff6bf05b00b78cae3aa5225d0577402f91135e26b39f1f7c8e6ce9059b434a9",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:6e9f0324e710bc74b53b0ea3fdb7e8bb5dcf0a20d8114210d0a5eba7b74bd095",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:50:43.0041732Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.8/windowsservercore-ltsc2016/Dockerfile"
@@ -630,7 +630,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:bfc6c9dd77473be518e4c63171d6d06baf300d873756d2f3c10d21a4defb2978",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:edc9fec17216c0d3a20c3c59d1051a0378062aed3c0cf5bb8c4e165bf8f6ee8a",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:23:12.5610995Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/runtime/4.8/windowsservercore-ltsc2019/Dockerfile"
@@ -662,7 +662,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:b83f8c1cb0b1f459d36f8b1e3ec6af52b944c59b10558f50ddb63aebe9a4a662",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:5774729b038388a8d647466211939b8588158130587e969d34bffb39f7961d12",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T19:38:50.6199302Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/3.5/windowsservercore-1903/Dockerfile"
@@ -676,7 +676,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:436e615547950714bf281930fdd4d9a60d385ee0caf54c52c6b3838b3d710ebb",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:4ee77da693b932f5597221b3f03ed12e481ece47bedd5f7d478b0c52490f593f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T19:38:57.455515Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/3.5/windowsservercore-1909/Dockerfile"
@@ -692,7 +692,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:639d29f403918ff84038b1035cc12fd611481b010eb3ea584106552f4603f78d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:c6c5a9f4c113b26f777337cec7a3fdbc0e1204f80d73838e504c6ec6c4be9a3c",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T19:30:29.6070402Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/3.5/windowsservercore-2004/Dockerfile"
@@ -706,7 +706,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:6fd389d21341d70627cf8331c0b161f717a7b400486857235bf505191a443183",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:faf58033cfa1421ad79983ac8093fb5b2eea7f6719bb9ba831f37481ea1d4417",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T19:32:01.4592479Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/3.5/windowsservercore-2009/Dockerfile"
@@ -720,7 +720,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:6a75c44a4d07c9f6ea9528d89a914f2bab44dd2e2d878cd55e9015e8329bf3ac",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:e2a57c90e0279103106c75b8092c6c888a1dc627eed2d8779e3e52f1df78dd02",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:22:37.9516381Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/3.5/windowsservercore-ltsc2016/Dockerfile"
@@ -734,7 +734,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:de2cfd43e3d8c61870d66d86f0f6f86102a13bfc133665b2b0ac43fa368fcd0f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:bdecb13eb2869dfa31b0e4fd9387612ab173a0ec9f0123369dffa6f47d2601eb",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:46:12.6927088Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/3.5/windowsservercore-ltsc2019/Dockerfile"
@@ -761,7 +761,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:fc875f05cd1e679bdaeae704079123dd9186f4657af9fe24b592c05e37d85aa2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:2785d5fa5198bb0564a50ab3c97608a23a42d51fe8b76d3667f63508258d907b",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T19:29:18.4281041Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/4.8/windowsservercore-1903/Dockerfile"
@@ -775,7 +775,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:08f4b08785faa947921dcc9704fb5965dac9a895ebfb76bd0c66af2ef7494f59",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:260388533c894a98722f89ac42716c1579d3cb0fdfd9a35f69115eeeadb16350",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T19:29:22.4251741Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/4.8/windowsservercore-1909/Dockerfile"
@@ -789,7 +789,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:eda4d27414ac5ce28b4c031ac24968939759a0cb0637a517f0f9973df70a1cee",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:10767c2bf04924f62faaa916643c0a76c4ee6111647734bb47d4e7ac58cccc9f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T19:23:53.5630114Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/4.8/windowsservercore-2004/Dockerfile"
@@ -803,7 +803,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:f160dab02b6421219196d40f0c1f998137a1749bf02e553fe6deb8c093e9fd37",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:de5ce0b02ed9e7acca097899578498ca09a95c15c3978ed70e850f2f1ad1df4f",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T19:24:12.0351949Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/4.8/windowsservercore-2009/Dockerfile"
@@ -817,7 +817,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:834cc03fb28663266757048c925063472a55617e5fc018734b9f08b50d265883",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:1ff6bf05b00b78cae3aa5225d0577402f91135e26b39f1f7c8e6ce9059b434a9",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:05:12.2200466Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/4.8/windowsservercore-ltsc2016/Dockerfile"
@@ -831,7 +831,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/sdk@sha256:259a6a2b67981e2f3c24800c5f77b2ea12cdc96292e1ce95fee0fd8eed360579",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/runtime@sha256:bfc6c9dd77473be518e4c63171d6d06baf300d873756d2f3c10d21a4defb2978",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:37:24.802217Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/25bdac46765c6dae7d05994cace836303f63b5e3/src/sdk/4.8/windowsservercore-ltsc2019/Dockerfile"
@@ -862,7 +862,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:4907cd92d4915036ff655272c14ee7c20031b894ebe69228400b99fd32b8d571",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:068d9662a41241de0e9e61bfae9716589fea96d1400fa514ba215cac53710a66",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T19:32:35.7620578Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.6.2/windowsservercore-ltsc2016/Dockerfile"
@@ -888,7 +888,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:6fa7d0d83bf38c52195bf07a53904e82167c2b0237c29193469fcf3c673d82ea",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:58272f7a79c151128f6b0b8b7a50ac1dd2622ba2b74c86e0291a08a8282fb705",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:01:32.2406531Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.7/windowsservercore-ltsc2016/Dockerfile"
@@ -914,7 +914,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:9b29af03f39ec5519012590045f76fa25de4941882d3ca5968651dcc3237e473",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:8c8d508065fe469d375c4ebc92f98541f4bc89e7b7ca484c85ceb1293188bbbd",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:03:43.6089968Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.7.1/windowsservercore-ltsc2016/Dockerfile"
@@ -940,7 +940,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:65a45f6b933605274c244664835ecb4661098871e92666fb317ec5c22dbc044b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:36eba66d4ab8d62042341343d6326d9372931e68cc450f8dc05af01594a673b3",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:00:43.3561317Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.7.2/windowsservercore-ltsc2016/Dockerfile"
@@ -954,7 +954,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:e9961ddaf10a51884c1bce3dc500e679d1ebc9257e90d0d3b2a38c3d9cc03d78",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:2ed5fe61908a7e5b91e807c0f0d1bc91e8a8dc1562841219a25b3b5b02335acb",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:22:17.4686963Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.7.2/windowsservercore-ltsc2019/Dockerfile"
@@ -981,7 +981,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:58bf476ce920462153dfe8b1525c65d3b27bd9e97b93b182c970f41f458200f2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:0ce9e45629f183fd3982ba7507fec3927918414daead67e0658934eaefcbfe17",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1903",
+              "osVersion": "windowsservercore-1903",
               "architecture": "amd64",
               "created": "2020-11-10T19:33:45.2693215Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.8/windowsservercore-1903/Dockerfile"
@@ -995,7 +995,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:7d24e8d84417231419e75ebb9c536dd4f51dd967a3215cd81091c5c1a10efa83",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:f46ee16a28075899c9dada4e2b884d29d20dad8219b0eca67a675b116d4a0ee4",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-11-10T19:33:43.5932173Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.8/windowsservercore-1909/Dockerfile"
@@ -1009,7 +1009,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:be0335858784af7dd186ccb27262b4ffdb2a7a0b287f8f6a429f5c2f5055e0be",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:0d3a63d54dc013fc4412a494806f0c8c63599ffc7881bec38d8c58cc3e8c5107",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-11-10T19:28:08.2484557Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.8/windowsservercore-2004/Dockerfile"
@@ -1023,7 +1023,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:a8b73b23ea2925726aeca5f4e9e3c6704f035ca79f3d8d7f760dce682c621412",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:01212505598214a35ed3420e2dd872cf3719b908910cc987f86a2bd2aa29f7c0",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2009",
+              "osVersion": "windowsservercore-2009",
               "architecture": "amd64",
               "created": "2020-11-10T19:27:00.3153891Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/a425cb4ccc1ec00ca26ee1c784c9ca82a1d0dd0e/src/wcf/4.8/windowsservercore-2009/Dockerfile"
@@ -1037,7 +1037,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:2cdc460558e21cdc21e1e1be8f0fdebb7f4641e4182248e2e3c4c08855612d85",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:568f9deecdc69e13dbfda34ed581f4e2eb42dcfae5fdf7e7f7931608c8310833",
               "osType": "Windows",
-              "osVersion": "Windows Server 2016",
+              "osVersion": "windowsservercore-ltsc2016",
               "architecture": "amd64",
               "created": "2020-11-10T20:10:50.1528317Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/b84ca3464bb98cfb89c724fa6158bb66355332e9/src/wcf/4.8/windowsservercore-ltsc2016/Dockerfile"
@@ -1051,7 +1051,7 @@
               "digest": "mcr.microsoft.com/dotnet/framework/wcf@sha256:f281d05576f6ecc3876ec9832cfa04e33b6d61585ea59bb1beb68349df7ff8b7",
               "baseImageDigest": "mcr.microsoft.com/dotnet/framework/aspnet@sha256:778b5bb7839f483f869b016fdb66400525093fbe0f75878a2950472e6c58573e",
               "osType": "Windows",
-              "osVersion": "Windows Server 2019",
+              "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
               "created": "2020-11-10T19:42:32.5799724Z",
               "commitUrl": "https://github.com/microsoft/dotnet-framework-docker/blob/44da47b0f4e6b0b30a1e3c033b212593c1a6618a/src/wcf/4.8/windowsservercore-ltsc2019/Dockerfile"


### PR DESCRIPTION
The format of the `osVersion` field was changed by https://github.com/dotnet/docker-tools/pull/697