### PR TITLE
Fix dotnet-extensions-experimental mirroring

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -402,7 +402,7 @@
         "https://github.com/aspnet/jquery-validation-unobtrusive/blob/main/**/*",
         "https://github.com/aspnet/SignalR-Client-Cpp/blob/main/**/*",
         "https://github.com/aspnet/SignalR-Client-Cpp/blob/release/**/*",
-        "https://github.com/Azure/dotnet-extensions-experimental/main/**/*",
+        "https://github.com/Azure/dotnet-extensions-experimental/blob/main/**/*",
         "https://github.com/dotnet/arcade-extensions/blob/main/**/*",
         "https://github.com/dotnet/arcade-extensions/blob/production/**/*",
         "https://github.com/dotnet/arcade-pool-provider/blob/main/**/*",


### PR DESCRIPTION
Mirroring is not working for the dotnet-extensions-experimental repo (reported on FR), the reason may be a wrong path