### PR TITLE
Disable msbuild/vs17.0 PR's into msbuild/main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1192,22 +1192,6 @@
         }
       }
     },
-    // Temporarily flow msbuild/main into msbuild/17.0 
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/msbuild/blob/main/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "vs17.0"
-        }
-      }
-    },
     // Temporary orchestrated build final publish in release/2.1.27
     {
       "triggerPaths": [

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1175,11 +1175,11 @@
         }
       }
     },
-    // Automate opening PRs to merge msbuild's vs* branches into main
+    // Automate opening PRs to merge msbuild's vs16* branches into main
     // For details on how the triggerpath globbing syntax works, see: https://github.com/dotnet/versions/issues/558
     {
       "triggerPaths": [
-        "https://github.com/dotnet/msbuild/blob/vs/**/*"
+        "https://github.com/dotnet/msbuild/blob/vs16/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -1189,6 +1189,22 @@
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
           "BaseBranch": "main"
+        }
+      }
+    },
+    // Temporarily flow msbuild/main into msbuild/17.0 
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/main/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.0"
         }
       }
     },


### PR DESCRIPTION
Disabled 17.0 PR's flowing into main by starting the glob after `vs16`

/cc: @rainersigwald https://github.com/dotnet/msbuild/pull/6353