### PR TITLE
Update format of osVersion in image info files

### DIFF
--- a/build-info/docker/image-info.dotnet-docker-tools-master-imagebuilder.json
+++ b/build-info/docker/image-info.dotnet-docker-tools-master-imagebuilder.json
@@ -21,7 +21,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/image-builder@sha256:d4b013b511de848aa521a4b1a10f5f1bc3039a1f686f685a69041282ffe4e23d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime-deps@sha256:006a8e99e2272e2b7685e79648184260558611d9e154e727776e8838a6f6167d",
               "osType": "Linux",
-              "osVersion": "Alpine",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-23T13:53:12.7420377Z",
               "commitUrl": "https://github.com/dotnet/docker-tools/blob/9ddf6f77283b494a4fbab73c8376acfbd8e235be/Dockerfile.linux"
@@ -34,7 +34,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/image-builder@sha256:2cdbf4fd44bc4b3d27e1bc920f531c32c25d31e6642e25187fa63562d75be880",
               "baseImageDigest": "mcr.microsoft.com/dotnet/core/runtime-deps@sha256:ff9cee298d0d750faf62d75d76a78494a3b3008814907df3910e9aff808c0591",
               "osType": "Linux",
-              "osVersion": "Alpine",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-23T13:54:27.5404808Z",
               "commitUrl": "https://github.com/dotnet/docker-tools/blob/9ddf6f77283b494a4fbab73c8376acfbd8e235be/Dockerfile.linux"

--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-master.json
@@ -14,7 +14,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:2bd5ff6b44502652491093010ede8e31629bd7338459e4773ba5b8d7e61272ee",
               "baseImageDigest": "python@sha256:2ddee163165cf1705b7f81a91f8e4a03d74bb03f1aa8717fbe76d5cef7b19c79",
               "osType": "Linux",
-              "osVersion": "Alpine 3.10",
+              "osVersion": "alpine3.10",
               "architecture": "amd64",
               "created": "2020-09-08T12:55:08.7862001Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/alpine/3.10/helix/amd64/Dockerfile"
@@ -31,7 +31,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:886bfacb26ec41b118d111f247cba1ebec1463c69c02e675558217c9c748d3f9",
               "baseImageDigest": "arm64v8/alpine@sha256:2cc2d09fe938c10bde86e9e800a72344c51fd0181c6fc81fe6e3eed4980bfa70",
               "osType": "Linux",
-              "osVersion": "Alpine 3.10",
+              "osVersion": "alpine3.10",
               "architecture": "arm64",
               "created": "2020-09-08T12:56:14.0194913Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/alpine/3.10/helix/arm64v8/Dockerfile"
@@ -48,7 +48,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:560d9c45e95b2b14b5ccf4d4c4798866d8814cc3c5aaf4440a4ca0c75c302b41",
               "baseImageDigest": "python@sha256:2c6e8a77863e42f437d2602e450b34628b23f41cbda2e4d52ecf940991551c66",
               "osType": "Linux",
-              "osVersion": "Alpine 3.11",
+              "osVersion": "alpine3.11",
               "architecture": "amd64",
               "created": "2020-09-08T12:55:08.2201517Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/alpine/3.11/helix/amd64/Dockerfile"
@@ -65,7 +65,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c427330e2016a59c107f101422c6d35233aeda1a793f493921b8b555fb905086",
               "baseImageDigest": "arm64v8/alpine@sha256:ad295e950e71627e9d0d14cdc533f4031d42edae31ab57a841c5b9588eacc280",
               "osType": "Linux",
-              "osVersion": "Alpine 3.11",
+              "osVersion": "alpine3.11",
               "architecture": "arm64",
               "created": "2020-09-08T12:56:08.9169844Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/alpine/3.11/helix/arm64v8/Dockerfile"
@@ -82,7 +82,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4916692169ff0aee5ceecdaeac5f48c08ceea7577a82844f840ecc2c7ab30440",
               "baseImageDigest": "alpine@sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-09-08T12:55:43.0059273Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/alpine/3.12/helix/amd64/Dockerfile"
@@ -99,7 +99,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:5e0002ff7054a0c6a0980588143ed99feec08aba5be1e9add98671c26861532e",
               "baseImageDigest": "arm32v7/alpine@sha256:c929c5ca1d3f793bfdd2c6d6d9210e2530f1184c0f488f514f1bb8080bb1e82b",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm32",
               "created": "2020-09-08T12:56:40.9234199Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/5bece88a70dd96de9609bd708e469b309175b6da/src/alpine/3.12/helix/arm32v7/Dockerfile"
@@ -116,7 +116,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:72a1e2f38cf8c2e8cde7dfbf5a655f4b13eb57c0f5864598be413f5d44268398",
               "baseImageDigest": "arm64v8/alpine@sha256:3b3f647d2d99cac772ed64c4791e5d9b750dd5fe0b25db653ec4976f7b72837c",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-09-08T12:57:09.8296123Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/alpine/3.12/helix/arm64v8/Dockerfile"
@@ -133,7 +133,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:3398e6a6263490e0b3c5ed972fdbb2e9f703a4ed7b5508311f65a8489f494f5d",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9738a29c3df7d3e4fe4719dd4b017929ef8c58878fdd08b04949317532e73677",
               "osType": "Linux",
-              "osVersion": "Alpine 3.9",
+              "osVersion": "alpine3.9",
               "architecture": "amd64",
               "created": "2020-09-08T13:27:46.5435675Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/0fc54a3fccdfec2c6936796037a9f31ad2e51e11/src/alpine/3.9/WithNode/amd64/Dockerfile"
@@ -150,7 +150,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9738a29c3df7d3e4fe4719dd4b017929ef8c58878fdd08b04949317532e73677",
               "baseImageDigest": "alpine@sha256:414e0518bb9228d35e4cd5165567fb91d26c6a214e9c95899e1e056fcd349011",
               "osType": "Linux",
-              "osVersion": "Alpine 3.9",
+              "osVersion": "alpine3.9",
               "architecture": "amd64",
               "created": "2020-09-08T12:53:27.578961Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfba074d71d40db4c67ef87c3da82646c05f55f7/src/alpine/3.9/amd64/Dockerfile"
@@ -167,7 +167,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:827fac0fce856326c4a9b7d818233879986357add47649ca45e7e06895bc7333",
               "baseImageDigest": "arm32v7/alpine@sha256:cfd8b55d209956f63c8fcc931f5c6874984e5e0ffdcb8f45ba9085f190385d73",
               "osType": "Linux",
-              "osVersion": "Alpine 3.9",
+              "osVersion": "alpine3.9",
               "architecture": "arm32",
               "created": "2020-09-08T12:53:21.4474084Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/6616c63298d6fe23e6aec2f1f5b6c4b82cedb026/src/alpine/3.9/arm32v7/Dockerfile"
@@ -184,7 +184,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f2515f3195df27eb7de02c9b83899db2b2c8df0d39608c73421fadd7e43987ae",
               "baseImageDigest": "arm64v8/alpine@sha256:f920ccc826134587fffcf1ddc6b2a554947e0f1a5ae5264bbf3435da5b2e8e61",
               "osType": "Linux",
-              "osVersion": "Alpine 3.9",
+              "osVersion": "alpine3.9",
               "architecture": "arm64",
               "created": "2020-09-08T12:53:31.9959532Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfba074d71d40db4c67ef87c3da82646c05f55f7/src/alpine/3.9/arm64v8/Dockerfile"
@@ -201,7 +201,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c2f5a29f950385f4f5d635f8084dba3ace4f85eecfed3aa45bfbe9ed5b168b21",
               "baseImageDigest": "python@sha256:d3953acf09227baf26919dbb4dc3637e8015ce46debbed4cf5444702728cfc16",
               "osType": "Linux",
-              "osVersion": "Alpine 3.9",
+              "osVersion": "alpine3.9",
               "architecture": "amd64",
               "created": "2020-09-08T12:54:49.1961927Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/alpine/3.9/helix/amd64/Dockerfile"
@@ -218,7 +218,7 @@
               "digest": "sha256:d56e32f3c757d4ba3a9f2c2c28006e7acf01af8b9f6c99e343b42501eb586bae",
               "baseImageDigest": "centos@sha256:dec8f471302de43f4cfcf82f56d99a5227b5ea1aa6d02fa56344986e1f4610e7",
               "osType": "Linux",
-              "osVersion": "Centos 6",
+              "osVersion": "centos6",
               "architecture": "amd64",
               "created": "2020-05-21T20:30:58.6028884Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/88012b63574b44f8ccf1b9d1752ef09156c1e1a0/src/centos/6/Dockerfile"
@@ -235,7 +235,7 @@
               "digest": "sha256:705e648a7242a3d4d9d611d13c77ec80c0d4b14e2817533b668ac798bae60602",
               "baseImageDigest": "centos@sha256:19a79828ca2e505eaee0ff38c2f3fd9901f4826737295157cc5212b7a372cd2b",
               "osType": "Linux",
-              "osVersion": "Centos 7",
+              "osVersion": "centos7",
               "architecture": "amd64",
               "created": "2020-08-11T20:55:07.8381396Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/359e48ed1b1f4d1b497f4765f035f9ee3de6ebdd/src/centos/7/Dockerfile"
@@ -251,7 +251,7 @@
               ],
               "digest": "sha256:a5b41752adf8964b1a601086127184d34b572f2f5cd27dda4be5ff2578191a8f",
               "osType": "Linux",
-              "osVersion": "Centos 7",
+              "osVersion": "centos7",
               "architecture": "amd64",
               "created": "2020-08-11T20:55:42.1738267Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/centos/7/mlnet/Dockerfile"
@@ -267,7 +267,7 @@
               ],
               "digest": "sha256:a84b45e71c77eb47eaf8fdc044278f971ceffaaedf16ad25ec2c4aa50bd65273",
               "osType": "Linux",
-              "osVersion": "Centos 7",
+              "osVersion": "centos7",
               "architecture": "amd64",
               "created": "2020-08-11T20:56:21.4589725Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/830f850df87620983b4e7462de44ef3d8bb932bd/src/centos/7/rpmpkg/Dockerfile"
@@ -284,7 +284,7 @@
               "digest": "sha256:10c930cfdf4ae37588ca008c778cb5997d2df1014c925f5f084774e15866d481",
               "baseImageDigest": "centos@sha256:19a79828ca2e505eaee0ff38c2f3fd9901f4826737295157cc5212b7a372cd2b",
               "osType": "Linux",
-              "osVersion": "Centos 7",
+              "osVersion": "centos7",
               "architecture": "amd64",
               "created": "2020-08-11T18:20:43.7424052Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/560e5e7bca41123f808450046e2ffe718ea9d5b9/src/centos/7/source-build/Dockerfile"
@@ -301,7 +301,7 @@
               "digest": "sha256:e8331efdd0bc9e8b24ed54930f20693600016db44bbd7e030227a5553cf6b7a7",
               "baseImageDigest": "centos@sha256:4062bbdd1bb0801b0aa38e0f83dece70fb7a5e9bce223423a68de2d8b784b43b",
               "osType": "Linux",
-              "osVersion": "Centos 8",
+              "osVersion": "centos8",
               "architecture": "amd64",
               "created": "2020-07-15T16:43:56.1035584Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/daa51168cffc9910facda82c5aae28b6168052bd/src/centos/8/Dockerfile"
@@ -317,7 +317,7 @@
               ],
               "digest": "sha256:05b4620014c545ece49e18daea5f60407554799b44361453dd08e37c880b94b5",
               "osType": "Linux",
-              "osVersion": "Centos 8",
+              "osVersion": "centos8",
               "architecture": "amd64",
               "created": "2020-07-15T16:45:06.3557454Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/daa51168cffc9910facda82c5aae28b6168052bd/src/centos/8/rpmpkg/Dockerfile"
@@ -334,7 +334,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:dc39a013ca2c310f5a6b05c661f6adc0e2bff2c75bc2677af687449b5656152f",
               "baseImageDigest": "debian@sha256:439a6bae1ef351ba9308fc9a5e69ff7754c14516f6be8ca26975fb564cb7fb76",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "amd64",
               "created": "2020-09-18T13:08:21.1897447Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/debian/10/helix/amd64/Dockerfile"
@@ -351,7 +351,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:5734a8cb1887dd8df219fd486b926f5dc7e4cbaa88911101f1a646ffcc060273",
               "baseImageDigest": "arm32v7/debian@sha256:82c62e2f1ed6045d002f848c1ddd4d910161e1f5007398097ac0f8512d70a969",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm32",
               "created": "2020-09-18T13:11:52.5501035Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/6616c63298d6fe23e6aec2f1f5b6c4b82cedb026/src/debian/10/helix/arm32v7/Dockerfile"
@@ -368,7 +368,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b8f472f10296cf0534650675ba0e585e6e7d55b32266218ae2339a6ab595a22e",
               "baseImageDigest": "arm64v8/debian@sha256:bfab5241510af5ddfebf441f0ecd546fcb6f37d36f745294b595d7d24a23ae55",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm64",
               "created": "2020-09-18T13:11:13.643734Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/debian/10/helix/arm64v8/Dockerfile"
@@ -385,7 +385,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:44d3839789bade2b8567243ed39383722c96cfcb44e2ad973340a28c75add37c",
               "baseImageDigest": "arm32v7/debian@sha256:d05c60bafb36f93e9a4427eb02c1305cd997346193213078a4a820ed50418781",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-09-18T13:08:20.8392059Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/debian/9/arm32v7/Dockerfile"
@@ -402,7 +402,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b77b15c72a4de9b67f3cd69db9f34c2766ee6814acfff7a236ecf5c34e4734fe",
               "baseImageDigest": "arm64v8/debian@sha256:109066fe2fe97aa5196bc97af7ec3dd686dbf00200290d23e7723d1ca155798a",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm64",
               "created": "2020-09-18T13:07:19.0732457Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/debian/9/arm64v8/Dockerfile"
