### PR TITLE
Add mirroring for the vscode-csharp prerelease branch

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -598,6 +598,7 @@
         "https://github.com/dotnet/vscode-csharp/blob/main/**/*",
         "https://github.com/dotnet/vscode-csharp/blob/patch/**/*",
         "https://github.com/dotnet/vscode-csharp/blob/release/**/*",
+        "https://github.com/dotnet/vscode-csharp/blob/prerelease/**/*",
         "https://github.com/dotnet/vscode-dotnet-runtime/blob/main/**/*",
         "https://github.com/dotnet/vscode-dotnet-runtime/blob/release/**/*",
         "https://github.com/dotnet/vscode-dotnet-pack/blob/main/**/*",


### PR DESCRIPTION
We're going to be using the prerelease branch for creating builds, so needs to be mirrored to the internal repo.