### PR TITLE
Stop mirroring dotnet/linker main branch

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -497,7 +497,6 @@
         "https://github.com/dotnet/interactive/blob/release/**/*",
         "https://github.com/dotnet/iot/blob/main/**/*",
         "https://github.com/dotnet/iot/blob/release/**/*",
-        "https://github.com/dotnet/linker/blob/main/**/*",
         "https://github.com/dotnet/linker/blob/release/**/*",
         "https://github.com/dotnet/llvm-project/blob/objwriter/**/*",
         "https://github.com/dotnet/llvm-project/blob/dotnet/main-14.x/**/*",


### PR DESCRIPTION
It was archived: https://github.com/dotnet/linker/pull/3238

/cc @mmitche 