### PR TITLE
Change WPF 'master' to 'main' in subscriptions.json

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -801,7 +801,7 @@
         "https://github.com/dotnet/winforms-designer/blob/master/**/*",
         "https://github.com/dotnet/winforms-designer/blob/release/**/*",
         "https://github.com/dotnet/wpf/blob/arcade/**/*",
-        "https://github.com/dotnet/wpf/blob/master/**/*",
+        "https://github.com/dotnet/wpf/blob/main/**/*",
         "https://github.com/dotnet/wpf/blob/release/**/*",
         "https://github.com/dotnet/xdt/blob/main/**/*",
         "https://github.com/dotnet/xdt/blob/release/**/*",


### PR DESCRIPTION
This is part of WPF's default branch change to main.  Thanks.  