### PR TITLE
Don't merge efcore 6.0/rc branches to main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -691,7 +691,7 @@
         "https://github.com/dotnet/ef6/blob/release/6.4//**/*",
         "https://github.com/dotnet/efcore/blob/release/3.1//**/*",
         "https://github.com/dotnet/efcore/blob/release/5.0//**/*",
-        "https://github.com/dotnet/efcore/blob/release/6.0/**/*",
+        "https://github.com/dotnet/efcore/blob/release/6.0//**/*",
         "https://github.com/dotnet/aspnetcore-tooling/blob/release/3.1//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",


### PR DESCRIPTION
Only `release/6.0` itself should merge to main. @mmitche syntax look right?