### PR TITLE
Remove dotnet/iot mirror

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -498,8 +498,6 @@
         "https://github.com/dotnet/interactive/blob/hotfix/**/*",
         "https://github.com/dotnet/interactive/blob/main/**/*",
         "https://github.com/dotnet/interactive/blob/release/**/*",
-        "https://github.com/dotnet/iot/blob/main/**/*",
-        "https://github.com/dotnet/iot/blob/release/**/*",
         "https://github.com/dotnet/linker/blob/release/**/*",
         "https://github.com/dotnet/llvm-project/blob/objwriter/**/*",
         "https://github.com/dotnet/llvm-project/blob/dotnet/main-14.x/**/*",


### PR DESCRIPTION
dotnet/iot is no longer building out of dnceng, so removing the mirror as we will remove the dnceng fork soon.

cc: @ericstj 