### PR TITLE
Add auto-merge for aspnetcore release/6.0-rc*,ga*

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -689,10 +689,10 @@
         }
       }
     },
-    // Automate merging aspnetcore release/6.0-rc & release/6.0-ga branches back to release/6.0
+    // Automate merging aspnetcore release/6.0-rc branches back to release/6.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/aspnetcore/blob/release/6.0-//**/*"
+        "https://github.com/dotnet/aspnetcore/blob/release/6.0-rc/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -689,6 +689,23 @@
         }
       }
     },
+    // Automate merging aspnetcore release/6.0-rc & release/6.0-ga branches back to release/6.0
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/aspnetcore/blob/release/6.0-//**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/6.0",
+          "ExtraSwitches": "-QuietComments"
+        }
+      }
+    },
     // Automate opening PRs to merge aspnetcore-tooling main changes into dev17 branches.
     {
       "triggerPaths": [


### PR DESCRIPTION
Should auto-merge `release/6.0-rc1`, `release/6.0-rc2`, and `release/6.0-ga` back to `release/6.0`. @mmitche does the syntax look right?

Will merge this just before 5 today