### PR TITLE
Fully-qualify the digest value in image info file

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
@@ -1083,7 +1083,7 @@
               "simpleTags": [
                 "nanoserver-1809-helix-amd64-20200804014859-56c6673"
               ],
-              "digest": "sha256:55e11ea9ba534c09d93aeb1f9141169a18bf7e36a4291f2902dde2c386782d05",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:55e11ea9ba534c09d93aeb1f9141169a18bf7e36a4291f2902dde2c386782d05",
               "baseImageDigest": "mcr.microsoft.com/powershell@sha256:8a4e778616607888d88eb64ca72eab4740b2ecef4c93fccf12e1d13cec204646",
               "osType": "Windows",
               "osVersion": "nanoserver-1809",


### PR DESCRIPTION
This is the only remaining digest value that's not fully qualified.  I'm manually setting it to be fully-qualified in order to unblock the work for https://github.com/dotnet/docker-tools/issues/611.