### PR TITLE
MSBuild vs17.6->vs16.7 merges (aka 17.7 -> 17.8 from VS perspective)

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1401,10 +1401,26 @@
         }
       }
     },
-    // MSBuild latest release to main
+    // Automate opening PRs to merge msbuild's vs17.6 into vs17.7
     {
       "triggerPaths": [
         "https://github.com/dotnet/msbuild/blob/vs17.6/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.7"
+        }
+      }
+    },
+    // MSBuild latest release to main
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs17.7/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
### Context
17.7 is being locked down; development on 17.8 will continue in main
This is cc of the https://github.com/dotnet/versions/pull/875 PR

### Changes made
MSBuild vs17.6 (so far latest release branch) will now flow to vs17.7 (newest release branch from now on) and vs17.7 changes will flow to main

cc @rainersigwald as FYI