### PR TITLE
Change auto merge from 5.0.2xx to 5.0.3xx

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1088,11 +1088,11 @@
         }
       }
     },
-    // Automate opening PRs to merge cli release/5.0.2xx to master
+    // Automate opening PRs to merge cli release/5.0.3xx to master
     {
       "triggerPaths": [
-        "https://github.com/dotnet/sdk/blob/release/5.0.2xx/**/*",
-        "https://github.com/dotnet/installer/blob/release/5.0.2xx/**/*"
+        "https://github.com/dotnet/sdk/blob/release/5.0.3xx/**/*",
+        "https://github.com/dotnet/installer/blob/release/5.0.3xx/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
Once 5.0.2xx reached servicing. It will get the latest runtime.
And that is not what we want in master. While 5.0.3xx is the branch with active
development