### PR TITLE
Add "test" branches to ICU mirror

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -461,6 +461,7 @@
         "https://github.com/dotnet/HttpRepl/blob/release/**/*",
         "https://github.com/dotnet/icu/blob/dotnet/main/**/*",
         "https://github.com/dotnet/icu/blob/dotnet/release/**/*",
+        "https://github.com/dotnet/icu/blob/dotnet/test/**/*",
         "https://github.com/dotnet/insertions-client/blob/main/**/*",
         "https://github.com/dotnet/install-scripts/blob/main/**/*",
         "https://github.com/dotnet/install-scripts-monitoring/blob/main/**/*",


### PR DESCRIPTION
We have a speculative branch of a new version of ICU with an alternative commit history, published to a branch on GitHub. We need to start mirroring this internally so we can test integration with downstream repositories.