### PR TITLE
Remove mono/api-doc-tools

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -586,7 +586,6 @@
         "https://github.com/microsoft/go/blob/microsoft/dev.boringcrypto/**/*",
         "https://github.com/microsoft/reverse-proxy/blob/main/**/*",
         "https://github.com/microsoft/reverse-proxy/blob/release/**/*",
-        "https://github.com/mono/api-doc-tools/blob/main/**/*",
         "https://github.com/mono/api-snapshot/blob/main/**/*",
         "https://github.com/mono/bockbuild/blob/main/**/*",
         "https://github.com/mono/boringssl/blob/mono/**/*",


### PR DESCRIPTION
From discussions with @huangmin-ms  this is no longer desired and has been broken for some time.