### PR TITLE
MSBuild-17.9 -> 17.10

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1593,10 +1593,26 @@
         }
       }
     },
-    // MSBuild latest release to main
+    // Automate opening PRs to merge msbuild's vs17.9 into vs17.10
     {
       "triggerPaths": [
         "https://github.com/dotnet/msbuild/blob/vs17.9/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "vs17.10"
+        }
+      }
+    },
+    // MSBuild latest release to main
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/msbuild/blob/vs17.10/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {


### PR DESCRIPTION
We are adding 17.10 branch in MSBuild repo, https://github.com/dotnet/msbuild/issues/9914. Adjusting the flow.