### PR TITLE
7.0 and 8.0.2xx are out of support starting in June releases 

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -952,26 +952,7 @@
         }
       }
     },
-    // Automate opening PRs to merge cli release/8.0.2xx to 8.0.3xx
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/sdk/blob/release/8.0.2xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/8.0.2xx//**/*",
-        "https://github.com/dotnet/templating/blob/release/8.0.2xx//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/8.0.3xx",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge cli release/8.0.1xx to 8.0.2xx
+    // Automate opening PRs to merge cli release/8.0.1xx to 8.0.3xx
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/8.0.1xx//**/*",
@@ -985,69 +966,12 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/8.0.2xx",
+          "BaseBranch": "release/8.0.3xx",
           "ExtraSwitches": "-QuietComments"
         }
       }
     },
-    // Automate opening PRs to merge cli release/7.0.4xx to 8.0.1xx
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/sdk/blob/release/7.0.4xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/7.0.4xx//**/*",
-        "https://github.com/dotnet/templating/blob/release/7.0.4xx//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/8.0.1xx",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge cli release/7.0.3xx to 7.0.4xx
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/sdk/blob/release/7.0.3xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/7.0.3xx//**/*",
-        "https://github.com/dotnet/templating/blob/release/7.0.3xx//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/7.0.4xx",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge cli release/7.0.1xx to 7.0.3xx
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/sdk/blob/release/7.0.1xx//**/*",
-        "https://github.com/dotnet/installer/blob/release/7.0.1xx//**/*",
-        "https://github.com/dotnet/templating/blob/release/7.0.1xx//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/7.0.3xx",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge cli release/6.0.4xx to 7.0.1xx
+    // Automate opening PRs to merge cli release/6.0.4xx to 8.0.1xx
     {
       "triggerPaths": [
         "https://github.com/dotnet/sdk/blob/release/6.0.4xx//**/*",
@@ -1061,7 +985,7 @@
           "GithubRepoOwner": "dotnet",
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/7.0.1xx",
+          "BaseBranch": "release/8.0.1xx",
           "ExtraSwitches": "-QuietComments"
         }
       }


### PR DESCRIPTION
so we don't need to include them in branch to branch flow anymore