### PR TITLE
Remove outdated source-build devdiv mirror

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1283,7 +1283,6 @@
         "https://github.com/dotnet/coreclr/blob/release/**/*",
         "https://github.com/dotnet/core-setup/blob/release/**/*",
         "https://github.com/dotnet/cli/blob/release/**/*",
-        "https://github.com/dotnet/source-build/blob/release/**/*",
         "https://github.com/NuGet/NuGet.Client/blob/dev/**/*",
         "https://github.com/NuGet/NuGet.Client/blob/release/**/*"
       ],


### PR DESCRIPTION
I noticed the code-mirror job on devdiv AzDO is failing for the source-build repo, looks like there's no internal repo anymore so removing the mirroring.

```
remote: TF401019: The Git repository with name or identifier dotnet-source-build-Trusted does not exist or you do not have permissions for the operation you are attempting.
fatal: repository 'https://dev.azure.com/devdiv/devdiv/_git/dotnet-source-build-Trusted/' not found
```