@@ -419,7 +419,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:bfea21dc43fc237319112eb812b50fdc10e90f82ab582d41f650ee1694479237",
               "baseImageDigest": "arm32v7/debian@sha256:d05c60bafb36f93e9a4427eb02c1305cd997346193213078a4a820ed50418781",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-09-18T13:12:13.7391465Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/6616c63298d6fe23e6aec2f1f5b6c4b82cedb026/src/debian/9/helix/arm32v7/Dockerfile"
@@ -436,7 +436,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:362642797c15bccf760f3c3fe4098b4005d4b2836b7489aa9106382169a5128c",
               "baseImageDigest": "arm64v8/debian@sha256:109066fe2fe97aa5196bc97af7ec3dd686dbf00200290d23e7723d1ca155798a",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm64",
               "created": "2020-09-18T13:11:54.4209901Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/debian/9/helix/arm64v8/Dockerfile"
@@ -453,7 +453,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1c2330d352b81780ad9c22471ab666095e7ebf1a446449ceb0a19bae0ff09c96",
               "baseImageDigest": "arm32v7/debian@sha256:82c62e2f1ed6045d002f848c1ddd4d910161e1f5007398097ac0f8512d70a969",
               "osType": "Linux",
-              "osVersion": "Debian",
+              "osVersion": "debian",
               "architecture": "arm32",
               "created": "2020-09-18T13:08:59.387615Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/be5b37dc9de9f23f6ad19bd02f2e814571b574c6/src/debian/iot/arm32v7/Dockerfile"
@@ -477,7 +477,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a6e11939f8dedf1dc91912d6c1af620f569c7ac609834645ddbd6b74864bd31b",
               "baseImageDigest": "debian@sha256:eac708db10f83a29eaf9bc33151ca4e742bf3aab1f2695864fa5a96e3be0af85",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-09-18T13:07:46.326801Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/842e47fc6254d43cbc65d22f068e7f4330498dbe/src/debian/stretch-slim/docker-testrunner/amd64/Dockerfile"
@@ -490,7 +490,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:945de5f610b58c53c4ffa0ea45f59f3b2652caf4f7a0c812c095a827a556ff23",
               "baseImageDigest": "arm64v8/debian@sha256:87a5f18734519beef306a1b237727d1fb4e8bec852fd0b77253863b60c2a4741",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm64",
               "created": "2020-09-18T13:07:24.7006683Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/842e47fc6254d43cbc65d22f068e7f4330498dbe/src/debian/stretch-slim/docker-testrunner/arm64v8/Dockerfile"
@@ -507,7 +507,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:90bce1319474db0b34a72e27c6169721b7cb4a0b0045af51812a22626526b983",
               "baseImageDigest": "debian@sha256:bc125c699d736ac84c92b76ab7028741bbac69f207b7a8a4065bca6f79d5698e",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-09-18T13:08:00.9974102Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/047508b6a9d2e2aa4a2825ff196beca17ed94511/src/debian/stretch/Dockerfile"
@@ -524,7 +524,7 @@
               "digest": "sha256:8d8796679897eae72338790693575cb26b17606b83bd2315d83cc4db425406dd",
               "baseImageDigest": "fedora@sha256:3a0c8c86d8ac2d1bbcfd08d40d3b757337f7916fb14f40efcb1d1137a4edef45",
               "osType": "Linux",
-              "osVersion": "Fedora 30",
+              "osVersion": "fedora30",
               "architecture": "amd64",
               "created": "2020-08-04T01:54:56.4633004Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/fedora/30/amd64/Dockerfile"
@@ -540,7 +540,7 @@
               ],
               "digest": "sha256:972fd1157ee12503076e367955c0a4e8db202155d2ae12573ba2794c74fbc931",
               "osType": "Linux",
-              "osVersion": "Fedora 30",
+              "osVersion": "fedora30",
               "architecture": "amd64",
               "created": "2020-08-04T01:56:13.7132879Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/fedora/30/helix/amd64/Dockerfile"
@@ -557,7 +557,7 @@
               "digest": "sha256:88407951916a5df21a323a0cc186609f1be377bfd8f9c6778594326e2f5a58b7",
               "baseImageDigest": "fedora@sha256:ba4fe6a3da48addb248a16e8a63599cc5ff5250827e7232d2e3038279a0e467e",
               "osType": "Linux",
-              "osVersion": "Fedora 31",
+              "osVersion": "fedora31",
               "architecture": "amd64",
               "created": "2020-08-04T01:55:40.6073189Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/02f7c7e83342b4be0509bbcb088477456286c807/src/fedora/31/amd64/Dockerfile"
@@ -574,7 +574,7 @@
               "digest": "sha256:74ce86276537cbb017181cab6137243ad3409ab483647293b9af5a6067b37fe8",
               "baseImageDigest": "fedora@sha256:d6a6d60fda1b22b6d5fe3c3b2abe2554b60432b7b215adc11a2b5fae16f50188",
               "osType": "Linux",
-              "osVersion": "Fedora 32",
+              "osVersion": "fedora32",
               "architecture": "amd64",
               "created": "2020-08-04T01:54:23.1615962Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/163ed2a56669a359f9b5f38d54d7ff57129d897b/src/fedora/32/amd64/Dockerfile"
@@ -590,7 +590,7 @@
               ],
               "digest": "sha256:5c89d8b73020307dc7db58d9a7b796c32a676898af966d390873124e3e9b22d0",
               "osType": "Linux",
-              "osVersion": "Fedora 32",
+              "osVersion": "fedora32",
               "architecture": "amd64",
               "created": "2020-08-04T01:55:55.3115884Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/fedora/32/helix/amd64/Dockerfile"
@@ -607,7 +607,7 @@
               "digest": "sha256:59b6de89c7f0aa8eb8530a39eca58febbfb07846ec3d15620a9bf6653fc5ad58",
               "baseImageDigest": "fedora@sha256:4b181cd2a40b557d651a8b8776847517f60ad21e540e81d24a812eeecc32ae6a",
               "osType": "Linux",
-              "osVersion": "Fedora-rawhide",
+              "osVersion": "fedora-rawhide",
               "architecture": "amd64",
               "created": "2020-08-04T01:53:53.5133668Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2ad2edd1bfbd300166973089f491f681465fd299/src/fedora/rawhide/amd64/Dockerfile"
@@ -641,7 +641,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:928a4aadcf71596b8c4c0e859e4a84d77577870f68e172eb8d08d56af323e6ca",
               "baseImageDigest": "ubuntu@sha256:185fec2d6dbe9165f35e4a1136b4cf09363b328d4f850695393ca191aa1475fd",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-10-22T20:44:32.8478393Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/047508b6a9d2e2aa4a2825ff196beca17ed94511/src/ubuntu/16.04/Dockerfile"
@@ -658,7 +658,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:0a3515d8ecc187b18eb36fb0792ad7afc725addf2c08e0702c907127b6d5581e",
               "baseImageDigest": "arm32v7/ubuntu@sha256:35700cb04768212221d2c3e2f1e3bfe013d0f3adb1ca24772bde3cae70ae433a",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "arm32",
               "created": "2020-10-22T20:42:53.9592682Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/16.04/arm32v7/Dockerfile"
@@ -675,7 +675,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:30cf385b52ba23cd2ec78dd28dc2003c6d21c0a5a35343ffe683bac6a6d2d241",
               "baseImageDigest": "arm64v8/ubuntu@sha256:a674c049d6598251536436a6db960db7ffc07875932b671c6b0238310548b41d",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "arm64",
               "created": "2020-10-22T20:43:02.9586748Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/16.04/arm64v8/Dockerfile"
@@ -692,7 +692,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6d45e606db70ea8332c32bb31f5a010d2604e3a23e082685c4156b64477290c8",
               "baseImageDigest": "mcr.microsoft.com/powershell@sha256:828aaedfbfbf6885800754618a99b7126f5dde4bb51d19a61a22f9a6044f70ee",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-09-18T14:59:15.3883132Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/16.04/coredeps/Dockerfile"
@@ -709,7 +709,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:ba7b6116e7ba371ee17802583bc214b848d1547b49f1e85644a1d5aeee7841f0",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:587528d295f18f0401bdd01fb17568a10f708072ead6b5d4ff9548831a77aae0",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-10-22T21:26:37.3939219Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/16.04/cross/Dockerfile"
@@ -726,7 +726,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:fcf4314704f418a87e4ba51907a125f5878530257f8cf23d984239819d3a2ecc",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:587528d295f18f0401bdd01fb17568a10f708072ead6b5d4ff9548831a77aae0",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-10-22T21:12:26.2234446Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/406629a56a1deaafb83a88278dc48856c67a866e/src/ubuntu/16.04/cross/arm64-alpine/Dockerfile"
@@ -743,7 +743,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:67581f2ba7a2f053843bcaaa65b32bb57cdfe6194b47df59b2ad911d112bbd80",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:587528d295f18f0401bdd01fb17568a10f708072ead6b5d4ff9548831a77aae0",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-10-22T21:03:48.2664979Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cfdd435784925f9e02090857adccacc3ffcba4ef/src/ubuntu/16.04/cross/arm64/Dockerfile"
@@ -760,7 +760,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:587528d295f18f0401bdd01fb17568a10f708072ead6b5d4ff9548831a77aae0",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6d45e606db70ea8332c32bb31f5a010d2604e3a23e082685c4156b64477290c8",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-10-22T20:50:28.300485Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/219667d0aa52f928cbffe6a40f704249ab967287/src/ubuntu/16.04/crossdeps/Dockerfile"
@@ -777,7 +777,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:fa1f7dcd1acaa1b24ae6cd26d4ec880c764fcf13e1d811c9ec6227f3a359204e",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:928a4aadcf71596b8c4c0e859e4a84d77577870f68e172eb8d08d56af323e6ca",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-10-22T20:45:14.872775Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cfdd435784925f9e02090857adccacc3ffcba4ef/src/ubuntu/16.04/debpkg/Dockerfile"
@@ -794,7 +794,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f58a345d868fda7a40f69d1fa453a129ae829d5598714d18d13cec1aab96cbad",
               "baseImageDigest": "arm32v7/ubuntu@sha256:35700cb04768212221d2c3e2f1e3bfe013d0f3adb1ca24772bde3cae70ae433a",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "arm32",
               "created": "2020-10-22T20:47:03.840109Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/6616c63298d6fe23e6aec2f1f5b6c4b82cedb026/src/ubuntu/16.04/helix/arm32v7/Dockerfile"
@@ -811,7 +811,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e0c40a17451ee1cb0d34c215fce880074c0b62e3c6deda62efa11cdda5c8aef1",
               "baseImageDigest": "arm64v8/ubuntu@sha256:a674c049d6598251536436a6db960db7ffc07875932b671c6b0238310548b41d",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "arm64",
               "created": "2020-10-22T20:46:41.8724303Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/ubuntu/16.04/helix/arm64v8/Dockerfile"
@@ -828,7 +828,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a792ad70172f257c6ef61c844096e4bbc35de1c13c9a8444233f5146c8e2d649",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:928a4aadcf71596b8c4c0e859e4a84d77577870f68e172eb8d08d56af323e6ca",
               "osType": "Linux",
-              "osVersion": "Ubuntu 16.04",
+              "osVersion": "xenial",
               "architecture": "amd64",
               "created": "2020-10-22T20:45:50.6861352Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2c829e8e6d00c72e1d9ea6f3b856d365fc0beb75/src/ubuntu/16.04/mlnet/Dockerfile"
@@ -845,7 +845,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:42141fb8a87cf7be0bec39a3d1555270dfaacedb01582e34ddd880ccbb392aed",
               "baseImageDigest": "ubuntu@sha256:646942475da61b4ce9cc5b3fadb42642ea90e5d0de46111458e100ff2c7031e6",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T20:45:13.7296384Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/047508b6a9d2e2aa4a2825ff196beca17ed94511/src/ubuntu/18.04/amd64/Dockerfile"
@@ -862,7 +862,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:991abd524a120a59e4c7cffd299a9bda01f7c272ce3649f24a5619ee520fe86e",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4529b1986ceb94427604fad97f1b430fe2729ff9af9f27156bcd92009a96f9e4",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-08-27T13:07:14.2517245Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/e2c3f8309fe0c8b68f29efc9e5566e4fe9de1c11/src/ubuntu/18.04/android/Dockerfile"
@@ -879,7 +879,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e27c9f165ec3b1a7eab73f89435c2d9db44d3441f8cb70c0b8b46f07259399f0",
               "baseImageDigest": "arm32v7/ubuntu@sha256:e80b8affb2361dc632c1fa8fcbf6b6514f750eb6ef99b7e7f825a55f849bfd89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-10-22T20:43:22.6292519Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm32v7/Dockerfile"
@@ -896,7 +896,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9f699add431002dbd068863fda7bb280d8989c585ee648c378879acf94066161",
               "baseImageDigest": "arm64v8/ubuntu@sha256:01a2038b20d165ab7df81934f9849bdfbc59bd6f6322c5d11e341504f66ec266",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-10-22T20:44:02.36371Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/bfcd90a7a269f4163f4b521d33afb65db12499ac/src/ubuntu/18.04/arm64v8/Dockerfile"
@@ -913,7 +913,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4529b1986ceb94427604fad97f1b430fe2729ff9af9f27156bcd92009a96f9e4",
               "baseImageDigest": "mcr.microsoft.com/powershell@sha256:e5eb8e021d1f3b0c7d4343d4c16ec68b284a4a0d5446b6fe2f8b5572f96a5481",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-08-27T13:01:24.1961816Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/coredeps/Dockerfile"
