### PR TITLE
Skip .2xx from now on

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -777,25 +777,7 @@
         }
       }
     },
-    // Automate opening PRs to merge cli release/6.0.2xx to .3xx
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/sdk/blob/release/6.0.2xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/6.0.2xx//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/6.0.3xx",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge cli release/6.0.1xx to .2xx
+    // Automate opening PRs to merge cli release/6.0.1xx to .3xx
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/6.0.1xx//**/*",
@@ -808,7 +790,7 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/6.0.2xx",
+          "BaseBranch": "release/6.0.3xx",
           "ExtraSwitches": "-QuietComments"
         }
       }


### PR DESCRIPTION
6.0.2xx goes out of support in May. The final changes should already be in the public repo. At this time, we should stop flowing changes from .1xx through .2xx and skip straight to .3xx.