### PR TITLE
Automate MSBuild's merge chain

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1316,42 +1316,75 @@
         }
       }
     },
-    // Automate opening PRs to merge msbuild's vs17* branches into main
-    // For details on how the triggerpath globbing syntax works, see: https://github.com/dotnet/versions/issues/558
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/msbuild/blob/vs17/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "main"
-        }
-      }
-    },
-    // Automate opening PRs to merge msbuild's vs16.10 into vs16.11 and vs16.11 into main
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/msbuild/blob/vs16.10/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "vs16.11"
-        }
-      }
-    },
+    // MSBuild servicing chain from oldest supported through currently-supported to main
+    // Automate opening PRs to merge msbuild's vs16.11 into vs17.0
     {
       "triggerPaths": [
         "https://github.com/dotnet/msbuild/blob/vs16.11/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.0"
+        }
+      }
+    },
+    // Automate opening PRs to merge msbuild's vs17.0 into vs17.2
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs17.0/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.2"
+        }
+      }
+    },
+    // Automate opening PRs to merge msbuild's vs17.2 into vs17.4
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs17.2/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.4"
+        }
+      }
+    },
+    // Automate opening PRs to merge msbuild's vs17.4 into vs17.5
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs17.4/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.5"
+        }
+      }
+    },
+    // MSBuild latest release to main
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs17.5/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
Explicitly chain MSBuild's servicing branches oldest->newest instead of having automation open everything->main and doing the chain manually.

cc @dotnet/msbuild-admins 