### PR TITLE
Add the dotnet/workload-version repo to code mirroring

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -607,6 +607,8 @@
         "https://github.com/dotnet/winforms-designer/blob/release/**/*",
         "https://github.com/dotnet/winforms/blob/main/**/*",
         "https://github.com/dotnet/winforms/blob/release/**/*",
+        "https://github.com/dotnet/workload-versions/blob/main/**/*",
+        "https://github.com/dotnet/workload-versions/blob/release/**/*",
         "https://github.com/dotnet/wpf/blob/arcade/**/*",
         "https://github.com/dotnet/wpf/blob/main/**/*",
         "https://github.com/dotnet/wpf/blob/release/**/*",


### PR DESCRIPTION
## Summary
This allows the [dotnet/workload-versions](https://github.com/dotnet/workload-versions) repo to be mirrored internally in Azure DevOps. It will mirror the `main` branch and any `release` branches.