### PR TITLE
Merging buildtools changes

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
@@ -2386,22 +2386,22 @@
             {
               "dockerfile": "src/windowsservercore/2004/helix/amd64/Dockerfile",
               "simpleTags": [
-                "windowsservercore-2004-helix-amd64-20210712204846-5f35d1a"
+                "windowsservercore-2004-helix-amd64-20210809131357-5f35d1a"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f9f328248274178b8622072e4e143f5bd744c2b2cf2f49649d4dd1df97148538",
-              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:ae9996fd649456364b9ee4343237d5cc9c08b9b3fcf7da8f8dd1ddfa8385647e",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e68790ac308c4ef8223930c39762b3cedb60c762758010ebff6686c628adcd2c",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:83425f6d41e50d6d92be42fb19e3321c073dd6441ea3a8600ecca45159982c91",
               "osType": "Windows",
               "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
-              "created": "2021-07-12T20:51:08.8375007Z",
+              "created": "2021-08-09T13:23:56.7971937Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/5f35d1a52fe8fc76ea520665769de2c68020226f/src/windowsservercore/2004/helix/amd64/Dockerfile",
               "layers": [
-                "sha256:05990ef4ec1627b13e95e11e6fbe66f185b0664e221ff824e7a5926d8007c2f3",
+                "sha256:0b4014da7e55a1e7adca38200c9daea24e5871e8362b6d016c64adb4878709b5",
                 "sha256:295f12394c4f250e83029adb04647faeb736b0c8d275aa9b34f5e3c60a89d0d2",
-                "sha256:469dbc0197ec523b21cec7c966dec0b009da02a0b9f921b83016ff42a76b9286",
-                "sha256:8b700885dbb325450cc12ff37e44c5abf14f818c4c234df6f0ba9b9d45b3fc8b",
-                "sha256:b91defd1beb8d4aad2d26ea07d152fa34702aadf7366316f0d0b51ecd3142926",
-                "sha256:bd307d0fa6ae57242fbe33f1ba19fece6b0afe9fe0b5dd9e2ef81225f42f4640"
+                "sha256:6907d97093063478e2c552549bbcd0b499d1dfba051bad994179f5a1d343fe58",
+                "sha256:6c2b5dfc1c5bb7250341688d91bd358485c72554680875d078d4a4115caabd41",
+                "sha256:7c49e89fe5b715cbaa3bf2f60540123525fd5af1e8c892b1a4d29ab77cba50a8",
+                "sha256:f29c7cf7a68c654dd488ea7579570615cc413f623d1a994abd8b1834ed14b153"
               ]
             }
           ]
