### PR TITLE
Add dotnet/templating to automatic release branch-to-branch codeflow

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -830,7 +830,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/8.0.2xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/8.0.2xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/8.0.2xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/8.0.2xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -848,7 +849,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/8.0.1xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/8.0.1xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/8.0.1xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/8.0.1xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -866,7 +868,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/7.0.4xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/7.0.4xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/7.0.4xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/7.0.4xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -884,7 +887,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/7.0.3xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/7.0.3xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/7.0.3xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/7.0.3xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -902,7 +906,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/7.0.1xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/7.0.1xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/7.0.1xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/7.0.1xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -920,7 +925,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/6.0.4xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/6.0.4xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/6.0.4xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/6.0.4xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -938,7 +944,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/6.0.3xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/6.0.3xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/6.0.3xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/6.0.3xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -956,7 +963,8 @@
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/6.0.1xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/6.0.1xx//**/*"
+        "https://github.com/dotnet/installer/blob/release/6.0.1xx//**/*",
+        "https://github.com/dotnet/templating/blob/release/6.0.1xx//**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
## Summary
This adds the [dotnet/templating](https://github.com/dotnet/templating) repo to automatically flow the code between the release branches. The flow is:
- release/6.0.1xx -> release/6.0.3xx
- release/6.0.3xx -> release/6.0.4xx
- release/6.0.4xx -> release/7.0.1xx
- release/7.0.1xx -> release/7.0.3xx
- release/7.0.3xx -> release/7.0.4xx
- release/7.0.4xx -> release/8.0.1xx
- release/8.0.1xx -> release/8.0.2xx
- release/8.0.2xx -> main