### PR TITLE
Add Go 'microsoft/dev.boringcrypto*' mirroring

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -598,6 +598,7 @@
         "https://github.com/microsoft/go/blob/dev/official/**/*",
         "https://github.com/microsoft/go/blob/microsoft/main/**/*",
         "https://github.com/microsoft/go/blob/microsoft/release-branch./**/*",
+        "https://github.com/microsoft/go/blob/microsoft/dev.boringcrypto/**/*",
         "https://github.com/microsoft/reverse-proxy/blob/main/**/*",
         "https://github.com/microsoft/reverse-proxy/blob/release/**/*",
         "https://github.com/mono/api-doc-tools/blob/main/**/*",


### PR DESCRIPTION
Add Go `dev.boringcrypto` branches to the list to mirror internally.

`microsoft/dev.boringcrypto/**/*` mirrors `microsoft/dev.boringcrypto*` because:

* #558

/cc @qmuntal @chsienki @jaredpar 