### PR TITLE
Add mirroring for MSBuild repo.

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -365,6 +365,7 @@
         "https://github.com/dotnet/msbuild/blob/vs/**/*",
         "https://github.com/dotnet/msbuild/blob/main/**/*",
         "https://github.com/dotnet/msbuild/blob/exp/**/*",
+        "https://github.com/dotnet/msbuild/blob/perf/**/*",
         "https://github.com/dotnet/project-system/blob/main/**/*",
         "https://github.com/dotnet/source-build/blob/main/**/*",
         "https://github.com/dotnet/source-build/blob/release/**/*",


### PR DESCRIPTION
Start to mirror "perf/*" branches of MSBuild repository to azdo for performance tests automation.