@@ -930,7 +930,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:fb8cd33447f0bba9035ed50c31199d77f3e92f65dfbebdf4e6edab98c3828489",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T21:38:52.1540596Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/Dockerfile"
@@ -947,7 +947,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:dc77393606fd19b721aa1255d4acf9e6a99e3422f5de2ad880259781129a98d6",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T21:17:32.7670152Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/14441ae43f4b7099016a965752e714a70e638418/src/ubuntu/18.04/cross/arm-alpine/Dockerfile"
@@ -964,7 +964,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f048f7c4d03a241ebcdf35e54cc0012471a0e1fbcbba6a301295e6d9ef272668",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T21:49:59.791048Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm/16.04/Dockerfile"
@@ -981,7 +981,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:52a0e85a2dc6d76a3c20a2f73304ac9ce0ccb47d7225651ac08ae6012e3c5157",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T21:26:59.6974978Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64-alpine/Dockerfile"
@@ -998,7 +998,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:12d0df9c3451a6b43f50880cb99a52b3575d14d6b7345ea1b856dd6fcf599d9f",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T20:57:50.3344473Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09ec75772538159cfc508bab041c882ff09b0012/src/ubuntu/18.04/cross/arm64/16.04/Dockerfile"
@@ -1015,7 +1015,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:40d62458adf5fa5a417d0d88db722bbc4860655979ff4494dee33aaae11d6c82",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T21:08:28.3221746Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/85814b76210b3830c4a3ec422dbf3f8f5eb3649e/src/ubuntu/18.04/cross/arm64/Dockerfile"
@@ -1032,7 +1032,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e40fb15b7e0c739170c2cc79ac5ac1653c807aa88f8b7e51ceec4ae4fddac3f6",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T21:53:13.5103014Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/11/Dockerfile"
@@ -1049,7 +1049,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:0b1c11e5822a5e7d53cc2d0236658345d57b0c143b09e025dcb162d4fee5961f",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T21:56:49.1830581Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/a84b0d2d74f97b0f48da7159cf309d22f1d74646/src/ubuntu/18.04/cross/freebsd/12/Dockerfile"
@@ -1066,7 +1066,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e05a9be82ac754b401beb983e686e77d4aea80202c50d887f50efdd6b465b428",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T22:12:34.8340663Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/772abb5ae3b7d57d9ed26313c2f5de1f6d330ca8/src/ubuntu/18.04/cross/illumos/Dockerfile"
@@ -1083,7 +1083,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9a81e8aa9da88041a1aafa8a405faa3bcec92076376bd7b221d616cb023199ef",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-28T11:01:59.8660988Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d6e0352cff80d92f423b7942e1fce0ebf5dbacba/src/ubuntu/18.04/cross/s390x/Dockerfile"
@@ -1100,7 +1100,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c1f18dfbc6960738510a7f0a117784c90f0a3b506b2e2aa87963250362a31a25",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4529b1986ceb94427604fad97f1b430fe2729ff9af9f27156bcd92009a96f9e4",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T20:47:27.6694045Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/219667d0aa52f928cbffe6a40f704249ab967287/src/ubuntu/18.04/crossdeps/Dockerfile"
@@ -1117,7 +1117,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b6dd6dd22fdeafcbc009bf7669f3e97e97488dfe69b2c4459a865b6cb16f71af",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:42141fb8a87cf7be0bec39a3d1555270dfaacedb01582e34ddd880ccbb392aed",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-22T20:45:39.8771861Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cfdd435784925f9e02090857adccacc3ffcba4ef/src/ubuntu/18.04/debpkg/Dockerfile"
@@ -1134,7 +1134,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f78d25e6e2dc4fcf4e005715d4aee90a93f4147bd34fa8a94d043c81b48e99b8",
               "baseImageDigest": "ubuntu@sha256:646942475da61b4ce9cc5b3fadb42642ea90e5d0de46111458e100ff2c7031e6",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-02T14:58:54.6249187Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/ae7e2e19eb9af5ea09255af4673f542e07c43222/src/ubuntu/18.04/helix/amd64/Dockerfile"
@@ -1151,7 +1151,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:ce08893475f0d9ab2b77ace955e9b956bcb2400aeff43fe6cb3eb113c8813dc5",
               "baseImageDigest": "arm32v7/ubuntu@sha256:e80b8affb2361dc632c1fa8fcbf6b6514f750eb6ef99b7e7f825a55f849bfd89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-10-22T20:48:32.2944033Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/6616c63298d6fe23e6aec2f1f5b6c4b82cedb026/src/ubuntu/18.04/helix/arm32v7/Dockerfile"
@@ -1168,7 +1168,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d6cf73140c1064698f14d9da6f5ebd0d7be6ff6aec29257246854a28be3a39f8",
               "baseImageDigest": "arm64v8/ubuntu@sha256:01a2038b20d165ab7df81934f9849bdfbc59bd6f6322c5d11e341504f66ec266",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-10-22T20:47:58.5429683Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/ubuntu/18.04/helix/arm64v8/Dockerfile"
@@ -1185,7 +1185,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:ab08af01ffe68ab7565f49281fbf7c83d989b146c435c61d242fafc2d8088d16",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f78d25e6e2dc4fcf4e005715d4aee90a93f4147bd34fa8a94d043c81b48e99b8",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-09T18:10:43.3041378Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/30699674a222912236190d12559c96216ebb3915/src/ubuntu/18.04/helix/sqlserver/amd64/Dockerfile"
@@ -1202,7 +1202,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8a05a489606b02e3a019b0fc0cd135a5f88d781af46df0699c96051070311060",
               "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4529b1986ceb94427604fad97f1b430fe2729ff9af9f27156bcd92009a96f9e4",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-23T17:01:30.0818011Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d7d1dfedb2d58fd04b055112b60080357422090b/src/ubuntu/18.04/webassembly/Dockerfile"
@@ -1219,7 +1219,7 @@
               "digest": null,
               "baseImageDigest": "ubuntu@sha256:bd5f4f235eb31768b2c5caf1988bbdc182d4fc3cb6ee4aca6c6d74613f256140",
               "osType": "Linux",
-              "osVersion": "Ubuntu 19.04",
+              "osVersion": "disco",
               "architecture": "amd64",
               "created": "2020-02-20T20:40:24.7603243Z",
               "commitUrl": null
@@ -1236,7 +1236,7 @@
               "digest": "sha256:fb568baf9c17250a2057f27236dbb00b0a41751722da53dac51aa9d44c64f57a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/core/sdk@sha256:d540a54c3510665fdd2278b3ec65b658a2d258d7c827fc076f949e0898bd2406",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-07-09T18:36:58.6148711Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/dd73ef79f1263cff08e78c742e3cbed2db9b7bde/src/ubuntu/20.04/crossdac/amd64/Dockerfile"
@@ -1253,7 +1253,7 @@
               "digest": "sha256:c8b4b03da527c41a185174adc9f8349e08b7ba4b6b3276ef82af2c17f2ad336e",
               "baseImageDigest": "ubuntu@sha256:c844b5fee673cd976732dda6860e09b8f2ae5b324777b6f9d25fd70a0904c2e0",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-07-09T18:39:33.5285492Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/b5586b32722270e7421ce7dbfc26203ad9a38abb/src/ubuntu/20.04/helix/wasm/amd64/Dockerfile"
@@ -1270,7 +1270,7 @@
               "digest": "sha256:a97d9a91c8d9d3b32f88d535b298e46a490c40c313bb0509073ed00fb8ca0ceb",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:890c2716924501d40173d998c007cd7aae7f14a596313de2deddb397845f6fe6",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 1909",
+              "osVersion": "windowsservercore-1909",
               "architecture": "amd64",
               "created": "2020-08-04T01:52:33.5021789Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/56c6673d3aa6c6d9887a5a584b814b10da7b7177/src/windowsservercore/1909/helix/amd64/Dockerfile"
@@ -1287,7 +1287,7 @@
               "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:0233a566f0ef050955d5c70b0ff7377c6f4959fe1395e142c47c7a4003b20a94",
               "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:5d64df31a952c6b2e12afdb7b137f3ea7127fba59a87f0e16dbdbc1534b76cdf",
               "osType": "Windows",
-              "osVersion": "Windows Server, version 2004",
+              "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
               "created": "2020-09-04T20:04:14.5856735Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/272704cf6d77b849f57552a46fd0dbcaa145b9f7/src/windowsservercore/2004/helix/amd64/Dockerfile"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-master-samples.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master-samples.json
@@ -21,7 +21,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:4fe90f7a6901fdc45a639ffa69c95b5dcbdc426e924c1a745bc6c87ed683d3f1",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:c7a62424519d45e1a4d75968eddbc295725be88e78cd17b0f1bdcd1f916862a0",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "amd64",
               "created": "2020-11-18T04:10:32.3718106Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/aspnetapp/Dockerfile"
@@ -86,7 +86,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:1fd2549494af31b8ec892301ab6c686763d600975dee05285793e5fb096b1684",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:c7a62424519d45e1a4d75968eddbc295725be88e78cd17b0f1bdcd1f916862a0",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm64",
               "created": "2020-11-18T04:09:43.7857598Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/aspnetapp/Dockerfile"
@@ -99,7 +99,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:5c7f34b64f81e3c4946dd314232d2caffd6183591b4a3fa1562835ad5d310b8b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:15c9b56a054743ee2e888b800dd067615a5962165bc6a71c7aaf5303d0c6abb9",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm32",
               "created": "2020-11-18T04:10:40.032312Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/aspnetapp/Dockerfile.debian-arm32"
@@ -124,7 +124,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:d74d12b4837ae7a42bb0a271d8f7c35c00077f0e2c07aab70a2fc16bbbf6411e",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:0ffc67290fa5de7c3e623a9e1b3cc4f7cb83c9603793ebc2f3dd58ebd39139a3",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "amd64",
               "created": "2020-11-18T04:10:31.2867765Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/dotnetapp/Dockerfile"
@@ -189,7 +189,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:ca572f33843825fa6df25cbce2437aba1e8451fd8673c401f068e19b5d4df574",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:0ffc67290fa5de7c3e623a9e1b3cc4f7cb83c9603793ebc2f3dd58ebd39139a3",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm64",
               "created": "2020-11-18T04:09:54.331483Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/dotnetapp/Dockerfile"
@@ -202,7 +202,7 @@
               "digest": "mcr.microsoft.com/dotnet/samples@sha256:5acee3cad81c5e6428695cfc829edcafe5fe22949d29f9d62a6055e5bef0c237",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:3de5ef41f508abefd0143ca1b829b033e2a09bc275a28a262f2f005e1741edbc",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm32",
               "created": "2020-11-18T04:10:48.0272013Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/244804c9b82045e5f8e49ee153ad04c1a59b1cfb/samples/dotnetapp/Dockerfile.debian-arm32"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -17,7 +17,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:ac967af1f4694afd1c3d6d9a0b0a60fc006b67eb30d70ec57463f467aa500e13",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:d8c4abc5c5cfc495c6e7ba66f5b3d2173305b29fe4d4fb8f84ca474128dbe56f",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:43.6157705Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/alpine3.12/amd64/Dockerfile"