@@ -2411,40 +2411,40 @@
             {
               "dockerfile": "src/windowsservercore/2004/helix/webassembly/Dockerfile",
               "simpleTags": [
-                "windowsservercore-2004-helix-webassembly-amd64-20210712204846-37436dd"
+                "windowsservercore-2004-helix-webassembly-amd64-20210809131357-5bb825f"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:35fed7614ad64b3235ede4483df6d065de55fee58cffbf3df915d965bf030b2d",
-              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f9f328248274178b8622072e4e143f5bd744c2b2cf2f49649d4dd1df97148538",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:566e4e759490844652572f928de814b1f30800e76b8c143fe1b718dd73bd362c",
+              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e68790ac308c4ef8223930c39762b3cedb60c762758010ebff6686c628adcd2c",
               "osType": "Windows",
               "osVersion": "windowsservercore-2004",
               "architecture": "amd64",
-              "created": "2021-07-12T21:00:31.5314629Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/37436ddcd55e2adaa75908a76b60dc782524f7ae/src/windowsservercore/2004/helix/webassembly/Dockerfile",
+              "created": "2021-08-09T13:33:12.5439352Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/5bb825f3519600bd5bf60ac7f3bec89fcb08ec53/src/windowsservercore/2004/helix/webassembly/Dockerfile",
               "layers": [
-                "sha256:02a0e1f918e64d4788c9563f37ee82908707a69bd4f7c7dcad06b3e752a73641",
-                "sha256:04319645783b34eae405a83bba337cf63094dd955ee434286b858a2190859f0a",
-                "sha256:05990ef4ec1627b13e95e11e6fbe66f185b0664e221ff824e7a5926d8007c2f3",
-                "sha256:0ab3f4d2fed2c29136f6be05d0b3a8f935299e369a1c5ae9ae34d435afb62397",
-                "sha256:0e27365039fab95ae1408e87facd4265ca3bf4744360913793df962dc964b735",
+                "sha256:0b4014da7e55a1e7adca38200c9daea24e5871e8362b6d016c64adb4878709b5",
+                "sha256:10caa749a00849a33090617a6258d4cd7239e931f414336b3fdd0b366e2447e1",
+                "sha256:156287f680f42c99e93e278d1b126083a8b6ef1fc2cfe5a01bf635da2eca82c5",
+                "sha256:1cfcff91393ce781e80fd345baf96b378a3cb48b206207c9050b64235f53f5ca",
+                "sha256:1e0009d8db9c32cf1600db0d3fc8408ff7d28bf6066a134139955bfad940c090",
                 "sha256:295f12394c4f250e83029adb04647faeb736b0c8d275aa9b34f5e3c60a89d0d2",
-                "sha256:30719f04f05f9d2681036e4aee3822b9b24b9ec38b84f93dbcf117b71c8aa63f",
-                "sha256:32d9f8cd0108397d688e6adb6b0f80323405184fa962035cc7a20aa11fc388b2",
-                "sha256:3edc8541f11051ebdc5cc8b6840a51afb9578f8233ebe2aa6e2a66b46fe165b5",
-                "sha256:469dbc0197ec523b21cec7c966dec0b009da02a0b9f921b83016ff42a76b9286",
-                "sha256:590071cb48f7a45e67ead057ec2bd3288266d958653bfa0189f91418cdae7f27",
-                "sha256:5d01ba1584a183c89bae1bb058812c92cfb3d01af5cbe3eed85aa47733c4a732",
-                "sha256:7700db1749d5281a902ec17938685c2097f660a7525772cc2cc2624778a97a0c",
-                "sha256:817acd3fcbd89a4e93c73d9e4367fd1f18959b0690992db859c198bc31f5adb4",
-                "sha256:8b700885dbb325450cc12ff37e44c5abf14f818c4c234df6f0ba9b9d45b3fc8b",
-                "sha256:8bd30885843e2c23c6782037a0f615cef1dc9ed72c232bfd71c43962b619ce47",
-                "sha256:9b9001b1b39ad753f1512f6e901bef2ef8fa26f047c6505e1c530bda2727434c",
-                "sha256:a47b5a18d2c5df2bc7f37de2f95025eb7687572f0e9be5f0c65b050a05801165",
-                "sha256:b91defd1beb8d4aad2d26ea07d152fa34702aadf7366316f0d0b51ecd3142926",
-                "sha256:bd307d0fa6ae57242fbe33f1ba19fece6b0afe9fe0b5dd9e2ef81225f42f4640",
-                "sha256:be4d26aab32a97b3e0fc1b462b7c55b85b0b96f3983c3e2936b67f3015509762",
-                "sha256:d42f5a4da05f7f04b8868025221d4f90218342116d635bb740a330dc7cabbb89",
-                "sha256:e237d47f446903cd2a758b261be1262abb4e862150650bdf48a60ab9c90b5563",
-                "sha256:f6d5cb1d6b73a54969d4332a95faa1855fd35b37003d7dff94ce29ff191a84b0"
+                "sha256:3236a157f814241e4fe2f154a35459abccbce2c9d8ea154fdb40e1927c2fabb2",
+                "sha256:3f4f1a19dae681b57d55437d379df1fda8f684c033fc35eed0988cf53b02bd85",
+                "sha256:65427c34387c5024c77dcc1f05a2e5df643532479f32adbede7bcdfbdc283871",
+                "sha256:6907d97093063478e2c552549bbcd0b499d1dfba051bad994179f5a1d343fe58",
+                "sha256:6c2b5dfc1c5bb7250341688d91bd358485c72554680875d078d4a4115caabd41",
+                "sha256:7c49e89fe5b715cbaa3bf2f60540123525fd5af1e8c892b1a4d29ab77cba50a8",
+                "sha256:80b80fe6590a5b8b0a33e711bc2357f2a372aeaf07e3ddd237bc18dc34252fef",
+                "sha256:87b7fab56a7bf2bb4fb9656e06181763ef8bfe980092988a024653017b400874",
+                "sha256:947ad141deda5e9114b501147150abd0d89f55aacb8a1cf8879b872c6acf5601",
+                "sha256:94ee731b90b877f99316401c34ed3c9780fbbadfa08f171028b45e05f82f9c55",
+                "sha256:97ba31331b22ec128e1b56b3293fa175236f1ea15a1dcc9c14a66b610882ae65",
+                "sha256:97da9e035a5867aa59ae9906fa0dccfcb444c7bb048783caa2ca3f995925daa4",
+                "sha256:9c4ffba6cc4d8c0c245377a1c99d38418111cdac0d3532ac82065d76c28a5859",
+                "sha256:a1c0f61b25c9b47cddc546ecfe61b1598ea905c37a4f3ed2209935a16e14edf0",
+                "sha256:b4f7a75162be6d1d89b53b38f9e49cbe344417e148f487f7ab3db89945250137",
+                "sha256:ca4f19926b383be2224ca244edc1d372c83c4f400669e45b40b46d723d1b38e8",
+                "sha256:f29c7cf7a68c654dd488ea7579570615cc413f623d1a994abd8b1834ed14b153",
+                "sha256:f6570a92aecb8f296acfb208b1ddd845ebdbf5fc9338c6ee3a466fcb710d4e9c"
               ]
             }
           ]


### PR DESCRIPTION
The 5df5239 commit was made to both GitHub and AzDO but the GitHub commit somehow did not get associated with a branch.  This caused AzDO to have the commit but GitHub did not have it which is breaking the code-mirror build for this repo.  Fixing this by merging in the commit to the main branch.