### PR TITLE
Mirror maintenance-packages main azdo branch to internal/main

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1403,6 +1403,7 @@
         "https://github.com/dotnet/installer/blob/release/7.0.3xx/**/*",
         "https://github.com/dotnet/installer/blob/release/7.0.4xx/**/*",
         "https://github.com/dotnet/installer/blob/release/8.0.1xx/**/*",
+        "https://github.com/dotnet/maintenance-packages/blob/main/**/*",
         "https://github.com/dotnet/runtime/blob/release/6.0/**/*",
         "https://github.com/dotnet/runtime/blob/release/7.0/**/*",
         "https://github.com/dotnet/runtime/blob/release/8.0/**/*",


### PR DESCRIPTION
The `github-dnceng-azdo-internal-merge-mirror` action is linked to the correct build definition: https://github.com/carlossanlop/versions/blob/ef97ed984ba3593524526644e0872f70bdb57e72/Maestro/subscriptions.json#L21-L26 

@ViktorHofer @ericstj @mmitche 