### PR TITLE
Update msbuild's trigger to point to main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1175,11 +1175,11 @@
         }
       }
     },
-    // Automate opening PRs to merge msbuild's vs16.x branches into master
+    // Automate opening PRs to merge msbuild's vs* branches into main
     // For details on how the triggerpath globbing syntax works, see: https://github.com/dotnet/versions/issues/558
     {
       "triggerPaths": [
-        "https://github.com/dotnet/msbuild/blob/vs16./**/*"
+        "https://github.com/dotnet/msbuild/blob/vs/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -1188,7 +1188,7 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "master"
+          "BaseBranch": "main"
         }
       }
     },


### PR DESCRIPTION
Also ensure any vs* branch update gets a PR generated from it instead of just 16.*