### PR TITLE
Seed the microsoft/go-docker imageinfo files

### DIFF
--- a/build-info/docker/image-info.microsoft-go-docker-main-nightly.json
+++ b/build-info/docker/image-info.microsoft-go-docker-main-nightly.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "1.0",
+  "repos": []
+}

--- a/build-info/docker/image-info.microsoft-go-docker-main.json
+++ b/build-info/docker/image-info.microsoft-go-docker-main.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "1.0",
+  "repos": []
+}


### PR DESCRIPTION
@mthalman Can you double-check my logic on these file names? (And is the amount of emptiness in the JSON correct?)

```
build-info/docker/image-info.microsoft-go-docker-main.json
build-info/docker/image-info.microsoft-go-docker-main-nightly.json
```

* This part seems standard: `build-info/docker/image-info.`
* This is based on the repo name, microsoft/go-docker: `microsoft-go-docker`
* The `-main` gets weirder.
  * The main branch in the repo is actually `microsoft/main`, and the nightly branch is planned to be `microsoft/nightly`. (Our repo is based on another one, so this prefix helps keep track of branches with changes for our Microsoft infra.)
  * The logic in https://github.com/dotnet/docker-tools/blob/main/eng/common/templates/steps/set-image-info-path-var.yml seems to check specifically for `nightly`, so both of our branches will hit the `else` and our `publicSourceBranch` will be `main` for both.
* The `-nightly` part would be specified by setting the `imageInfoVariant` var in our nightly pipeline only.
