### PR TITLE
Mirror new repository

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -813,6 +813,8 @@
         "https://github.com/Microsoft/dotnet-framework-docker/blob/main/**/*",
         "https://github.com/Microsoft/clrmd/blob/master/**/*",
         "https://github.com/Microsoft/clrmd/blob/release/**/*",
+        "https://github.com/microsoft/go/blob/microsoft/main/**/*",
+        "https://github.com/microsoft/go/blob/microsoft/release-branch./**/*",
         "https://github.com/microsoft/reverse-proxy/blob/main/**/*",
         "https://github.com/microsoft/reverse-proxy/blob/release/**/*",
         "https://github.com/mono/api-doc-tools/blob/main/**/*",


### PR DESCRIPTION
Note: `/**/*` in this file means `.*$`, not `/.*$`, so counterintuitively, the release branch pattern should work. (See https://github.com/dotnet/versions/issues/558.)