### PR TITLE
Mirror razor-tooling to DevDiv

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -387,6 +387,8 @@
         "https://github.com/dotnet/msbuild/blob/vs/**/*",
         "https://github.com/dotnet/msbuild/blob/main/**/*",
         "https://github.com/dotnet/msbuild/blob/exp/**/*",
+        "https://github.com/dotnet/razor-tooling/blob/main/**/*",
+        "https://github.com/dotnet/razor-tooling/blob/release/**/*",
         "https://github.com/dotnet/source-build/blob/main/**/*",
         "https://github.com/dotnet/source-build/blob/release/**/*",
         "https://github.com/dotnet/standard/blob/release/**/*",


### PR DESCRIPTION
We need to be mirrored into DevDiv as well. Possibly we'll remove the dotnet AZDO mirror at a later date.