### PR TITLE
Update runtimelab default branch in triggers

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -500,7 +500,7 @@
         "https://github.com/dotnet/runtime/blob/release/**/*",
         "https://github.com/dotnet/runtime/blob/dev/infrastructure/**/*",
         "https://github.com/dotnet/runtimelab/blob/feature/**/*",
-        "https://github.com/dotnet/runtimelab/blob/main/**/*",
+        "https://github.com/dotnet/runtimelab/blob/docs/**/*",
         "https://github.com/dotnet/runtime-assets/blob/main/**/*",
         "https://github.com/dotnet/runtime-assets/blob/release/**/*",
         "https://github.com/dotnet/sdk/blob/main/**/*",


### PR DESCRIPTION
We renamed main to make it less confusing as the purpose of that branch is for documentation reasons. However we have a yml file that we want to be mirrored into internal repo as we use it as the mirror from dotnet/runtime to dotnet/runtimelab. 

cc: @ViktorHofer @mmitche 