@@ -36,7 +36,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:08c46002f3a7119fb7d7eaf21e257150b0319cd78ce617c08f829b5ae00cbec9",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:2b53cc8d1bb1156f476f951c502a9d8023b5652ef9f01044082e7aebfed42cc3",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:19.7386123Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/bionic/amd64/Dockerfile"
@@ -55,7 +55,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:990b7a88fbab7dedb6cfcd9c11fabc5567691b5600bfd9d9e98b825dc118801b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:99cf3705ea1a211f05e5f0bbe6c8a6f6dcaacd7094477cd4033104acfce058d6",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-09T15:34:40.5842218Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/bionic/arm32v7/Dockerfile"
@@ -74,7 +74,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:a27f841d9a777a27a2bd04d03e6ba729a91021fdd557059857072d8cd3d89862",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:969bb4f14f3f31301f07e015b44b64375ec9bbe9b9426980271ae82e70afd6ef",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:48.6303906Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/focal/amd64/Dockerfile"
@@ -93,7 +93,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:de62923be2d019118320868278fb98062e6b8180c35c56dd2d048d8187dcfe13",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:775b6e44deb8662bff6901b4da8e5f8ee41a21a2de902cc078d0182f824d99ea",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T15:34:42.9752398Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/focal/arm32v7/Dockerfile"
@@ -190,7 +190,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:eea9f69fc91d0b64628c2961e330ac4c06830eaa0dd4d39cad08b02aa93aa200",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4acc7b5034a2053583398e0fe56f9e7def62dfaf10cab7d634d164ea6edaaa66",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T00:11:57.990052Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/stretch-slim/amd64/Dockerfile"
@@ -204,7 +204,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:3c8eaca81eefaf1c0c22818bd85c9ec23585b889aaf48193c0dc2fdc7a021727",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:f588e89263b0b3b6a36b9fe748ebb21e9120ab59348cb27172bdb0c6adc74966",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T00:12:01.2218775Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -224,7 +224,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:67bffbc2227fb167a690511499b4466294598f4dc5904cca0b0c82f4adf0f8cc",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:b84ea5135d3e9598d29b4e682174d5f0efede8e98152d52b9250f218beff88f6",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:15.7730068Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/alpine3.12/amd64/Dockerfile"
@@ -244,7 +244,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:781641014f42de82f342c4ff8d47260929d7e73803e3cab6a2218699e22c71d8",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:386dd3b41ed75480e9edeae34f509f2552253ed3c8b7f9bb37c727a4a54cf181",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-10T15:03:15.810719Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -263,7 +263,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:c547dc94fe10bf7c283b498a56c942a9017ee82d1b10c68e282f8e0c088cb7dc",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:b1cbe9ed44383cf2285d0fec54447c3a61dcaef9c8821984be0435f5c2af4fb0",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:35.3488093Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/bionic/amd64/Dockerfile"
@@ -282,7 +282,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:e3c849f49ba18a730932902ddd9a81a56d9f9adac88e45b1e6607e3c5cfd3f15",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:d531ee5d44573d3dadf3c81605e98a211f8fcdf445c4d37865c50601f213bef2",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:56.6718903Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/bionic/arm32v7/Dockerfile"
@@ -301,7 +301,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:6fb0bd51a06eeb1f37966207df4b71ccd6b9f8bc21d4275c105ae336102f67e0",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:199fe0d2ddebda9906b852654743be2ba38ce7440dcc99ebcc1c5e33787859f7",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:04:17.9018243Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/bionic/arm64v8/Dockerfile"
@@ -328,7 +328,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:46da5637d6db51c89725e9dc1c5a945a274ec35cf368a3ef73f44c35b489dcb3",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:a739fde1f253790412001c2d1ee42b0da097648c6b0a7b0824fe18bd12d89c12",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:12:24.8233324Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/buster-slim/amd64/Dockerfile"
@@ -342,7 +342,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:e24a8798ef0169a3f1cf74b7f262bbbe67416d22b9d99e6c3c93363c208317d9",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:c67d0628ea93f7f7959174c305db392887f1fcee3d7edf8c21a11de8ff00289b",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:55.2045301Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/buster-slim/arm32v7/Dockerfile"
@@ -356,7 +356,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:f8bf7b7e857ce4c8ba8e40d7ed5f5a147511780049943f69bbb2f40a3ed83169",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:a678f416ec4452287ffd1fa919d0958053aa5e567831127d7eb3f4489dc75d52",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:12:00.899822Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/buster-slim/arm64v8/Dockerfile"
@@ -445,7 +445,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:863c460694a785e8a3f7ec28d6be07dc3cb2728c76c9fb10980f45fe7f0a6d70",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:5f64e68bb833037485edddb4d034a04c50749101d841b861bffdd4522fc51721",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:04:38.8977524Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/focal/amd64/Dockerfile"
@@ -464,7 +464,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:a16b9d448cbcb247496af4fb83d0b3cec3c29a0b9c0ea5f09e21d6228b1252a2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:b3997054f53fa7378b5d3940f4857df630781654884b1240b9b8333c8d0f5c03",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:51.2400676Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/focal/arm32v7/Dockerfile"
@@ -483,7 +483,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:73992a94662cb8c7db6c0286695f073b5902a3319c21c39cd31dfedc86dd29d7",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:98e4b36fddfbbf5f026a61741a45c350dc69cd7849769abd871c3a0d7e5601d6",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:04:03.0188956Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/focal/arm64v8/Dockerfile"
@@ -506,7 +506,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:056f2d892f8ac176b5e5c65d838cd5fee14a1d8121c86e87edaf981219f76702",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:12:32.0001791Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/amd64/Dockerfile"
@@ -516,7 +516,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:15c9b56a054743ee2e888b800dd067615a5962165bc6a71c7aaf5303d0c6abb9",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:12:01.5784507Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile"
@@ -526,7 +526,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:ce378d0700346d93b924fd80019a5960dec430170ae84f0da5af2a098a675a91",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:12:08.0764196Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile"
@@ -555,7 +555,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:82c663af4d9c4865dd9b982d0424dabe3cd323606bda3df6c97d8108bdbda042",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:728e8a44d254bc8444e58d76f8a1895ccade82db853ffd3932a93c9d02ba9732",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T20:49:53.1880591Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/alpine3.12/amd64/Dockerfile"
@@ -570,7 +570,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:9372904cee9c4b39fbbe8094933935755d943a6500adffeb44d628fa51f404c2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:b0e8c606dc785a5cc6e107d6754f5cba7a3d0f431356d3bb0539715b8352622f",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-09T20:50:10.5124081Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile"
@@ -598,7 +598,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:056f2d892f8ac176b5e5c65d838cd5fee14a1d8121c86e87edaf981219f76702",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:52b511ce6ac9a4a5e69ed5ee9005384146bfe057889dbf7b608b10358221f428",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:12:32.0001791Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/amd64/Dockerfile"
@@ -612,7 +612,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:15c9b56a054743ee2e888b800dd067615a5962165bc6a71c7aaf5303d0c6abb9",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:3de5ef41f508abefd0143ca1b829b033e2a09bc275a28a262f2f005e1741edbc",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:12:01.5784507Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile"
@@ -626,7 +626,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:ce378d0700346d93b924fd80019a5960dec430170ae84f0da5af2a098a675a91",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:0b867e81cb9631a7a17bed9b51f836bf01a79ca3da508da4950274fc410b865e",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:12:08.0764196Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile"
@@ -709,7 +709,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:f39e3e4f85b314e1fe68834a2080c9539d9c7fe6e42c973de0829f7f877ef6b1",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:126ba9df4ddc70efe05fd7a57c9dde0d73b27efc2658eb154090c8951b5f1697",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T20:50:52.0001163Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/focal/amd64/Dockerfile"
@@ -723,7 +723,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:8b1c64f135d179dcf6b3862833ba072ec00a01642078daa16fc12a2644f1b1fe",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:aafe621720d9e1ba4190a5e9d0b99ffac461345955f1010cd4294bc6aad90627",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T20:50:46.9361448Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/focal/arm32v7/Dockerfile"
@@ -737,7 +737,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:7d4da4a965c17237a7f421b75a65aefcf88e91027e1d76aad5cee2049629783a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:81182f129087953de53833937eccbb88446bba1335e4a70002fea09763308f34",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-09T20:50:17.7673578Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/focal/arm64v8/Dockerfile"
@@ -781,7 +781,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:5a0605d119ffede82e47ecdca8163d05e0f241390c302ac5e6189882e1680ae8",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:d8c4abc5c5cfc495c6e7ba66f5b3d2173305b29fe4d4fb8f84ca474128dbe56f",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:27.0178942Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/alpine3.12/amd64/Dockerfile"
@@ -800,7 +800,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:2ea1f6f7df00d2f7c28bb9b675db34bcc8791bf0eec381e817af12d079bf247d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:2b53cc8d1bb1156f476f951c502a9d8023b5652ef9f01044082e7aebfed42cc3",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:12.1957739Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/bionic/amd64/Dockerfile"
@@ -819,7 +819,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:4cdbfd8337ae5f3751bb2ba9b64f55807656afdf1f6bfe741b5265567470072d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:99cf3705ea1a211f05e5f0bbe6c8a6f6dcaacd7094477cd4033104acfce058d6",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-09T15:34:32.3922339Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/bionic/arm32v7/Dockerfile"
@@ -838,7 +838,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:cf0e46105797339cf78f955f3d2d159af61ad7d1c14027db63081798cd3f729f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:969bb4f14f3f31301f07e015b44b64375ec9bbe9b9426980271ae82e70afd6ef",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:40.6598358Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/focal/amd64/Dockerfile"
@@ -857,7 +857,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:f3a94e2efe6fd9245e8c9017425a815eea2b5af9bbfce1dec9bec2d60b12fc38",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:775b6e44deb8662bff6901b4da8e5f8ee41a21a2de902cc078d0182f824d99ea",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T15:34:33.9232918Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/focal/arm32v7/Dockerfile"
@@ -954,7 +954,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:4271ebb8e3bbaa94e71227eeba7688a4a5ea56fe08422238a150aa2a29094868",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4acc7b5034a2053583398e0fe56f9e7def62dfaf10cab7d634d164ea6edaaa66",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T00:11:50.2997811Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/stretch-slim/amd64/Dockerfile"
@@ -968,7 +968,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:34e5e92fa58a861268014f82036e58ad5a901aa33ffd9cd98af2a10e48472c0a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:f588e89263b0b3b6a36b9fe748ebb21e9120ab59348cb27172bdb0c6adc74966",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:52.9765179Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -988,7 +988,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:b84ea5135d3e9598d29b4e682174d5f0efede8e98152d52b9250f218beff88f6",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:006a8e99e2272e2b7685e79648184260558611d9e154e727776e8838a6f6167d",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:08.4929071Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/alpine3.12/amd64/Dockerfile"
@@ -1008,7 +1008,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:386dd3b41ed75480e9edeae34f509f2552253ed3c8b7f9bb37c727a4a54cf181",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:ff9cee298d0d750faf62d75d76a78494a3b3008814907df3910e9aff808c0591",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-10T15:03:05.6040994Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -1027,7 +1027,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:b1cbe9ed44383cf2285d0fec54447c3a61dcaef9c8821984be0435f5c2af4fb0",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:c3016a2d1c666de9ffddf9c1f06057ad1953fff89196a48a57eafec4d69b6285",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:28.5434414Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/bionic/amd64/Dockerfile"
@@ -1046,7 +1046,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:d531ee5d44573d3dadf3c81605e98a211f8fcdf445c4d37865c50601f213bef2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:a83ee88b5b04dec1c8120b3408dfd3be9bd21843b6e8f06a18e1d709b1fd7689",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:50.539963Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/bionic/arm32v7/Dockerfile"
@@ -1065,7 +1065,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:199fe0d2ddebda9906b852654743be2ba38ce7440dcc99ebcc1c5e33787859f7",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:291da170ae26b28eacea9a2c48d222f0b112db36abfcd7692cd94d9a5280cdbd",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:04:13.3641386Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/bionic/arm64v8/Dockerfile"
@@ -1092,7 +1092,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:a739fde1f253790412001c2d1ee42b0da097648c6b0a7b0824fe18bd12d89c12",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:b744aa1a1c2f051bbb555b40fe9be79473220ae5dbb5f5a2d287f2547d71a8ae",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:12:10.4116777Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/buster-slim/amd64/Dockerfile"
@@ -1106,7 +1106,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:c67d0628ea93f7f7959174c305db392887f1fcee3d7edf8c21a11de8ff00289b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:8928e4f7de0900abf4a6834734540023fcdaacaa4d2c5f7ba50bbfbbdfa8ea32",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:42.0963014Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/buster-slim/arm32v7/Dockerfile"
@@ -1120,7 +1120,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:a678f416ec4452287ffd1fa919d0958053aa5e567831127d7eb3f4489dc75d52",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:b994222ea97cb4bab8c3423cb9c1e0951b08e961b8867007443df5fbaacb4cac",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:11:45.7196676Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/buster-slim/arm64v8/Dockerfile"
@@ -1209,7 +1209,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:5f64e68bb833037485edddb4d034a04c50749101d841b861bffdd4522fc51721",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:a6c0c4664a9b88275d4e1c8487ca422744c59d43e83b10c7408e4a0205fd32de",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:04:31.5604059Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/focal/amd64/Dockerfile"
@@ -1228,7 +1228,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:b3997054f53fa7378b5d3940f4857df630781654884b1240b9b8333c8d0f5c03",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4a1c16aab4eddaee225be047e6e8cf4571a565c4a045ef1d903c18f96a7f8a1a",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:39.6061431Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/focal/arm32v7/Dockerfile"
@@ -1247,7 +1247,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:98e4b36fddfbbf5f026a61741a45c350dc69cd7849769abd871c3a0d7e5601d6",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:93992e09dfee6de577ed2c633e2462ae2c845edd4b5130a97aaedfc0431a8d6c",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:03:51.1232338Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/focal/arm64v8/Dockerfile"
@@ -1270,7 +1270,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:52b511ce6ac9a4a5e69ed5ee9005384146bfe057889dbf7b608b10358221f428",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:12:21.9163201Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/amd64/Dockerfile"
@@ -1280,7 +1280,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:3de5ef41f508abefd0143ca1b829b033e2a09bc275a28a262f2f005e1741edbc",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:49.7630724Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm32v7/Dockerfile"
@@ -1290,7 +1290,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:0b867e81cb9631a7a17bed9b51f836bf01a79ca3da508da4950274fc410b865e",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:11:55.2204589Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm64v8/Dockerfile"
@@ -1319,7 +1319,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:728e8a44d254bc8444e58d76f8a1895ccade82db853ffd3932a93c9d02ba9732",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:7379ef42254a8a03116c3ca6261e6c0d9e668f4ee879ad6a1c9fcd4688933dda",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T20:49:47.4252792Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/alpine3.12/amd64/Dockerfile"
@@ -1334,7 +1334,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:b0e8c606dc785a5cc6e107d6754f5cba7a3d0f431356d3bb0539715b8352622f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:939b132d3ba1f3c54d8fff76ecb83f1469a93848e2d0c8670329ff5c99adabee",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-09T20:50:03.0761913Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile"
@@ -1362,7 +1362,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:52b511ce6ac9a4a5e69ed5ee9005384146bfe057889dbf7b608b10358221f428",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:b744aa1a1c2f051bbb555b40fe9be79473220ae5dbb5f5a2d287f2547d71a8ae",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:12:21.9163201Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/amd64/Dockerfile"
@@ -1376,7 +1376,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:3de5ef41f508abefd0143ca1b829b033e2a09bc275a28a262f2f005e1741edbc",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:8928e4f7de0900abf4a6834734540023fcdaacaa4d2c5f7ba50bbfbbdfa8ea32",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:49.7630724Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm32v7/Dockerfile"
@@ -1390,7 +1390,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:0b867e81cb9631a7a17bed9b51f836bf01a79ca3da508da4950274fc410b865e",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:b994222ea97cb4bab8c3423cb9c1e0951b08e961b8867007443df5fbaacb4cac",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:11:55.2204589Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm64v8/Dockerfile"
@@ -1473,7 +1473,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:126ba9df4ddc70efe05fd7a57c9dde0d73b27efc2658eb154090c8951b5f1697",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:8d133b553a3a22107e21aca72710bab533f44da1440b01aae1e5d0b3c52f4c80",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T20:50:44.0607486Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/focal/amd64/Dockerfile"
@@ -1487,7 +1487,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:aafe621720d9e1ba4190a5e9d0b99ffac461345955f1010cd4294bc6aad90627",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:8b508d6990f551ddcd01f87d8d2a7f4de9c74444f0f8e56901d598dad1657f6a",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T20:50:37.8289337Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/focal/arm32v7/Dockerfile"
@@ -1501,7 +1501,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:81182f129087953de53833937eccbb88446bba1335e4a70002fea09763308f34",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:e376f2582832bcd8727aa8fa08225084abffcb3e74bd6850447e23b51fe7f233",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-09T20:50:06.8718682Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/focal/arm64v8/Dockerfile"
@@ -1545,7 +1545,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:d8c4abc5c5cfc495c6e7ba66f5b3d2173305b29fe4d4fb8f84ca474128dbe56f",
               "baseImageDigest": "amd64/alpine@sha256:d7342993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:20.305071Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/1799df71ee5fed03442701cae10db16c73a17d47/src/runtime-deps/2.1/alpine3.12/amd64/Dockerfile"
