### PR TITLE
Remove interbranch merges for asp.net

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -649,7 +649,7 @@
         }
       }
     },
-    // Automate opening PRs to merge EF release branches back to main
+    // Automate opening PRs to merge Asp.Net/EF release branches back to main
     {
       "triggerPaths": [
         "https://github.com/aspnet/BuildTools/blob/release/2.1//**/*"
@@ -671,7 +671,8 @@
         "https://github.com/dotnet/ef6/blob/release/6.4//**/*",
         "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/efcore/blob/release/5.0//**/*",
-        "https://github.com/dotnet/efcore/blob/release/6.0/**/*"
+        "https://github.com/dotnet/efcore/blob/release/6.0/**/*",
+        "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -649,23 +649,7 @@
         }
       }
     },
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/extensions/blob/release/2.1//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.1",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge aspnet release branches back to main
+    // Automate opening PRs to merge EF release branches back to main
     {
       "triggerPaths": [
         "https://github.com/aspnet/BuildTools/blob/release/2.1//**/*"
@@ -684,11 +668,6 @@
     },
     {
       "triggerPaths": [
-        "https://github.com/dotnet/aspnetcore/blob/release/2.1//**/*",
-        "https://github.com/dotnet/aspnetcore/blob/release/3.1//**/*",
-        "https://github.com/dotnet/aspnetcore/blob/release/5.0//**/*",
-        "https://github.com/dotnet/aspnetcore/blob/release/6.0/**/*",
-        "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*",
         "https://github.com/dotnet/ef6/blob/release/6.4//**/*",
         "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/efcore/blob/release/5.0//**/*",


### PR DESCRIPTION
I left EF alone for now - @ajcvickers please let me know if you'd like me to get rid of the inter-branch merges for EF as well.