### PR TITLE
Auto-merging main -> main-vs-deps for aspnetcore-tooling.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -718,7 +718,7 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/vs17.0-pp1",
+          "BaseBranch": "main-vs-deps",
           "ExtraSwitches": "-QuietComments"
         }
       }


### PR DESCRIPTION
- This transitions the pre-existing release/vs17.0-pp1 to main-vs-deps.

/cc @dougbu 