@@ -1564,7 +1564,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:2b53cc8d1bb1156f476f951c502a9d8023b5652ef9f01044082e7aebfed42cc3",
               "baseImageDigest": "amd64/ubuntu@sha256:45c6f8f1b2fe15adaa72305616d69a6cd641169bc8b16886756919e7c01fa48b",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-09T15:33:47.64512Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/2.1/bionic/amd64/Dockerfile"
@@ -1583,7 +1583,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:99cf3705ea1a211f05e5f0bbe6c8a6f6dcaacd7094477cd4033104acfce058d6",
               "baseImageDigest": "arm32v7/ubuntu@sha256:e80b8affb2361dc632c1fa8fcbf6b6514f750eb6ef99b7e7f825a55f849bfd89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-09T15:34:06.1089213Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/2.1/bionic/arm32v7/Dockerfile"
@@ -1602,7 +1602,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:969bb4f14f3f31301f07e015b44b64375ec9bbe9b9426980271ae82e70afd6ef",
               "baseImageDigest": "amd64/ubuntu@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:26.5440712Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/2.1/focal/amd64/Dockerfile"
@@ -1621,7 +1621,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:775b6e44deb8662bff6901b4da8e5f8ee41a21a2de902cc078d0182f824d99ea",
               "baseImageDigest": "arm32v7/ubuntu@sha256:ebc8925ee51929a9d691f260b34dd6ed59b4cc2f6ca61e515ce08d31d38e0a87",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T15:34:05.4410087Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/2cb58a25a3b5b146c3a34ef8c556b1be62b73810/src/runtime-deps/2.1/focal/arm32v7/Dockerfile"
@@ -1648,7 +1648,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4acc7b5034a2053583398e0fe56f9e7def62dfaf10cab7d634d164ea6edaaa66",
               "baseImageDigest": "amd64/debian@sha256:e14ad2a63bfebbe02919d95f9be1f93a3665c7a81f4cf17ede7f4e91ac7ef67f",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T00:11:40.8886773Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile"
@@ -1662,7 +1662,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:f588e89263b0b3b6a36b9fe748ebb21e9120ab59348cb27172bdb0c6adc74966",
               "baseImageDigest": "arm32v7/debian@sha256:e2ea286755bd9e16bb913a0f45384b394288b8bc1f11274f112e887ce02b6dd8",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:35.3605196Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -1682,7 +1682,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:006a8e99e2272e2b7685e79648184260558611d9e154e727776e8838a6f6167d",
               "baseImageDigest": "amd64/alpine@sha256:d7342993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:02.2053203Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile"
@@ -1702,7 +1702,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:ff9cee298d0d750faf62d75d76a78494a3b3008814907df3910e9aff808c0591",
               "baseImageDigest": "arm64v8/alpine@sha256:fbb820c07896f5c2516167e7146d9938fc82d4b6b1db167defa5b0a7162e4480",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-10T15:02:53.4228326Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -1721,7 +1721,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:c3016a2d1c666de9ffddf9c1f06057ad1953fff89196a48a57eafec4d69b6285",
               "baseImageDigest": "amd64/ubuntu@sha256:45c6f8f1b2fe15adaa72305616d69a6cd641169bc8b16886756919e7c01fa48b",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:14.5259578Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/bionic/amd64/Dockerfile"
@@ -1740,7 +1740,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:a83ee88b5b04dec1c8120b3408dfd3be9bd21843b6e8f06a18e1d709b1fd7689",
               "baseImageDigest": "arm32v7/ubuntu@sha256:e80b8affb2361dc632c1fa8fcbf6b6514f750eb6ef99b7e7f825a55f849bfd89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:25.8800158Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/bionic/arm32v7/Dockerfile"
@@ -1759,7 +1759,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:291da170ae26b28eacea9a2c48d222f0b112db36abfcd7692cd94d9a5280cdbd",
               "baseImageDigest": "arm64v8/ubuntu@sha256:01a2038b20d165ab7df81934f9849bdfbc59bd6f6322c5d11e341504f66ec266",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:03:47.6415791Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile"
@@ -1793,7 +1793,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:b744aa1a1c2f051bbb555b40fe9be79473220ae5dbb5f5a2d287f2547d71a8ae",
               "baseImageDigest": "amd64/debian@sha256:bb5473161a03d24b397c46778e58f845e29f1ce42a2953666ef8289f00afda42",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:12:01.3467386Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile"
@@ -1809,7 +1809,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:8928e4f7de0900abf4a6834734540023fcdaacaa4d2c5f7ba50bbfbbdfa8ea32",
               "baseImageDigest": "arm32v7/debian@sha256:e2ba4d923b1ca64a946de5bbfe550d4a78e4723df4c543a38d4f4a35af3a284b",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:27.2471049Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile"
@@ -1825,7 +1825,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:b994222ea97cb4bab8c3423cb9c1e0951b08e961b8867007443df5fbaacb4cac",
               "baseImageDigest": "arm64v8/debian@sha256:5d0f4e33abe44c7fca183c2c7ea7b2084d769aef3528ffd630f0dffda0784089",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:11:26.4271763Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile"
@@ -1844,7 +1844,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:a6c0c4664a9b88275d4e1c8487ca422744c59d43e83b10c7408e4a0205fd32de",
               "baseImageDigest": "amd64/ubuntu@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:04:16.0325175Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/focal/amd64/Dockerfile"
@@ -1863,7 +1863,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4a1c16aab4eddaee225be047e6e8cf4571a565c4a045ef1d903c18f96a7f8a1a",
               "baseImageDigest": "arm32v7/ubuntu@sha256:ebc8925ee51929a9d691f260b34dd6ed59b4cc2f6ca61e515ce08d31d38e0a87",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:15.1921405Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/2cb58a25a3b5b146c3a34ef8c556b1be62b73810/src/runtime-deps/3.1/focal/arm32v7/Dockerfile"
@@ -1882,7 +1882,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:93992e09dfee6de577ed2c633e2462ae2c845edd4b5130a97aaedfc0431a8d6c",
               "baseImageDigest": "arm64v8/ubuntu@sha256:65cd340c0735f062e84507c3c2298502b5446037cc282bc1f3ac720ef42fb137",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:03:21.891309Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/focal/arm64v8/Dockerfile"
@@ -1911,7 +1911,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:7379ef42254a8a03116c3ca6261e6c0d9e668f4ee879ad6a1c9fcd4688933dda",
               "baseImageDigest": "amd64/alpine@sha256:d7342993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T15:34:33.1700554Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile"
@@ -1926,7 +1926,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:939b132d3ba1f3c54d8fff76ecb83f1469a93848e2d0c8670329ff5c99adabee",
               "baseImageDigest": "arm64v8/alpine@sha256:fbb820c07896f5c2516167e7146d9938fc82d4b6b1db167defa5b0a7162e4480",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-09T15:33:28.56115Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -1953,7 +1953,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:8d133b553a3a22107e21aca72710bab533f44da1440b01aae1e5d0b3c52f4c80",
               "baseImageDigest": "amd64/ubuntu@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T15:33:56.8646803Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/focal/amd64/Dockerfile"
@@ -1967,7 +1967,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:8b508d6990f551ddcd01f87d8d2a7f4de9c74444f0f8e56901d598dad1657f6a",
               "baseImageDigest": "arm32v7/ubuntu@sha256:ebc8925ee51929a9d691f260b34dd6ed59b4cc2f6ca61e515ce08d31d38e0a87",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T15:34:30.989685Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/2cb58a25a3b5b146c3a34ef8c556b1be62b73810/src/runtime-deps/3.1/focal/arm32v7/Dockerfile"
@@ -1981,7 +1981,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:e376f2582832bcd8727aa8fa08225084abffcb3e74bd6850447e23b51fe7f233",
               "baseImageDigest": "arm64v8/ubuntu@sha256:65cd340c0735f062e84507c3c2298502b5446037cc282bc1f3ac720ef42fb137",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-09T15:37:08.294905Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/3.1/focal/arm64v8/Dockerfile"
@@ -2006,7 +2006,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:f3317449ec9d3f1cf37054e0835c5a050f2b821e1ce9a492f8f2fb677a9bed40",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:d8c4abc5c5cfc495c6e7ba66f5b3d2173305b29fe4d4fb8f84ca474128dbe56f",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T15:36:29.7695679Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/sdk/2.1/alpine3.12/amd64/Dockerfile"
@@ -2025,7 +2025,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:f98b059b017c28431f35a4c3d8acbd34ad762bd2576845c35c82c2ec4f3ea219",
               "baseImageDigest": "amd64/buildpack-deps@sha256:ead7fb5c1085e367ea54982507c6abf5259c172e903a9db6299fca17f4aef6b7",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-09T15:35:43.0287962Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/bionic/amd64/Dockerfile"
@@ -2044,7 +2044,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:9a2fa4292ee7add2700f6eee379c3964ce9b1357a632fb13d2a019be10c7fb52",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:83e5a995554ad528e280a76e681b64566e97ae1ff4eaeea56f41901114ca9ab9",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-09T15:36:20.7146258Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/bionic/arm32v7/Dockerfile"
@@ -2063,7 +2063,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:f4ae97ef113566728d722a999e6e986be0650b1db6c1f0fb9f6bdb256d562457",
               "baseImageDigest": "amd64/buildpack-deps@sha256:a186f6b0f35601f7543a9eed0d144373e724c742990a9e9b27d5c4530c0d995c",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T15:35:47.3651138Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/focal/amd64/Dockerfile"
@@ -2082,7 +2082,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:b81d9114cb2c7addf81981953fbb84e92bab00c8e5087da0630b3b4d789f9753",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:13f937ab3218c43e0ca7dcbe61ce29adf7689a1a6e2eb20e57ab4b1a2c9898c8",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T15:36:34.9799861Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/focal/arm32v7/Dockerfile"
@@ -2179,7 +2179,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:50017bf829789e3f25b5c615807c26bb16acb1b7bf9ac9a9113d017f26ff69c5",
               "baseImageDigest": "amd64/buildpack-deps@sha256:edd6ecc5330ceafb541c9071c835b33c6371af3b59b1e7f300717481d0967dc3",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T04:10:59.5859922Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/stretch/amd64/Dockerfile"
@@ -2193,7 +2193,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:fb4316b9dc884c5821049b1937e51345849fd205b67854030289d94eb5fbc153",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:ea4e3f52e8d8073e3bea484687f3fb8cb66852cd4c00be19a208d4dd206bbc43",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T00:13:40.6402992Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/stretch/arm32v7/Dockerfile"
@@ -2213,7 +2213,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:3982ac41d8777b78ad7a2efe4c9674338975ebf9a25eeceb943348e45edf91b1",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:67bffbc2227fb167a690511499b4466294598f4dc5904cca0b0c82f4adf0f8cc",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:42.2298069Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/alpine3.12/amd64/Dockerfile"
@@ -2232,7 +2232,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:a2dc6e7047552a853d492646d2f8b4f886f56a20aaade87b3c1c57b4c47035c4",
               "baseImageDigest": "amd64/buildpack-deps@sha256:ead7fb5c1085e367ea54982507c6abf5259c172e903a9db6299fca17f4aef6b7",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:04:38.7386834Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/bionic/amd64/Dockerfile"
@@ -2251,7 +2251,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:b51b04c1cfad7b82c6c82f299e15f9de3f3c04dbb8e70661d8eaa30b4eff841c",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:83e5a995554ad528e280a76e681b64566e97ae1ff4eaeea56f41901114ca9ab9",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:55.6569697Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/bionic/arm32v7/Dockerfile"
@@ -2270,7 +2270,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:de255c0532666c108998d54f3193345b7a324614afcf9513a77a0f8cd02e123a",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:7d9bea06c3481d78231b04ba66296b49d7283cc84eac5581010f5ed5b5613198",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:03:49.9535041Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/bionic/arm64v8/Dockerfile"
@@ -2297,7 +2297,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:bbf31e5a084085e58743a4c34833c3678c685eba049ee17c13471bbb0e0b4796",
               "baseImageDigest": "amd64/buildpack-deps@sha256:034e7f8b59fdd9bc2c5c7c1abdb00ec715e6add7a28aad9ab1e18a14c63f1cab",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "amd64",
               "created": "2020-11-18T04:10:28.6601443Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/buster/amd64/Dockerfile"
@@ -2311,7 +2311,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:885c9568d8379d5a62813d1ab7c9ff8578dc5f3996dbb43ea4de04994e215c24",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:d6518cb49a38c000f61d8e878bd3c166c960886bd0f84ff81c020da2273a7c5d",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:46.1309719Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/buster/arm32v7/Dockerfile"
@@ -2325,7 +2325,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:73b32f6830bca5952add18925b9be702ad2e213c3ffb121013ffaaaaff8f9b50",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:62062ef22be551021de31c67bd4bc24762485533b1b6e0d9585027e6c30d4ea8",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm64",
               "created": "2020-11-18T00:11:31.6112831Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/buster/arm64v8/Dockerfile"
@@ -2414,7 +2414,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:d56dd8c01174aac05314a315163294c90f9117ae8987b7c4eb0486239b7b75b6",
               "baseImageDigest": "amd64/buildpack-deps@sha256:a186f6b0f35601f7543a9eed0d144373e724c742990a9e9b27d5c4530c0d995c",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:03:49.835482Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/focal/amd64/Dockerfile"
