### PR TITLE
Handle all `release/6.0*` branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -685,12 +685,12 @@
         "https://github.com/dotnet/aspnetcore/blob/release/2.1//**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/5.0//**/*",
-        "https://github.com/dotnet/aspnetcore/blob/release/6.0*/**/*",
+        "https://github.com/dotnet/aspnetcore/blob/release/6.0/**/*",
         "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*",
         "https://github.com/dotnet/ef6/blob/release/6.4//**/*",
         "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/efcore/blob/release/5.0//**/*",
-        "https://github.com/dotnet/efcore/blob/release/6.0*/**/*"
+        "https://github.com/dotnet/efcore/blob/release/6.0/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
- for some reason, @mmitche claims this isn't a microformat 😀