### PR TITLE
Rename primary msbuild branch from master to main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -664,7 +664,7 @@
         "https://github.com/dotnet/xliff-tasks/blob/master/**/*",
         "https://github.com/dotnet/xliff-tasks/blob/release/**/*",
         "https://github.com/Microsoft/msbuild/blob/vs/**/*",
-        "https://github.com/Microsoft/msbuild/blob/master/**/*",
+        "https://github.com/Microsoft/msbuild/blob/main/**/*",
         "https://github.com/Microsoft/visualfsharp/dev/**/*",
         "https://github.com/Microsoft/visualfsharp/master/**/*"
       ],
@@ -818,7 +818,7 @@
         "https://github.com/dotnet/xliff-tasks/blob/master/**/*",
         "https://github.com/dotnet/xliff-tasks/blob/release/**/*",
         "https://github.com/Microsoft/dotnet-framework-docker/blob/master/**/*",
-        "https://github.com/Microsoft/msbuild/blob/master/**/*",
+        "https://github.com/Microsoft/msbuild/blob/main/**/*",
         "https://github.com/Microsoft/msbuild/blob/release/**/*",
         "https://github.com/Microsoft/clrmd/blob/master/**/*",
         "https://github.com/Microsoft/clrmd/blob/release/**/*",


### PR DESCRIPTION
Following https://github.com/dotnet/arcade/blob/main/Documentation/Projects/M2MRenaming/Master-to-Main-renaming-guide.md#3-update-the-build-mirroring-in-subscriptionsjson

Still waiting on CI for adding `main` as a trigger.