### PR TITLE
Auto sync roslyn-tool main to dnceng mirror

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -536,6 +536,7 @@
         "https://github.com/dotnet/roslyn-analyzers/blob/main/**/*",
         "https://github.com/dotnet/roslyn-analyzers/blob/release/**/*",
         "https://github.com/dotnet/roslyn-debug/blob/main/**/*",
+        "https://github.com/dotnet/roslyn-tool/blob/main/**/*",
         "https://github.com/dotnet/roslyn/blob/features/**/*",
         "https://github.com/dotnet/roslyn/blob/main-vs-deps/**/*",
         "https://github.com/dotnet/roslyn/blob/main/**/*",


### PR DESCRIPTION
Hi, I want to setup the auto sync from https://github.com/dotnet/roslyn-tools to its dnceng mirror https://dev.azure.com/dnceng/internal/_git/dotnet-roslyn-tools