### PR TITLE
Remove arcade auto-PR from release/3.x to main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1153,8 +1153,7 @@
       "triggerPaths": [
         "https://github.com/dotnet/arcade-services/blob/production/**/*",
         "https://github.com/dotnet/arcade-pool-provider/blob/production/**/*",
-        "https://github.com/dotnet/helix-service/blob/production/**/*",
-        "https://github.com/dotnet/arcade/blob/release/3.x/**/*"
+        "https://github.com/dotnet/helix-service/blob/production/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
https://github.com/dotnet/arcade/blob/release/3.x has diverged too much from main for these PRs to make sense.  Changes should now be manually ported if at all.