### PR TITLE
Add auto merge for the servicing branches of 6.0.Nxx

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -776,6 +776,42 @@
         }
       }
     },
+    // Automate opening PRs to merge cli release/6.0.2xx to .3xx
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/sdk/blob/release/6.0.2xx//**/*",
+        "https://github.com/dotnet/installer/blob/release/6.0.2xx//**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "release/6.0.2xx",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/6.0.3xx",
+          "ExtraSwitches": "-QuietComments"
+        }
+      }
+    },
+    // Automate opening PRs to merge cli release/6.0.1xx to .2xx
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/sdk/blob/release/6.0.1xx//**/*",
+        "https://github.com/dotnet/installer/blob/release/6.0.1xx//**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "release/6.0.1xx",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/6.0.2xx",
+          "ExtraSwitches": "-QuietComments"
+        }
+      }
+    },
     // Update dependencies in cli release/2.0.0
     {
       "triggerPaths": [


### PR DESCRIPTION
Source build works in the 1xx branch which can put us out of sync in servicing. Adding automatic flow from 1xx and 2xx up a level each.