### PR TITLE
Image info for dotnet-buildtools/prereqs production branch

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-production.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-production.json
@@ -1,0 +1,4 @@
+{
+  "schemaVersion": "1.0",
+  "repos": []
+}


### PR DESCRIPTION
Now that the dotnet-buildtools/prereqs has a new `production` branch from which to build official images, we need a corresponding image info file for that branch. By default, it will be empty and then populated with metadata as new builds run from that branch.