### PR TITLE
Disable mirror of dotnet/maui

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -507,8 +507,6 @@
         "https://github.com/dotnet/machinelearning/blob/release/**/*",
         "https://github.com/dotnet/maintenance-packages/blob/main/**/*",
         "https://github.com/dotnet/maintenance-packages/blob/release/**/*",
-        "https://github.com/dotnet/maui/blob/main/**/*",
-        "https://github.com/dotnet/maui/blob/release/**/*",
         "https://github.com/dotnet/metadata-tools/blob/main/**/*",
         "https://github.com/dotnet/metadata-tools/blob/release/**/*",
         "https://github.com/dotnet/microsoft.maui.graphics/blob/main/**/*",


### PR DESCRIPTION
Internal mirror is disabled (not yet in use) so disable mirroring.