### PR TITLE
Update vscode-csharp to mirror any patch/ branches

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -590,7 +590,7 @@
         "https://github.com/dotnet/upgrade-assistant/blob/release/**/*",
         "https://github.com/dotnet/versions/blob/main/**/*",
         "https://github.com/dotnet/vscode-csharp/blob/main/**/*",
-        "https://github.com/dotnet/vscode-csharp/blob/prerelease/**/*",
+        "https://github.com/dotnet/vscode-csharp/blob/patch/**/*",
         "https://github.com/dotnet/vscode-csharp/blob/release/**/*",
         "https://github.com/dotnet/vscode-dotnet-runtime/blob/main/**/*",
         "https://github.com/dotnet/vscode-dotnet-runtime/blob/release/**/*",


### PR DESCRIPTION
Adding support to mirror any patch/* branches from vscode-csharp to the internal repo.  We'll be using the patch/* branches to release urgent out of band fixes to the C# extension that cannot go through the normal flow.

We do not use the prerelease branch any more, so that one is removed.