### PR TITLE
Fix osVersion in Docker image info files

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-docker-master.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-master.json
@@ -190,7 +190,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:eea9f69fc91d0b64628c2961e330ac4c06830eaa0dd4d39cad08b02aa93aa200",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4acc7b5034a2053583398e0fe56f9e7def62dfaf10cab7d634d164ea6edaaa66",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:11:57.990052Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/stretch-slim/amd64/Dockerfile"
@@ -204,7 +204,7 @@
               "digest": "mcr.microsoft.com/dotnet/aspnet@sha256:3c8eaca81eefaf1c0c22818bd85c9ec23585b889aaf48193c0dc2fdc7a021727",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:f588e89263b0b3b6a36b9fe748ebb21e9120ab59348cb27172bdb0c6adc74966",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:12:01.2218775Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/aspnet/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -954,7 +954,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:4271ebb8e3bbaa94e71227eeba7688a4a5ea56fe08422238a150aa2a29094868",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4acc7b5034a2053583398e0fe56f9e7def62dfaf10cab7d634d164ea6edaaa66",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:11:50.2997811Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/stretch-slim/amd64/Dockerfile"
@@ -968,7 +968,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime@sha256:34e5e92fa58a861268014f82036e58ad5a901aa33ffd9cd98af2a10e48472c0a",
               "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:f588e89263b0b3b6a36b9fe748ebb21e9120ab59348cb27172bdb0c6adc74966",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:52.9765179Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/329c7a5790a2263a683c5734819501e51f209c17/src/runtime/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -1648,7 +1648,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:4acc7b5034a2053583398e0fe56f9e7def62dfaf10cab7d634d164ea6edaaa66",
               "baseImageDigest": "amd64/debian@sha256:e14ad2a63bfebbe02919d95f9be1f93a3665c7a81f4cf17ede7f4e91ac7ef67f",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "amd64",
               "created": "2020-11-18T00:11:40.8886773Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile"
@@ -1662,7 +1662,7 @@
               "digest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:f588e89263b0b3b6a36b9fe748ebb21e9120ab59348cb27172bdb0c6adc74966",
               "baseImageDigest": "arm32v7/debian@sha256:e2ea286755bd9e16bb913a0f45384b394288b8bc1f11274f112e887ce02b6dd8",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "arm32",
               "created": "2020-11-18T00:11:35.3605196Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/c0e8be8a44b47b1dcc2a5b4b2ebd92022087ac0b/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile"

--- a/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
+++ b/build-info/docker/image-info.dotnet-dotnet-docker-nightly.json
@@ -190,7 +190,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:9ba35ef473c72c5ec3203890ec96a9542b5886c46a47e579efda9e8c0436ea10",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6e209b0890bad7aff8d1887a367530d857f02402ecc0150b7a8688a04095635",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:37.7617966Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/stretch-slim/amd64/Dockerfile"
@@ -204,7 +204,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/aspnet@sha256:48e0952f56b3d529abcf241b414af26bcce308d5cc63d2f58ca5954cb50cf6ed",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c449c106e0ea6ee943678e0e6de1f30b14315b2882372bb81dfe548844ff2d8",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:55.7781089Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/aspnet/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -986,7 +986,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:67f61073725bc73f56e34e2e316060006ed5451a733e1bb09484e029bbfdcc06",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6e209b0890bad7aff8d1887a367530d857f02402ecc0150b7a8688a04095635",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:27.283598Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/stretch-slim/amd64/Dockerfile"
@@ -1000,7 +1000,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime@sha256:ffc9fbc9edc11d0dee0e2492e7bde6dc7e9f17a6e9a49679530b559ecfb2379b",
               "baseImageDigest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c449c106e0ea6ee943678e0e6de1f30b14315b2882372bb81dfe548844ff2d8",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:47.4684577Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/80681b4172404ce3dbdad6634f0385d97e17e68a/src/runtime/2.1/stretch-slim/arm32v7/Dockerfile"
@@ -1680,7 +1680,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:d6e209b0890bad7aff8d1887a367530d857f02402ecc0150b7a8688a04095635",
               "baseImageDigest": "amd64/debian@sha256:e14ad2a63bfebbe02919d95f9be1f93a3665c7a81f4cf17ede7f4e91ac7ef67f",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "amd64",
               "created": "2020-11-18T13:43:17.265876Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/2.1/stretch-slim/amd64/Dockerfile"
@@ -1694,7 +1694,7 @@
               "digest": "mcr.microsoft.com/dotnet/nightly/runtime-deps@sha256:9c449c106e0ea6ee943678e0e6de1f30b14315b2882372bb81dfe548844ff2d8",
               "baseImageDigest": "arm32v7/debian@sha256:e2ea286755bd9e16bb913a0f45384b394288b8bc1f11274f112e887ce02b6dd8",
               "osType": "Linux",
-              "osVersion": "stretch",
+              "osVersion": "stretch-slim",
               "architecture": "arm32",
               "created": "2020-11-18T13:43:26.3065934Z",
               "commitUrl": "https://github.com/dotnet/dotnet-docker/blob/58e44fed08d6b0d692c5bcf5cb4369e5c34b0048/src/runtime-deps/2.1/stretch-slim/arm32v7/Dockerfile"


### PR DESCRIPTION
Fixing `osVersion` for Dockerfiles based on stretch-slim to use `stretch-slim` instead of `stretch`.