### PR TITLE
Mirror dotnet/project-system into DevDiv AzDO

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -365,6 +365,7 @@
         "https://github.com/dotnet/msbuild/blob/vs/**/*",
         "https://github.com/dotnet/msbuild/blob/main/**/*",
         "https://github.com/dotnet/msbuild/blob/exp/**/*",
+        "https://github.com/dotnet/project-system/blob/main/**/*",
         "https://github.com/dotnet/source-build/blob/main/**/*",
         "https://github.com/dotnet/source-build/blob/release/**/*",
         "https://github.com/dotnet/standard/blob/release/**/*",


### PR DESCRIPTION
This is enabling mirroring support for https://github.com/dotnet/project-system. It should mirror `main` into https://dev.azure.com/devdiv/DevDiv/_git/dotnet-project-system.