### PR TITLE
Set up mirroring for objwriter/release branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -469,6 +469,7 @@
         "https://github.com/dotnet/linker/blob/main/**/*",
         "https://github.com/dotnet/linker/blob/release/**/*",
         "https://github.com/dotnet/llvm-project/blob/objwriter/**/*",
+        "https://github.com/dotnet/llvm-project/blob/objwriter/release/**/*",
         "https://github.com/dotnet/llvm-project/blob/dotnet/main/**/*",
         "https://github.com/dotnet/llvm-project/blob/dotnet/release/**/*",
         "https://github.com/dotnet/machinelearning/blob/features/**/*",


### PR DESCRIPTION
The `objwriter/**/*` wildcard apparently doesn't cover it because it's not getting mirrored.