### PR TITLE
Tell GitHub to not make JSON comments red

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -50,3 +50,8 @@
 *.fsproj text=auto
 *.dbproj text=auto
 *.sln text=auto eol=crlf
+
+## GitHub Linguist
+
+# Allow JSON files to have comments without red highlighting on GitHub
+*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
The default `JSON` language disallows comments, but they're really helpful in `subscriptions.json`.

Compare for example https://github.com/dotnet/versions/blob/9461cd023c450752070d7dc8f36f733c60fac13e/Maestro/subscriptions.json

![image](https://github.com/dotnet/versions/assets/3347530/60a37acf-b2be-4c3f-9a50-6f93f0bcffcf)

with

https://github.com/rainersigwald/versions/blob/18af711f72ea66a5c056d787e4236dde5d28154b/Maestro/subscriptions.json

![image](https://github.com/dotnet/versions/assets/3347530/6923ad1d-a60b-471c-a76f-e2999cbff346)
