### PR TITLE
Update Maestro auto-PR rules for MSBuild 16.10 and 16.11

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1184,7 +1184,7 @@
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
-        "vsoSourceBranch": "vs16.11",
+        "vsoSourceBranch": "main",
         "vsoBuildParameters": {
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1176,11 +1176,26 @@
         }
       }
     },
-    // Automate opening PRs to merge msbuild's vs16* branches into main
+    // Automate opening PRs to merge msbuild's vs16.10 into vs16.11 and vs16.11 into main
     // For details on how the triggerpath globbing syntax works, see: https://github.com/dotnet/versions/issues/558
     {
       "triggerPaths": [
-        "https://github.com/dotnet/msbuild/blob/vs16/**/*"
+        "https://github.com/dotnet/msbuild/blob/vs16.10/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "vs16.11",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs16.11"
+        }
+      }
+    },
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs16.11/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
MSBuild has two Dev16 release branches with non-trivial development activity. We want changes to both to roll forward to `main`, and additionally we want `16.10` to roll forward to `16.11`.