### PR TITLE
Update subscriptions.json to migrate dotnet/spark to main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -763,7 +763,7 @@
         "https://github.com/dotnet/source-indexer/blob/master/**/*",
         "https://github.com/dotnet/sourcelink/blob/master/**/*",
         "https://github.com/dotnet/sourcelink/blob/release/**/*",
-        "https://github.com/dotnet/spark/blob/master/**/*",
+        "https://github.com/dotnet/spark/blob/main/**/*",
         "https://github.com/dotnet/spark/blob/release/**/*",
         "https://github.com/dotnet/standard/blob/master/**/*",
         "https://github.com/dotnet/standard/blob/release/**/*",


### PR DESCRIPTION
Update `subscriptions.json` to migrate `dotnet/spark` to `main`.