### PR TITLE
Set up mirroring for the `ctp` branch of `dotnet/wpf`

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -579,6 +579,7 @@
         "https://github.com/dotnet/wpf/blob/arcade/**/*",
         "https://github.com/dotnet/wpf/blob/main/**/*",
         "https://github.com/dotnet/wpf/blob/release/**/*",
+        "https://github.com/dotnet/wpf/blob/ctp/**/*",
         "https://github.com/dotnet/xdt/blob/main/**/*",
         "https://github.com/dotnet/xdt/blob/release/**/*",
         "https://github.com/dotnet/xharness/blob/main/**/*",


### PR DESCRIPTION
Add CTP branch for automated tests and internal mirrors.