### PR TITLE
Changing branch to main for test-templates

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -778,7 +778,7 @@
         "https://github.com/dotnet/symstore/blob/release/**/*",
         "https://github.com/dotnet/templating/blob/master/**/*",
         "https://github.com/dotnet/templating/blob/release/**/*",
-        "https://github.com/dotnet/test-templates/blob/master/**/*",
+        "https://github.com/dotnet/test-templates/blob/main/**/*",
         "https://github.com/dotnet/test-templates/blob/release/**/*",
         "https://github.com/dotnet/toolset/blob/master/**/*",
         "https://github.com/dotnet/toolset/blob/release/**/*",


### PR DESCRIPTION
Changing branch to main for test-templates
Part of this work [Renaming default branch to main for test-tempates](https://github.com/dotnet/test-templates/issues/131).