### PR TITLE
Removed entry - release/3.1 to main in wpf repos

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1227,23 +1227,6 @@
         }
       }
     },
-    // Automate opening PRs to merge dotnet org repos' release/3.1 changes into main branches
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/wpf/blob/release/3.1/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "main",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
     // Automate opening PRs to merge services' production branches into main
     {
       "triggerPaths": [


### PR DESCRIPTION
Removed the subscription entry that creates PR from release/3.1 -> main in WPF repo , as main ( 7.0 now ) and 3.1 have diverged.

There was a discussion last year regarding this in https://github.com/dotnet/wpf/pull/4164#issuecomment-781550340. 