### PR TITLE
MSBuild 17.6->16.7 merges

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1384,10 +1384,26 @@
         }
       }
     },
-    // MSBuild latest release to main
+    // Automate opening PRs to merge msbuild's vs17.5 into vs17.6
     {
       "triggerPaths": [
         "https://github.com/dotnet/msbuild/blob/vs17.5/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.6"
+        }
+      }
+    },
+    // MSBuild latest release to main
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs17.6/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
We are locking down for 17.6 and main will become 17.7.