### PR TITLE
Automatic runtime dual check-in from `release/8.0` into `release/8.0-staging`

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -677,6 +677,23 @@
       "action": "github-runtime-main-to-runtimelab-mirror",
       "actionArguments": {}
     },
+    // Automate merging runtime release/8.0 branch into release/8.0-staging
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/runtime/blob/release/8.0/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/8.0-staging",
+          "ExtraSwitches": "-QuietComments"
+        }
+      }
+    },
     // Automate merging runtime release/7.0 branch into release/7.0-staging
     {
       "triggerPaths": [


### PR DESCRIPTION
Same as with `7.0-staging` and `6.0-staging`, which was done in #872 and then in #873.

@ericstj @ViktorHofer @lewing @hoyosjs @steveisok @mmitche