### PR TITLE
Delete main-vs-deps subscription from razor-tooling repository

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -740,23 +740,6 @@
         }
       }
     },
-    // Automate opening PRs to merge razor-tooling main changes into dev17 branches.
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/razor-tooling/blob/main//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "main-vs-deps",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
     // Automate opening PRs to merge cli release/6.0.3xx to main
     {
       "triggerPaths": [


### PR DESCRIPTION
- We're no longer maintaining a main-vs-deps branch in the razor-tooling repo.