@@ -2433,7 +2433,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:97ca71d2bff3b06f1142a198d114667d154ad6deb0f2ee0e933bb45f8dbb3575",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:13f937ab3218c43e0ca7dcbe61ce29adf7689a1a6e2eb20e57ab4b1a2c9898c8",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T15:03:47.0567727Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/focal/arm32v7/Dockerfile"
@@ -2452,7 +2452,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:873b40a93f2b966f3543bca654aebb63e61dbebcf8a728b7648c9d57ff2132e4",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:bae744b076916bf31afcc5a08b84fb3e6c7fe1c3317a1781f333b38fd1488b28",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:03:48.121722Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/focal/arm64v8/Dockerfile"
@@ -2475,7 +2475,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:481094034311859bde3b2818a4c2259345732215a5dd763a136f8d01007588e7",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:13:06.6151004Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/buster-slim/amd64/Dockerfile"
@@ -2485,7 +2485,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:338a7e4cf33cbf0c79d5d200863984938ae2b7390b57b10f4a39a226408f07aa",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:12:56.4283524Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/buster-slim/arm32v7/Dockerfile"
@@ -2495,7 +2495,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:738daec55033c84a5c5ad565721d7fc28ededa90d9cf6b8c95929d22e38b41e2",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:13:08.0385473Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/buster-slim/arm64v8/Dockerfile"
@@ -2524,7 +2524,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:6f23cab680b4d77efcad18f62ea21d2c5bafa9bf0159122963c77d77db143cda",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:82c663af4d9c4865dd9b982d0424dabe3cd323606bda3df6c97d8108bdbda042",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-09T20:50:31.7594788Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/alpine3.12/amd64/Dockerfile"
@@ -2552,7 +2552,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:481094034311859bde3b2818a4c2259345732215a5dd763a136f8d01007588e7",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:056f2d892f8ac176b5e5c65d838cd5fee14a1d8121c86e87edaf981219f76702",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:13:06.6151004Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/buster-slim/amd64/Dockerfile"
@@ -2566,7 +2566,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:338a7e4cf33cbf0c79d5d200863984938ae2b7390b57b10f4a39a226408f07aa",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:15c9b56a054743ee2e888b800dd067615a5962165bc6a71c7aaf5303d0c6abb9",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:12:56.4283524Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/buster-slim/arm32v7/Dockerfile"
@@ -2580,7 +2580,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:738daec55033c84a5c5ad565721d7fc28ededa90d9cf6b8c95929d22e38b41e2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:ce378d0700346d93b924fd80019a5960dec430170ae84f0da5af2a098a675a91",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T00:13:08.0385473Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/buster-slim/arm64v8/Dockerfile"
@@ -2663,7 +2663,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:2ec7bba7ba81395d2db5cb3386435ffe5cb932310d32f79826a9dbac8d5f26f2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:f39e3e4f85b314e1fe68834a2080c9539d9c7fe6e42c973de0829f7f877ef6b1",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-09T20:51:32.4839008Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/focal/amd64/Dockerfile"
@@ -2677,7 +2677,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:06bc0f6e90ccc6d00d6bd8b633a4b59cfa5ff2c1bb28f58db8c5295b8fe2952a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:8b1c64f135d179dcf6b3862833ba072ec00a01642078daa16fc12a2644f1b1fe",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-09T20:51:40.6253798Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/focal/arm32v7/Dockerfile"
@@ -2691,7 +2691,7 @@
               "digest": "mcr.microsoft.com/dotnet/sdk@sha256:7ccfe4d57983896809c57092eca27533382a5efaa6624cee0d04e9456c650eb6",
               "baseImageDigest": "mcr.microsoft.com/dotnet/aspnet@sha256:7d4da4a965c17237a7f421b75a65aefcf88e91027e1d76aad5cee2049629783a",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-09T20:51:56.9668093Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/sdk/5.0/focal/arm64v8/Dockerfile"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
@@ -17,7 +17,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:6302a41a3eb3b70578172c370940c44b2b1604bb67b77cc1b526ed8272c3574f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:6d69b8a8d8f2a2f854840d28ba5e39c861b4c4be4b79e252fd243e1c7c37bc01",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-10-27T22:59:00.5533572Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/alpine3.12/amd64/Dockerfile"
@@ -36,7 +36,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:f8c8d7ebfef9c4e84e73f6f01279955d28b3db481cc01ac645a86bb261317ac5",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:03e804bf0937be119d33adc0368ffd2e6a3fa8eff0db9e2fe7277597a87a806b",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-27T23:00:15.5189893Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/bionic/amd64/Dockerfile"
@@ -55,7 +55,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:22fce65602a21afa556724d7dab7893063c3f2b7026d8a5c9cf94c177fde7870",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ba9656265430086ece906b517e98d2980ba67036c29dd3fd8a65cfafed090b32",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-10-27T22:59:56.0041988Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/bionic/arm32v7/Dockerfile"
@@ -74,7 +74,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:d4ec1d0fbc19bd63f0a210f6a12d34e5106cfaa168d87ab66265b70c12dc43cf",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d60eca1a2e576c78f55881859100b6469f603d20a30a91a5b34822e0d32cb20e",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-10-27T22:59:16.3552272Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/focal/amd64/Dockerfile"
@@ -93,7 +93,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:4a17007c27e59be8e07a8cb24215bda0594aa6b558034d22286da9f675d4dc87",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:f38f14f597e1dcf6b7523c8c198e3213ba09fd8d845b6346873ae3da19ce52e2",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-10-27T23:00:13.1750472Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/focal/arm32v7/Dockerfile"
@@ -190,7 +190,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:9ba35ef473c72c5ec3203890ec96a9542b5886c46a47e579efda9e8c0436ea10",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6e209b0890bad7aff8d1887a367530d857f02402ecc0150b7a8688a04095635",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:37.7617966Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/stretch-slim/amd64/Dockerfile"
@@ -204,7 +204,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:48e0952f56b3d529abcf241b414af26bcce308d5cc63d2f58ca5954cb50cf6ed",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c449c106e0ea6ee943678e0e6de1f30b14315b2882372bb81dfe548844ff2d8",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:55.7781089Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -224,7 +224,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:050eacd25406c286163cd79cb902a06acc4e40f7e9f4ac6029aa6385a79b23e3",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:6f630e818d1e10b829ad43620e693d3df59bbfc958ab019886c235e02d558c48",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:50:51.1033689Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/alpine3.12/amd64/Dockerfile"
@@ -244,7 +244,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:a5c8cb98f93380199c392e5b7ffeb46ebe93eec8861de540aa9fe60a5b1a7408",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:20eba01b7f6e14d056559ba7ed764c0134ee25beeda795cb2c8eac47ad041eb6",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-10T15:51:12.1758603Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -263,7 +263,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:a577ca978ae6c0acd10901677002ae0c893476addb27ab0ffa3190f7f41d5bc6",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:38d92a34b81871e51e8a677feee10d35e56b8d58c9871de75b44803aa0fcd1cb",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:51:06.199208Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/bionic/amd64/Dockerfile"
@@ -282,7 +282,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:67fa8c546b197295354c0a140e8ba4c231dd94bb8e86d7734bbc1c9d16be99a2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:623e1b53b5762c96fc0603ec9dcf088d072c1dc926b5105e9868f1b8a81f1368",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:51:19.4474403Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/bionic/arm32v7/Dockerfile"
@@ -301,7 +301,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:34f19f0ab834e1894a9bb89004d01f4e222e7d988a77d08c86f0f37a18dc5a52",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:145fd94e81ec2f7750e96837fcbaad38bd68abb197cd5ee9a01cca87cb6530b3",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:52:11.3433993Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/bionic/arm64v8/Dockerfile"
@@ -328,7 +328,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:88dd386fbd5d25aba8438815bac56906479a40e80fb76de7de9988df357a95a3",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:0dc53909f2acd76cf0508618c40f9283604131c9a9ff019521c57870da7ba673",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:45.8199571Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/buster-slim/amd64/Dockerfile"
@@ -342,7 +342,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:d5ea75d1288d772570834fc61a135feccff8c6c65ec5dbce56ca437b1a65a5dc",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:5299d2186c068a5302dee42c2471a7cfa04d237e8897596dbd63f7f456778f91",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:55.5458878Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/buster-slim/arm32v7/Dockerfile"
@@ -356,7 +356,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:0900a248227b754a76ec3fe91d7af871b44fd921f9d7f9b036044f538ca0ff2e",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:c552b9488d9bcbadf4cbd0a1cb76c05a1f8ec9d93db218d3e54d9ce9d3643f78",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:44:00.3073435Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/buster-slim/arm64v8/Dockerfile"
@@ -445,7 +445,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5025d99b967c0bdf6fd8a85251efe431571f644af7f7de1c2b2b8095bd8049fe",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:fb2e0f88e7068d945289171c6ccca7f8b3828783f29e3fbdbd64974657394449",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:51:12.8719556Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/focal/amd64/Dockerfile"
@@ -464,7 +464,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:19deea01b03871ae32c8690212e487bf9104de1784a82cc39c7f7630bfcfc1ac",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:7b954840e4a8d4531f57cdb82f78863a32b38a231cd9de0d9d7ea7220ce0c5c1",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T16:10:06.8259Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/focal/arm32v7/Dockerfile"
@@ -483,7 +483,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:bc4aa984c17a725328d9dd009fdf48132d8cfba0d7a7e6c413da4b92809d7907",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:2270e95d889e128016b651d84c09313ab064861fa7c70ff501ab17aad84471cb",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:51:34.7423898Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/aspnet/3.1/focal/arm64v8/Dockerfile"
@@ -512,7 +512,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5540c543b451770b9907b32300a3051e299f086d3f7ec7447d6e8ddc11f69eda",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:49c945f6d817e091a3523ecb60ab6619023dcdc918208a0afa4ecc49e9a2058a",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-16T13:57:59.7182515Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/alpine3.12/amd64/Dockerfile"
@@ -527,7 +527,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:91fff572ba640ebf5eca80687ffa92ff5270c8b08125987b18bf218611da8e0e",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:bbe4ed9250a1cbeeae86c7a71974774bb6cb4ee716cd94a8361cfc69e89be016",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-16T13:57:58.4271645Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/alpine3.12/arm64v8/Dockerfile"
@@ -555,7 +555,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:15f228a4260cb934e39dec68005a60b0e04a3b6557f94f152123d74ce48d3d68",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:d4b48149e5b71fb97c220019f64f4dddb792d160f4918afa229abd4e4fcc2aa8",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:53.0001255Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/amd64/Dockerfile"
@@ -569,7 +569,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:848c22a6a211ad68624797dc630715cd80037a636fb4097ebd56d0b214ee996c",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:9787cb2256d2e0a62ff5ecb32c289b3f6bd85bdd7196feb7c2988507741e47aa",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:44:02.0679105Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile"
@@ -583,7 +583,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5f5590dbdb15966fb990e230a694e2ea01ff2e5e999b3e362241abed5abaa2db",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:96384aa94a146d8c4bb845ba34ebf063d933403fea2c30459deca43d58f209c9",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:44:07.6474505Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile"
@@ -666,7 +666,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:3ff8d375c5aab0f2120d6faa140acb5efa3bb060efa6352d9f082dbcc9203ecd",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:415a04814c9bfec399e62fd851c4c4045163bf43c7d060b0eeb0ea3996225ffa",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-16T13:58:57.0002242Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/focal/amd64/Dockerfile"
@@ -680,7 +680,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:8acd85fef359969a31102f00572e2e833066f1c17dd1b293fc58b49b1f23895d",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:3945759081ec44905cfeb554e37106a1d18b017659044aec6b23db967204bf06",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-16T14:00:04.0560214Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/focal/arm32v7/Dockerfile"
@@ -694,7 +694,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:c1c15287ab00a0657333a44544381facc797c121ab2546be986c3fd677a83e7e",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:680ba80354ef2d01389999da8ad2373162b94e4b3532368db56f5fcc635e3997",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-16T13:58:05.0912781Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/focal/arm64v8/Dockerfile"
@@ -736,7 +736,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:15f228a4260cb934e39dec68005a60b0e04a3b6557f94f152123d74ce48d3d68",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:53.0001255Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/amd64/Dockerfile"
@@ -746,7 +746,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:848c22a6a211ad68624797dc630715cd80037a636fb4097ebd56d0b214ee996c",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:44:02.0679105Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm32v7/Dockerfile"
@@ -756,7 +756,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5f5590dbdb15966fb990e230a694e2ea01ff2e5e999b3e362241abed5abaa2db",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:44:07.6474505Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/aspnet/5.0/buster-slim/arm64v8/Dockerfile"
@@ -788,7 +788,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/monitor@sha256:d9f9e8ddd0642854165e066b14a1bd53dd8e645bea09ea33472fbd83786617b8",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:050eacd25406c286163cd79cb902a06acc4e40f7e9f4ac6029aa6385a79b23e3",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-16T13:58:49.130142Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/fe07c2c3830b77a2eb383ce276671c977c53e081/src/monitor/5.0/alpine/amd64/Dockerfile"
@@ -813,7 +813,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:d981fc1bf572ff654a6bf767fa55f2546ba4b530b4b841c859f96a570441d367",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:6d69b8a8d8f2a2f854840d28ba5e39c861b4c4be4b79e252fd243e1c7c37bc01",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-10-27T22:58:51.6510837Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/alpine3.12/amd64/Dockerfile"
@@ -832,7 +832,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:12485896c7b45a7392cb097015c22914f9e9ca4c3babbc2b4372cbbe6ae4efd5",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:03e804bf0937be119d33adc0368ffd2e6a3fa8eff0db9e2fe7277597a87a806b",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-27T23:00:00.335291Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/bionic/amd64/Dockerfile"
@@ -851,7 +851,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:2d1456e46240ad91b6296731700abcc4d5b1c1a7d48fcfe44654d8b079f88e1c",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ba9656265430086ece906b517e98d2980ba67036c29dd3fd8a65cfafed090b32",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-10-27T22:59:48.384548Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/bionic/arm32v7/Dockerfile"
@@ -870,7 +870,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:8baba0173d07a6810bfca1ef16837c6ba43b29801be572990bb9cbbe17257bb2",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d60eca1a2e576c78f55881859100b6469f603d20a30a91a5b34822e0d32cb20e",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-10-27T22:59:09.0212183Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/focal/amd64/Dockerfile"
@@ -889,7 +889,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:91d060c8e369196097783980c1330d58592e9ed37bbb07f87af328a652d0c457",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:f38f14f597e1dcf6b7523c8c198e3213ba09fd8d845b6346873ae3da19ce52e2",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-10-27T23:00:04.8339203Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/focal/arm32v7/Dockerfile"
@@ -986,7 +986,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:67f61073725bc73f56e34e2e316060006ed5451a733e1bb09484e029bbfdcc06",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6e209b0890bad7aff8d1887a367530d857f02402ecc0150b7a8688a04095635",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:27.283598Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/stretch-slim/amd64/Dockerfile"
@@ -1000,7 +1000,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:ffc9fbc9edc11d0dee0e2492e7bde6dc7e9f17a6e9a49679530b559ecfb2379b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c449c106e0ea6ee943678e0e6de1f30b14315b2882372bb81dfe548844ff2d8",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:47.4684577Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -1020,7 +1020,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:6f630e818d1e10b829ad43620e693d3df59bbfc958ab019886c235e02d558c48",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:c01d76dd46d9d26b89e465e94ab4dfab9f1e1cf003a9cc2d8d660ddc87c2cf16",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:50:40.7607654Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/alpine3.12/amd64/Dockerfile"
@@ -1040,7 +1040,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:20eba01b7f6e14d056559ba7ed764c0134ee25beeda795cb2c8eac47ad041eb6",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c0ca16fed516b74a9fbb0d7b0495b651e0c314009fd8747e1ef11965834bd54",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-10T15:50:55.68395Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -1059,7 +1059,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:38d92a34b81871e51e8a677feee10d35e56b8d58c9871de75b44803aa0fcd1cb",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:655f4aeb2088dc9a64a8b65cf68830da2476b92aed2cb6d95f5b446d3a11d4d8",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:51:02.5264005Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/bionic/amd64/Dockerfile"
@@ -1078,7 +1078,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:623e1b53b5762c96fc0603ec9dcf088d072c1dc926b5105e9868f1b8a81f1368",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:80c13077fd134f30c7c5f959e9d46f39be4d96dda80afe4cc3ef46db57fa5ee5",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:51:14.8726443Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/bionic/arm32v7/Dockerfile"
@@ -1097,7 +1097,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:145fd94e81ec2f7750e96837fcbaad38bd68abb197cd5ee9a01cca87cb6530b3",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:599df18771a9ab98f9b28ee7c43f3ee825c01676cb19835f0be7d1e44313c390",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:52:05.5669774Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/bionic/arm64v8/Dockerfile"
@@ -1124,7 +1124,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:0dc53909f2acd76cf0508618c40f9283604131c9a9ff019521c57870da7ba673",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6834c5dd436591e541001bd11f70e42913d351159441c612c7e377a1f4630de",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:31.394198Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/buster-slim/amd64/Dockerfile"
@@ -1138,7 +1138,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:5299d2186c068a5302dee42c2471a7cfa04d237e8897596dbd63f7f456778f91",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:23dbea6e0714496351b961b562b69f24c47b834d1ad8556034a758cbb8fa672b",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:42.3323064Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/buster-slim/arm32v7/Dockerfile"
@@ -1152,7 +1152,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:c552b9488d9bcbadf4cbd0a1cb76c05a1f8ec9d93db218d3e54d9ce9d3643f78",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:506a96c86629b15ac3fbed52d14e6e545f6d56f04ebe9a2bfadc8e54f764a81e",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:43:42.8073787Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/buster-slim/arm64v8/Dockerfile"
@@ -1241,7 +1241,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:fb2e0f88e7068d945289171c6ccca7f8b3828783f29e3fbdbd64974657394449",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:a534a514c80f0224b0d265b7eafff150890a3f8ea42f325aaaaefbb29d910adc",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:50:58.6083622Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/focal/amd64/Dockerfile"
@@ -1260,7 +1260,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:7b954840e4a8d4531f57cdb82f78863a32b38a231cd9de0d9d7ea7220ce0c5c1",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:6baa9f83287711c2c1fe891c25418f6ba903314d250ad997eeca53e2e8976a89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T16:09:48.8058906Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/focal/arm32v7/Dockerfile"
@@ -1279,7 +1279,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:2270e95d889e128016b651d84c09313ab064861fa7c70ff501ab17aad84471cb",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ef6fd3188ea7fd18347725c90197eacfac93a4031243534cf13a9f5725767ec5",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:51:23.687003Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/runtime/3.1/focal/arm64v8/Dockerfile"
@@ -1308,7 +1308,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:49c945f6d817e091a3523ecb60ab6619023dcdc918208a0afa4ecc49e9a2058a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:c01d76dd46d9d26b89e465e94ab4dfab9f1e1cf003a9cc2d8d660ddc87c2cf16",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-16T13:57:53.5924891Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/alpine3.12/amd64/Dockerfile"
@@ -1323,7 +1323,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:bbe4ed9250a1cbeeae86c7a71974774bb6cb4ee716cd94a8361cfc69e89be016",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c0ca16fed516b74a9fbb0d7b0495b651e0c314009fd8747e1ef11965834bd54",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-16T13:57:49.6846115Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/alpine3.12/arm64v8/Dockerfile"
@@ -1351,7 +1351,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:d4b48149e5b71fb97c220019f64f4dddb792d160f4918afa229abd4e4fcc2aa8",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6834c5dd436591e541001bd11f70e42913d351159441c612c7e377a1f4630de",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:43.0493645Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/amd64/Dockerfile"
@@ -1365,7 +1365,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:9787cb2256d2e0a62ff5ecb32c289b3f6bd85bdd7196feb7c2988507741e47aa",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:23dbea6e0714496351b961b562b69f24c47b834d1ad8556034a758cbb8fa672b",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:49.929215Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm32v7/Dockerfile"
@@ -1379,7 +1379,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:96384aa94a146d8c4bb845ba34ebf063d933403fea2c30459deca43d58f209c9",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:506a96c86629b15ac3fbed52d14e6e545f6d56f04ebe9a2bfadc8e54f764a81e",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:43:54.450047Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm64v8/Dockerfile"
@@ -1462,7 +1462,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:415a04814c9bfec399e62fd851c4c4045163bf43c7d060b0eeb0ea3996225ffa",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:a534a514c80f0224b0d265b7eafff150890a3f8ea42f325aaaaefbb29d910adc",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-16T13:58:49.109646Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/focal/amd64/Dockerfile"
@@ -1476,7 +1476,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:3945759081ec44905cfeb554e37106a1d18b017659044aec6b23db967204bf06",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:6baa9f83287711c2c1fe891c25418f6ba903314d250ad997eeca53e2e8976a89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-16T13:59:49.6362613Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/focal/arm32v7/Dockerfile"
@@ -1490,7 +1490,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:680ba80354ef2d01389999da8ad2373162b94e4b3532368db56f5fcc635e3997",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ef6fd3188ea7fd18347725c90197eacfac93a4031243534cf13a9f5725767ec5",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-16T13:57:55.3779372Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/focal/arm64v8/Dockerfile"
@@ -1532,7 +1532,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:d4b48149e5b71fb97c220019f64f4dddb792d160f4918afa229abd4e4fcc2aa8",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:43.0493645Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/amd64/Dockerfile"
@@ -1542,7 +1542,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:9787cb2256d2e0a62ff5ecb32c289b3f6bd85bdd7196feb7c2988507741e47aa",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:49.929215Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm32v7/Dockerfile"
@@ -1552,7 +1552,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:96384aa94a146d8c4bb845ba34ebf063d933403fea2c30459deca43d58f209c9",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:43:54.450047Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/be0f47d5dbad88adcbda0a386022fc4ed73a6d07/src/runtime/5.0/buster-slim/arm64v8/Dockerfile"
@@ -1577,7 +1577,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:6d69b8a8d8f2a2f854840d28ba5e39c861b4c4be4b79e252fd243e1c7c37bc01",
               "baseImageDigest": "amd64/alpine@sha256:d7342993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-10-27T22:58:46.3379752Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/a4ec20905f5fc36156100d7da0b69ac43cb492c6/src/runtime-deps/2.1/alpine3.12/amd64/Dockerfile"
