### PR TITLE
Invert direction of dual-commit merge for runtime servicing and staging.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -648,10 +648,10 @@
       "action": "github-runtime-main-to-runtimelab-mirror",
       "actionArguments": {}
     },
-    // Automate merging runtime release/7.0-staging branches back into release/7.0
+    // Automate merging runtime release/7.0 branch into release/7.0-staging
     {
       "triggerPaths": [
-        "https://github.com/dotnet/runtime/blob/release/7.0-staging/**/*"
+        "https://github.com/dotnet/runtime/blob/release/7.0/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -660,15 +660,15 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/7.0",
+          "BaseBranch": "release/7.0-staging",
           "ExtraSwitches": "-QuietComments"
         }
       }
     },
-    // Automate merging runtime release/6.0-staging branches back into release/6.0
+    // Automate merging runtime release/6.0 branch into release/6.0-staging
     {
       "triggerPaths": [
-        "https://github.com/dotnet/runtime/blob/release/6.0-staging/**/*"
+        "https://github.com/dotnet/runtime/blob/release/6.0/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -677,7 +677,7 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/6.0",
+          "BaseBranch": "release/6.0-staging",
           "ExtraSwitches": "-QuietComments"
         }
       }


### PR DESCRIPTION
Inverts the change introduced here: https://github.com/dotnet/versions/pull/872

We want to trigger an automated PR that merges new changes introduced to `release/X.0` branches into the `release/X.0-staging` branches.

@ViktorHofer @hoyosjs