### PR TITLE
Add release branches for PackageSourceMapper

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -625,6 +625,7 @@
         "https://github.com/mono/roslyn-binaries/blob/main/**/*",
         "https://github.com/mono/rx/blob/rx-oss-v2.2/**/*",
         "https://github.com/nuget/packageSourceMapper/blob/dev/**/*",
+        "https://github.com/nuget/packageSourceMapper/blob/release/**/*",
         "https://github.com/SignalR/SignalR/blob/dev/**/*",
         "https://github.com/SignalR/SignalR/blob/main/**/*",
         "https://github.com/SignalR/SignalR/blob/release/**/*"


### PR DESCRIPTION
We created this `release/1.0.x`  branch
https://github.com/NuGet/PackageSourceMapper/tree/release/1.0.x