@@ -1596,7 +1596,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:03e804bf0937be119d33adc0368ffd2e6a3fa8eff0db9e2fe7277597a87a806b",
               "baseImageDigest": "amd64/ubuntu@sha256:45c6f8f1b2fe15adaa72305616d69a6cd641169bc8b16886756919e7c01fa48b",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-27T22:59:47.8461595Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/2.1/bionic/amd64/Dockerfile"
@@ -1615,7 +1615,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ba9656265430086ece906b517e98d2980ba67036c29dd3fd8a65cfafed090b32",
               "baseImageDigest": "arm32v7/ubuntu@sha256:e80b8affb2361dc632c1fa8fcbf6b6514f750eb6ef99b7e7f825a55f849bfd89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-10-27T22:59:21.0007673Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/2.1/bionic/arm32v7/Dockerfile"
@@ -1634,7 +1634,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d60eca1a2e576c78f55881859100b6469f603d20a30a91a5b34822e0d32cb20e",
               "baseImageDigest": "amd64/ubuntu@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-10-27T22:58:58.9734889Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/2.1/focal/amd64/Dockerfile"
@@ -1653,7 +1653,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:f38f14f597e1dcf6b7523c8c198e3213ba09fd8d845b6346873ae3da19ce52e2",
               "baseImageDigest": "arm32v7/ubuntu@sha256:ebc8925ee51929a9d691f260b34dd6ed59b4cc2f6ca61e515ce08d31d38e0a87",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-10-27T22:59:36.0299276Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d58f76b400dd5d265044d909fb08982fd3ff23df/src/runtime-deps/2.1/focal/arm32v7/Dockerfile"
@@ -1680,7 +1680,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6e209b0890bad7aff8d1887a367530d857f02402ecc0150b7a8688a04095635",
               "baseImageDigest": "amd64/debian@sha256:e14ad2a63bfebbe02919d95f9be1f93a3665c7a81f4cf17ede7f4e91ac7ef67f",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:17.265876Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile"
@@ -1694,7 +1694,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c449c106e0ea6ee943678e0e6de1f30b14315b2882372bb81dfe548844ff2d8",
               "baseImageDigest": "arm32v7/debian@sha256:e2ea286755bd9e16bb913a0f45384b394288b8bc1f11274f112e887ce02b6dd8",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:26.3065934Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -1714,7 +1714,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:c01d76dd46d9d26b89e465e94ab4dfab9f1e1cf003a9cc2d8d660ddc87c2cf16",
               "baseImageDigest": "amd64/alpine@sha256:d7342993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:50:35.2058491Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile"
@@ -1734,7 +1734,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c0ca16fed516b74a9fbb0d7b0495b651e0c314009fd8747e1ef11965834bd54",
               "baseImageDigest": "arm64v8/alpine@sha256:fbb820c07896f5c2516167e7146d9938fc82d4b6b1db167defa5b0a7162e4480",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-11-10T15:50:32.8525838Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -1753,7 +1753,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:655f4aeb2088dc9a64a8b65cf68830da2476b92aed2cb6d95f5b446d3a11d4d8",
               "baseImageDigest": "amd64/ubuntu@sha256:45c6f8f1b2fe15adaa72305616d69a6cd641169bc8b16886756919e7c01fa48b",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:50:49.4543697Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/bionic/amd64/Dockerfile"
@@ -1772,7 +1772,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:80c13077fd134f30c7c5f959e9d46f39be4d96dda80afe4cc3ef46db57fa5ee5",
               "baseImageDigest": "arm32v7/ubuntu@sha256:e80b8affb2361dc632c1fa8fcbf6b6514f750eb6ef99b7e7f825a55f849bfd89",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:50:54.1739823Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/bionic/arm32v7/Dockerfile"
@@ -1791,7 +1791,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:599df18771a9ab98f9b28ee7c43f3ee825c01676cb19835f0be7d1e44313c390",
               "baseImageDigest": "arm64v8/ubuntu@sha256:01a2038b20d165ab7df81934f9849bdfbc59bd6f6322c5d11e341504f66ec266",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:51:39.27275Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/bionic/arm64v8/Dockerfile"
@@ -1825,7 +1825,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6834c5dd436591e541001bd11f70e42913d351159441c612c7e377a1f4630de",
               "baseImageDigest": "amd64/debian@sha256:bb5473161a03d24b397c46778e58f845e29f1ce42a2953666ef8289f00afda42",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:22.9230252Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/buster-slim/amd64/Dockerfile"
@@ -1841,7 +1841,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:23dbea6e0714496351b961b562b69f24c47b834d1ad8556034a758cbb8fa672b",
               "baseImageDigest": "arm32v7/debian@sha256:e2ba4d923b1ca64a946de5bbfe550d4a78e4723df4c543a38d4f4a35af3a284b",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:27.6989481Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/buster-slim/arm32v7/Dockerfile"
@@ -1857,7 +1857,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:506a96c86629b15ac3fbed52d14e6e545f6d56f04ebe9a2bfadc8e54f764a81e",
               "baseImageDigest": "arm64v8/debian@sha256:5d0f4e33abe44c7fca183c2c7ea7b2084d769aef3528ffd630f0dffda0784089",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:43:24.3233519Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/buster-slim/arm64v8/Dockerfile"
@@ -1876,7 +1876,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:a534a514c80f0224b0d265b7eafff150890a3f8ea42f325aaaaefbb29d910adc",
               "baseImageDigest": "amd64/ubuntu@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:50:44.4682746Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/focal/amd64/Dockerfile"
