### PR TITLE
Add dotnet/sign repo mirroring

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -521,6 +521,7 @@
         "https://github.com/dotnet/sdk/blob/main/**/*",
         "https://github.com/dotnet/sdk/blob/rel/**/*",
         "https://github.com/dotnet/sdk/blob/release/**/*",
+        "https://github.com/dotnet/sign/blob/cli/**/*",
         "https://github.com/dotnet/spa-templates/blob/main/**/*",
         "https://github.com/dotnet/spa-templates/blob/release/**/*",
         "https://github.com/dotnet/source-build-externals/blob/main/**/*",


### PR DESCRIPTION
Add AzDO mirroring for the dotnet/sign repository, cli branch only.

CC @MattGal