### PR TITLE
Handle more master to maining

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -636,9 +636,8 @@
         "https://github.com/aspnet/AspLabs/blob/release/**/*",
         "https://github.com/dotnet/aspnetcore/blob/main/**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/**/*",
-        "https://github.com/aspnet/AspNetCore-Internal/blob/master/**/*",
         "https://github.com/aspnet/Benchmarks/blob/main/**/*",
-        "https://github.com/dotnet/aspnetcore-tooling/blob/master/**/*",
+        "https://github.com/dotnet/aspnetcore-tooling/blob/main/**/*",
         "https://github.com/dotnet/aspnetcore-tooling/blob/release/**/*",
         "https://github.com/dotnet/blazor/blob/master/**/*",
         "https://github.com/dotnet/blazor/blob/release/**/*",
@@ -1056,27 +1055,12 @@
     },
     {
       "triggerPaths": [
-        "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*",
-        "https://github.com/dotnet/ef6/blob/release/6.4//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "master",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "master",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    {
-      "triggerPaths": [
         "https://github.com/dotnet/aspnetcore/blob/release/2.1//**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/5.0//**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/6.0*//**/*",
+        "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*",
+        "https://github.com/dotnet/ef6/blob/release/6.4//**/*"
         "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/efcore/blob/release/5.0//**/*",
         "https://github.com/dotnet/efcore/blob/release/6.0*//**/*"
@@ -1511,7 +1495,6 @@
         "https://github.com/dotnet/aspnetcore/blob/release/5.0/**/*",
         "https://github.com/dotnet/aspnetcore-tooling/blob/release/2/**/*",
         "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1/**/*",
-        //"https://github.com/dotnet/aspnetcore-tooling/blob/release/5.0/**/*",
         "https://github.com/dotnet/blazor/blob/release/2/**/*",
         //"https://github.com/dotnet/blazor/blob/release/3.1/**/*",
         "https://github.com/aspnet/BrowserLink/blob/release/**/*",

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1060,7 +1060,7 @@
         "https://github.com/dotnet/aspnetcore/blob/release/5.0//**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/6.0*//**/*",
         "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*",
-        "https://github.com/dotnet/ef6/blob/release/6.4//**/*"
+        "https://github.com/dotnet/ef6/blob/release/6.4//**/*",
         "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/efcore/blob/release/5.0//**/*",
         "https://github.com/dotnet/efcore/blob/release/6.0*//**/*"


### PR DESCRIPTION
- in midst of renaming default branch of dotnet/aspnetcore-tooling
- ef6 'master' branch no longer exists, should not be target of merge PRs
- aspnet/aspnetcore-internal doesn't have an internal mirror