### PR TITLE
Disabling aspire vNext subscriptions

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -421,7 +421,6 @@
         "https://github.com/dotnet/astra/blob/main/**/*",
         "https://github.com/dotnet/astra/blob/release/**/*",
         "https://github.com/dotnet/aspire/blob/main/**/*",
-        "https://github.com/dotnet/aspire/blob/vNext/**/*",
         "https://github.com/dotnet/aspire/blob/release/**/*",
         "https://github.com/dotnet/binaryen/blob/dotnet/main/**/*",
         "https://github.com/dotnet/binaryen/blob/dotnet/release/**/*",
@@ -843,23 +842,6 @@
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
           "BaseBranch": "dev",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge aspire main branch back to vNext
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/aspire/blob/main//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "vNext",
           "ExtraSwitches": "-QuietComments"
         }
       }


### PR DESCRIPTION
Aspire will no longer maintain the vNext branch, so we are disabling the mirror as well as the merge PRs from main