### PR TITLE
Fix broken github-dnceng-branch-merge-pr-generator subscription for sdk/installer

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -783,7 +783,7 @@
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
-        "vsoSourceBranch": "release/6.0.2xx",
+        "vsoSourceBranch": "main",
         "vsoBuildParameters": {
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
@@ -801,7 +801,7 @@
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
-        "vsoSourceBranch": "release/6.0.1xx",
+        "vsoSourceBranch": "main",
         "vsoBuildParameters": {
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",


### PR DESCRIPTION
The subscriptions added with https://github.com/dotnet/versions/pull/808 are not appearing to run.  I think this is because the `vsoSourceBranch`  is not correctly specified.  My understanding is the `vsoSourceBranch` is the branch for where the action lives (e.g. arcade) not where the pr generator should run