### PR TITLE
Predefine repo in new dotnet-buildtools/prereqs image info

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-production.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-production.json
@@ -1,4 +1,8 @@
 {
   "schemaVersion": "1.0",
-  "repos": []
+  "repos": [
+    {
+      "repo": "dotnet-buildtools/prereqs"
+    }
+  ]
 }


### PR DESCRIPTION
The [logic in Image Builder](https://github.com/dotnet/docker-tools/blob/defad2c5d0b303dac5ab9a6046e88d8676a62037/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs#L173-L223) doesn't handle the case of an empty repos array in the image info file very well. It thinks the merging behavior has caused all the data to be removed and throws an exception as a fail safe from accidentally removing unintended data.

The workaround is just to predefine the `dotnet-buildtools/prereqs` repo in the array.