### PR TITLE
Mirror all dotnet-monitor release branches to internal branches.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1160,7 +1160,7 @@
         "https://github.com/dotnet/corefx/blob/release/2/**/*",
         "https://github.com/dotnet/corefx/blob/release/3.1/**/*",
         "https://github.com/dotnet/diagnostics/blob/release/**/*",
-        "https://github.com/dotnet/dotnet-monitor/blob/release/6.0/**/*",
+        "https://github.com/dotnet/dotnet-monitor/blob/release/**/*",
         "https://github.com/dotnet/ef6/blob/release/6.4/**/*",
         "https://github.com/dotnet/efcore/blob/release/2/**/*",
         "https://github.com/dotnet/efcore/blob/release/3.1/**/*",


### PR DESCRIPTION
The dotnet-monitor project now has multiple active release branches that should be mirrored to their corresponding internal/* branches.

cc @dotnet/dotnet-monitor 