### PR TITLE
Rename Maestro sub for mono/linker for master->main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -818,7 +818,7 @@
         "https://github.com/mono/ikdasm/blob/master/**/*",
         "https://github.com/mono/ikvm-fork/blob/master/**/*",
         "https://github.com/mono/illinker-test-assets/blob/master/**/*",
-        "https://github.com/mono/linker/blob/master/**/*",
+        "https://github.com/mono/linker/blob/main/**/*",
         "https://github.com/mono/linker/blob/release/**/*",
         "https://github.com/mono/llvm/blob/release_60/**/*",
         "https://github.com/mono/mono/blob/master/**/*",


### PR DESCRIPTION
Ref. https://github.com/mono/linker/issues/1775