### PR TITLE
Add bot rule for auto dual check-in from dotnet/runtime staging to base servicing branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -648,10 +648,10 @@
       "action": "github-runtime-main-to-runtimelab-mirror",
       "actionArguments": {}
     },
-    // Automate merging runtime release/7.0-rc* branches back into release/7.0
+    // Automate merging runtime release/7.0-staging branches back into release/7.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/runtime/blob/release/7.0-rc/**/*"
+        "https://github.com/dotnet/runtime/blob/release/7.0-staging/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -665,10 +665,10 @@
         }
       }
     },
-    // Automate merging runtime release/6.0-rc* branches back into release/6.0
+    // Automate merging runtime release/6.0-staging branches back into release/6.0
     {
       "triggerPaths": [
-        "https://github.com/dotnet/runtime/blob/release/6.0-rc/**/*"
+        "https://github.com/dotnet/runtime/blob/release/6.0-staging/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
Based on https://github.com/dotnet/versions/pull/835

The bot should automatically create PRs that backport everything from the (upcoming) staging branches:

- release/7.0-staging
- release/6.0-staging

into their respective base branches:

- release/7.0
- release/6.0

Then a human can manually merge the PR on code-complete day.

### Notes

- The staging branches have not been created yet. Allow me to create them first, then we can merge this PR. cc @dotnet/dnceng because I'll need someone to help merge this when the time comes.
- The RC rules are not relevant anymore for .NET 6 and 7. We will eventually create a new rule for .NET 8 when the time comes. Let me know if you think I should bring them back for some reason.

cc @mmitche @ViktorHofer @ericstj @jeffhandley @akoeplinger @hoyosjs 

