### PR TITLE
Remove mirroring of versions repo

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -550,7 +550,6 @@
         "https://github.com/dotnet/try-convert/blob/release/**/*",
         "https://github.com/dotnet/upgrade-assistant/blob/main/**/*",
         "https://github.com/dotnet/upgrade-assistant/blob/release/**/*",
-        "https://github.com/dotnet/versions/blob/main/**/*",
         "https://github.com/dotnet/vscode-dotnet-runtime/blob/main/**/*",
         "https://github.com/dotnet/vscode-dotnet-runtime/blob/release/**/*",
         "https://github.com/dotnet/wcf/blob/main/**/*",


### PR DESCRIPTION
This was only used by the .NET Docker team's infrastructure. But that dependency has been removed as part of the work for https://github.com/dotnet/docker-tools/issues/986.