@@ -1895,7 +1895,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:6baa9f83287711c2c1fe891c25418f6ba903314d250ad997eeca53e2e8976a89",
               "baseImageDigest": "arm32v7/ubuntu@sha256:ebc8925ee51929a9d691f260b34dd6ed59b4cc2f6ca61e515ce08d31d38e0a87",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T16:09:17.3431211Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d58f76b400dd5d265044d909fb08982fd3ff23df/src/runtime-deps/3.1/focal/arm32v7/Dockerfile"
@@ -1914,7 +1914,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:ef6fd3188ea7fd18347725c90197eacfac93a4031243534cf13a9f5725767ec5",
               "baseImageDigest": "arm64v8/ubuntu@sha256:65cd340c0735f062e84507c3c2298502b5446037cc282bc1f3ac720ef42fb137",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:50:57.6839268Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/focal/arm64v8/Dockerfile"
@@ -1943,7 +1943,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:20c27af39b0f2c7bec49a68f96f8b73513bbe5b59eb4cf56a1d959088a799da4",
               "baseImageDigest": "amd64/alpine@sha256:d7342993700f8cd7aba8496c2d0e57be0666e80b4c441925fc6f9361fa81d10e",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-10-22T04:09:56.1696422Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/alpine3.12/amd64/Dockerfile"
@@ -1958,7 +1958,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:58d6e7196f2b70fe538447f8b0fbbfc6b10eb24c79dbfa80fe8fbc63ed48e7b3",
               "baseImageDigest": "arm64v8/alpine@sha256:fbb820c07896f5c2516167e7146d9938fc82d4b6b1db167defa5b0a7162e4480",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "arm64",
               "created": "2020-10-22T04:08:43.6939411Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/alpine3.12/arm64v8/Dockerfile"
@@ -1985,7 +1985,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d07825a2384422080bb01e8adcaf51ff0a113c6d164414b7fc8677d924fc6c37",
               "baseImageDigest": "amd64/ubuntu@sha256:1d7b639619bdca2d008eca2d5293e3c43ff84cbee597ff76de3b7a7de3e84956",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-10-23T20:09:21.6897278Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/focal/amd64/Dockerfile"
@@ -1999,7 +1999,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:0eea40bd9a9c5467f73e0a219c6c04f6a8721453455ec24d82e4a708e4743267",
               "baseImageDigest": "arm32v7/ubuntu@sha256:ebc8925ee51929a9d691f260b34dd6ed59b4cc2f6ca61e515ce08d31d38e0a87",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-10-23T20:10:08.0818599Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/d58f76b400dd5d265044d909fb08982fd3ff23df/src/runtime-deps/3.1/focal/arm32v7/Dockerfile"
@@ -2013,7 +2013,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:06cf9889a161b5e764323daae7398de76fd56b7af1f2ff60e6c15280e75acb42",
               "baseImageDigest": "arm64v8/ubuntu@sha256:65cd340c0735f062e84507c3c2298502b5446037cc282bc1f3ac720ef42fb137",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-10-23T20:10:12.6754424Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/3.1/focal/arm64v8/Dockerfile"
@@ -2038,7 +2038,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:b1fa5f47e144c0aa563252d432296747791ca57b5a1157686d28842042c32727",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:6d69b8a8d8f2a2f854840d28ba5e39c861b4c4be4b79e252fd243e1c7c37bc01",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-10-27T23:00:19.0087412Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/sdk/2.1/alpine3.12/amd64/Dockerfile"
@@ -2057,7 +2057,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:7449953d994e3219a58264c551fff28f32380a71fba7f4a8f0391f78515ae034",
               "baseImageDigest": "amd64/buildpack-deps@sha256:ead7fb5c1085e367ea54982507c6abf5259c172e903a9db6299fca17f4aef6b7",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-10-27T23:00:47.2245665Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/bionic/amd64/Dockerfile"
@@ -2076,7 +2076,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:717b45744d79318782dba45cc66d912b38c847b2f130be22425dc47b9304a1a6",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:83e5a995554ad528e280a76e681b64566e97ae1ff4eaeea56f41901114ca9ab9",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-10-27T23:03:26.502231Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/bionic/arm32v7/Dockerfile"
@@ -2095,7 +2095,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:7a93d0c24a49e7fb95942ab7d54faf2c75a2cea078e18c75487c6854c70b70fb",
               "baseImageDigest": "amd64/buildpack-deps@sha256:a186f6b0f35601f7543a9eed0d144373e724c742990a9e9b27d5c4530c0d995c",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-10-27T23:00:10.1489057Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/focal/amd64/Dockerfile"
@@ -2114,7 +2114,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:0ce9bd21e8587d77987a9711dc57e7f027d8d490aff5ec2efaf84d92055bbfea",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:13f937ab3218c43e0ca7dcbe61ce29adf7689a1a6e2eb20e57ab4b1a2c9898c8",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-10-27T23:03:30.9411076Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/focal/arm32v7/Dockerfile"
@@ -2211,7 +2211,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:a2dbb1655ccea8e3a145fc0ed741e370b5b8162ee5b3a56ac2eeb0eb519e9cf8",
               "baseImageDigest": "amd64/buildpack-deps@sha256:edd6ecc5330ceafb541c9071c835b33c6371af3b59b1e7f300717481d0967dc3",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "amd64",
               "created": "2020-11-18T13:44:57.3525655Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/stretch/amd64/Dockerfile"
@@ -2225,7 +2225,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:362778f0a06365788ea07be4cf3a2d0f7da6a01ba5ed97a0f976f03e39d3ca23",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:ea4e3f52e8d8073e3bea484687f3fb8cb66852cd4c00be19a208d4dd206bbc43",
               "osType": "Linux",
-              "osVersion": "Debian 9",
+              "osVersion": "stretch",
               "architecture": "arm32",
               "created": "2020-11-18T13:47:27.7491824Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/29a3a72dc277f4fe2e51a956ce8e7daf60fa625f/src/sdk/2.1/stretch/arm32v7/Dockerfile"
@@ -2245,7 +2245,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:cfaf26dd02dc6cdf257a069f5bc2c1f9f278954a865dbed8fc0b3cd12ae753ab",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:050eacd25406c286163cd79cb902a06acc4e40f7e9f4ac6029aa6385a79b23e3",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-10T15:51:21.1699774Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/alpine3.12/amd64/Dockerfile"
@@ -2264,7 +2264,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:7b23dee5b73358aef06a8211e84cf5d090379e54815932747529eb6533c6c3e7",
               "baseImageDigest": "amd64/buildpack-deps@sha256:ead7fb5c1085e367ea54982507c6abf5259c172e903a9db6299fca17f4aef6b7",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "amd64",
               "created": "2020-11-10T15:51:26.886728Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/bionic/amd64/Dockerfile"
@@ -2283,7 +2283,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:29017c0c15670c097d039f9304bbcc7675f9de90a89c7bf44d12951cc5a65c26",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:83e5a995554ad528e280a76e681b64566e97ae1ff4eaeea56f41901114ca9ab9",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm32",
               "created": "2020-11-10T15:51:35.2562413Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/bionic/arm32v7/Dockerfile"
@@ -2302,7 +2302,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:0bc34907ae064054fc07e7f51625e13f158d22419c1cdc7f6a039d8d1b8adcc8",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:7d9bea06c3481d78231b04ba66296b49d7283cc84eac5581010f5ed5b5613198",
               "osType": "Linux",
-              "osVersion": "Ubuntu 18.04",
+              "osVersion": "bionic",
               "architecture": "arm64",
               "created": "2020-11-10T15:51:52.3990944Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/bionic/arm64v8/Dockerfile"
@@ -2329,7 +2329,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:f5297e14caba73a3ab1a9d58d9279f94f235d1b2c506aa2c4faa12fdc26a1bb0",
               "baseImageDigest": "amd64/buildpack-deps@sha256:034e7f8b59fdd9bc2c5c7c1abdb00ec715e6add7a28aad9ab1e18a14c63f1cab",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "amd64",
               "created": "2020-11-18T13:44:23.7522379Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/buster/amd64/Dockerfile"
@@ -2343,7 +2343,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:3f25dd4f976f0824d36a0d5ff8dac9e0dd07b8e80c6cb3326e8ff23169bcccdc",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:d6518cb49a38c000f61d8e878bd3c166c960886bd0f84ff81c020da2273a7c5d",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:34.7544178Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/buster/arm32v7/Dockerfile"
@@ -2357,7 +2357,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:69a688b94f3f2c5129623e196057a5c3955cec39fef078b459ba3d3cf769b57f",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:62062ef22be551021de31c67bd4bc24762485533b1b6e0d9585027e6c30d4ea8",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster",
               "architecture": "arm64",
               "created": "2020-11-18T13:43:46.9751021Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/buster/arm64v8/Dockerfile"
@@ -2446,7 +2446,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:e009828a4481816f2fff72910639faa469ea85751eaa8856a5120d8774117f1b",
               "baseImageDigest": "amd64/buildpack-deps@sha256:a186f6b0f35601f7543a9eed0d144373e724c742990a9e9b27d5c4530c0d995c",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-10T15:51:22.0668902Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/focal/amd64/Dockerfile"
@@ -2465,7 +2465,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:79645aea95f9c5d5d2bc2e28418c6e39f43344d3e970ef5170abb202740c1975",
               "baseImageDigest": "arm32v7/buildpack-deps@sha256:13f937ab3218c43e0ca7dcbe61ce29adf7689a1a6e2eb20e57ab4b1a2c9898c8",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-10T15:51:47.6575228Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/focal/arm32v7/Dockerfile"
@@ -2484,7 +2484,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:fc1b46942f4e74bf5a4e7334d9d2ff447c03b569f8bf18c06a34eae7d1d743f8",
               "baseImageDigest": "arm64v8/buildpack-deps@sha256:bae744b076916bf31afcc5a08b84fb3e6c7fe1c3317a1781f333b38fd1488b28",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-10T15:51:52.651546Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/801573a24f0c45fabb0db24ff8d3425c1957e068/src/sdk/3.1/focal/arm64v8/Dockerfile"
@@ -2513,7 +2513,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:ec24fc24298928e84ae3b02d86295a0e6885285a37e1c7a53e1f2b7bc387771b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5540c543b451770b9907b32300a3051e299f086d3f7ec7447d6e8ddc11f69eda",
               "osType": "Linux",
-              "osVersion": "Alpine 3.12",
+              "osVersion": "alpine3.12",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:55.2059482Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/alpine3.12/amd64/Dockerfile"
@@ -2541,7 +2541,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:14536e4638385f5047c04a1a7e991e78ff831c7f54b6cd88ad8f9b37f7a57495",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:15f228a4260cb934e39dec68005a60b0e04a3b6557f94f152123d74ce48d3d68",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:44:28.4975122Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/buster-slim/amd64/Dockerfile"
@@ -2555,7 +2555,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:f5dc554a66f33ac10d4fd659680f8285a3311d1835298ace93a8d70b8863ff86",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:848c22a6a211ad68624797dc630715cd80037a636fb4097ebd56d0b214ee996c",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:44:47.9150274Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/buster-slim/arm32v7/Dockerfile"
@@ -2569,7 +2569,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:f5d2eb86e5364c75627ac8eb26bff0fd7636dec39777c716a2dcf0bc1c8419de",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:5f5590dbdb15966fb990e230a694e2ea01ff2e5e999b3e362241abed5abaa2db",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:45:20.2381313Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/buster-slim/arm64v8/Dockerfile"
@@ -2652,7 +2652,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:f4e957ef9b05eb47f854df377ba70166c72e81c6ede551b9ab851c7bdb7d3fa5",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:3ff8d375c5aab0f2120d6faa140acb5efa3bb060efa6352d9f082dbcc9203ecd",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:50.212116Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/focal/amd64/Dockerfile"
@@ -2666,7 +2666,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:4cf87fda2f551a140b3ebdb98e5547c0c69206b17ccdf3adf12989a4e6301f6f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:8acd85fef359969a31102f00572e2e833066f1c17dd1b293fc58b49b1f23895d",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm32",
               "created": "2020-11-18T13:46:24.733784Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/focal/arm32v7/Dockerfile"
@@ -2680,7 +2680,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:c0adaab1b45e1571defbf3b3ca1abc004a01b3c628bb4a9d05c313fcf33c575f",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:c1c15287ab00a0657333a44544381facc797c121ab2546be986c3fd677a83e7e",
               "osType": "Linux",
-              "osVersion": "Ubuntu 20.04",
+              "osVersion": "focal",
               "architecture": "arm64",
               "created": "2020-11-18T13:44:15.7307443Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/focal/arm64v8/Dockerfile"
@@ -2722,7 +2722,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:14536e4638385f5047c04a1a7e991e78ff831c7f54b6cd88ad8f9b37f7a57495",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:44:28.4975122Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/buster-slim/amd64/Dockerfile"
@@ -2732,7 +2732,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:f5dc554a66f33ac10d4fd659680f8285a3311d1835298ace93a8d70b8863ff86",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:44:47.9150274Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/buster-slim/arm32v7/Dockerfile"
@@ -2742,7 +2742,7 @@
               "simpleTags": [],
               "digest": "mcr.microsoft.com/dotnet/nightly/sdk@sha256:f5d2eb86e5364c75627ac8eb26bff0fd7636dec39777c716a2dcf0bc1c8419de",
               "osType": "Linux",
-              "osVersion": "Debian 10",
+              "osVersion": "buster-slim",
               "architecture": "arm64",
               "created": "2020-11-18T13:45:20.2381313Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/ecafadb10c650e8244317f07fc00edfa89d23adc/src/sdk/5.0/buster-slim/arm64v8/Dockerfile"


### PR DESCRIPTION
This is a continuation of the changes from https://github.com/dotnet/versions/pull/651.  I missed converting the Linux-based OS version values.