### PR TITLE
Remove obsolete dnceng mirroring entries (2)

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -1150,7 +1150,7 @@
       "triggerPaths": [
         "https://github.com/dotnet/arcade-services/blob/production/**/*",
         "https://github.com/dotnet/arcade-pool-provider/blob/production/**/*",
-        "https://github.com/dotnet/helix-service/blob/production/**/*",
+        "https://github.com/dotnet/helix-service/blob/production/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -1393,6 +1393,40 @@
           "GithubRepo": "<trigger-repo>",
           "BranchToMirror": "<trigger-branch>",
           "CommitsToMirror": "<trigger-commitlist>"
+        }
+      }
+    },
+    // Automate opening PRs to merge winforms-designer release/16.10p4 to release/16.11p1
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/winforms-designer/blob/release/16.10p4/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "release/16.11p1",
+          "ExtraSwitches": "-QuietComments"
+        }
+      }
+    },
+    // Automate opening PRs to merge winforms-designer release/16.11 preview branches to main
+    {
+      "triggerPaths": [
+        "https://github.com/dotnet/winforms-designer/blob/release/16.11/**/*"
+      ],
+      "action": "github-dnceng-branch-merge-pr-generator",
+      "actionArguments": {
+        "vsoSourceBranch": "main",
+        "vsoBuildParameters": {
+          "GithubRepoOwner": "dotnet",
+          "GithubRepoName": "<trigger-repo>",
+          "HeadBranch": "<trigger-branch>",
+          "BaseBranch": "main",
+          "ExtraSwitches": "-QuietComments"
         }
       }
     }

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -96,12 +96,6 @@
       "vsoProject": "DevDiv",
       "buildDefinitionId": 7644
     },
-    // A build definition that will update the dependencies of the dotnet/toolset repo
-    "toolset-dependencies": {
-      "vsoInstance": "devdiv.visualstudio.com",
-      "vsoProject": "DevDiv",
-      "buildDefinitionId": 9750
-    },
     // A build definition capable of running any .ps1 script in the WCF repo. By default, the main branch.
     "wcf-general": {
       "vsoInstance": "devdiv.visualstudio.com",
@@ -272,24 +266,18 @@
     {
       "triggerPaths": [
         "https://github.com/aspnet/AspLabs/blob/main/**/*",
-        "https://github.com/aspnet/AspLabs/blob/release/**/*",
         "https://github.com/aspnet/AspNetKatana/blob/main/**/*",
         "https://github.com/aspnet/AspNetKatana/blob/release/**/*",
         "https://github.com/aspnet/AspNetWebHooks/blob/main/**/*",
-        "https://github.com/aspnet/AspNetWebHooks-Signed/blob/main/**/*",
         "https://github.com/aspnet/AspNetWebStack/blob/main/**/*",
-        "https://github.com/aspnet/AspNetWebStack/blob/release/**/*",
         "https://github.com/aspnet/Benchmarks/blob/main/**/*",
-        "https://github.com/aspnet/BuildTools/blob/main/**/*",
         "https://github.com/aspnet/BuildTools/blob/release/**/*",
         "https://github.com/aspnet/jquery-validation-unobtrusive/blob/main/**/*",
         "https://github.com/aspnet/SignalR-Client-Cpp/blob/main/**/*",
         "https://github.com/aspnet/SignalR-Client-Cpp/blob/release/**/*",
         "https://github.com/dotnet/arcade-extensions/blob/main/**/*",
-        "https://github.com/dotnet/arcade-extensions/blob/production/**/*",
         "https://github.com/dotnet/arcade-services/blob/main/**/*",
         "https://github.com/dotnet/arcade-services/blob/production/**/*",
-        "https://github.com/dotnet/arcade-services/blob/release/**/*",
         "https://github.com/dotnet/arcade-validation/blob/main/**/*",
         "https://github.com/dotnet/arcade-validation/blob/release/**/*",
         "https://github.com/dotnet/arcade/blob/main/**/*",
@@ -303,17 +291,14 @@
         "https://github.com/dotnet/cecil/blob/main/**/*",
         "https://github.com/dotnet/cecil/blob/release/**/*",
         "https://github.com/dotnet/cli-lab/blob/main/**/*",
-        "https://github.com/dotnet/cli-lab/blob/release/**/*",
         "https://github.com/dotnet/command-line-api/blob/main/**/*",
         "https://github.com/dotnet/command-line-api/blob/release/**/*",
         "https://github.com/dotnet/corescan/blob/main/**/*",
         "https://github.com/dotnet/cpython/blob/dotnet/main/**/*",
         "https://github.com/dotnet/cpython/blob/dotnet/release/**/*",
         "https://github.com/dotnet/crank/blob/main/**/*",
-        "https://github.com/dotnet/crank/blob/release/**/*",
         "https://github.com/dotnet/cssparser/blob/main/**/*",
         "https://github.com/dotnet/debugger-contracts/blob/main/**/*",
-        "https://github.com/dotnet/debugger-contracts/blob/release/**/*",
         "https://github.com/dotnet/deployment-tools/blob/main/**/*",
         "https://github.com/dotnet/deployment-tools/blob/release/**/*",
         "https://github.com/dotnet/diagnostics/blob/main/**/*",
@@ -323,7 +308,6 @@
         "https://github.com/dotnet/dnceng-shared/blob/main/**/*",
         "https://github.com/dotnet/docker-tools/blob/main/**/*",
         "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/main/**/*",
-        "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/production/**/*",
         "https://github.com/dotnet/dotnet-docker/blob/main/**/*",
         "https://github.com/dotnet/dotnet-docker/blob/nightly/**/*",
         "https://github.com/dotnet/dotnet/blob/main/**/*",
@@ -331,7 +315,6 @@
         "https://github.com/dotnet/dotnet-monitor/blob/feature/**/*",
         "https://github.com/dotnet/dotnet-monitor/blob/main/**/*",
         "https://github.com/dotnet/dotnet-monitor/blob/release/**/*",
-        "https://github.com/dotnet/dotnet-monitor/blob/shipped/**/*",
         "https://github.com/dotnet/ef6/blob/main/**/*",
         "https://github.com/dotnet/ef6/blob/release/**/*",
         "https://github.com/dotnet/efcore/blob/main/**/*",
@@ -343,7 +326,7 @@
         "https://github.com/dotnet/extensions/blob/dev/**/*",
         "https://github.com/dotnet/extensions/blob/main/**/*",
         "https://github.com/dotnet/extensions/blob/release/**/*",
-        "https://github.com/dotnet/format/blob/main/**/*",
+        "https://github.com/dotnet/format/blob/archive/**/*",
         "https://github.com/dotnet/format/blob/release/**/*",
         "https://github.com/dotnet/fsharp/blob/main/**/*",
         "https://github.com/dotnet/fsharp/blob/release/**/*",
@@ -353,18 +336,12 @@
         "https://github.com/dotnet/HttpRepl/blob/release/**/*",
         "https://github.com/dotnet/icu/blob/dotnet/main/**/*",
         "https://github.com/dotnet/icu/blob/dotnet/release/**/*",
-        "https://github.com/dotnet/icu/blob/dotnet/test/**/*",
         "https://github.com/dotnet/insertions-client/blob/main/**/*",
         "https://github.com/dotnet/install-scripts/blob/main/**/*",
-        "https://github.com/dotnet/install-scripts-monitoring/blob/main/**/*",
         "https://github.com/dotnet/installer/blob/main/**/*",
         "https://github.com/dotnet/installer/blob/release/**/*",
         "https://github.com/dotnet/interactive-window/blob/main/**/*",
-        "https://github.com/dotnet/interactive-window/blob/release/**/*",
-        "https://github.com/dotnet/interactive/blob/feature/**/*",
-        "https://github.com/dotnet/interactive/blob/hotfix/**/*",
         "https://github.com/dotnet/interactive/blob/main/**/*",
-        "https://github.com/dotnet/interactive/blob/release/**/*",
         "https://github.com/dotnet/linker/blob/release/**/*",
         "https://github.com/dotnet/llvm-project/blob/objwriter/**/*",
         "https://github.com/dotnet/llvm-project/blob/dotnet/main-14.x/**/*",
@@ -374,13 +351,7 @@
         "https://github.com/dotnet/machinelearning/blob/main/**/*",
         "https://github.com/dotnet/machinelearning/blob/release/**/*",
         "https://github.com/dotnet/maintenance-packages/blob/main/**/*",
-        "https://github.com/dotnet/maintenance-packages/blob/release/**/*",
         "https://github.com/dotnet/metadata-tools/blob/main/**/*",
-        "https://github.com/dotnet/metadata-tools/blob/release/**/*",
-        "https://github.com/dotnet/microsoft.maui.graphics/blob/main/**/*",
-        "https://github.com/dotnet/microsoft.maui.graphics/blob/release/**/*",
-        "https://github.com/dotnet/msbuild-language-service/blob/main/**/*",
-        "https://github.com/dotnet/msbuild-language-service/blob/release/**/*",
         "https://github.com/dotnet/msbuild/blob/main/**/*",
         "https://github.com/dotnet/msbuild/blob/vs/**/*",
         "https://github.com/dotnet/msquic/blob/main/**/*",
@@ -398,7 +369,6 @@
         "https://github.com/dotnet/roslyn-analyzers/blob/2.9.x/**/*",
         "https://github.com/dotnet/roslyn-analyzers/blob/main/**/*",
         "https://github.com/dotnet/roslyn-analyzers/blob/release/**/*",
-        "https://github.com/dotnet/roslyn-debug/blob/main/**/*",
         "https://github.com/dotnet/roslyn-tools/blob/main/**/*",
         "https://github.com/dotnet/roslyn/blob/features/**/*",
         "https://github.com/dotnet/roslyn/blob/main-vs-deps/**/*",
@@ -406,7 +376,6 @@
         "https://github.com/dotnet/roslyn/blob/release/**/*",
         "https://github.com/dotnet/runtime-assets/blob/main/**/*",
         "https://github.com/dotnet/runtime-assets/blob/release/**/*",
-        "https://github.com/dotnet/runtime/blob/dev/infrastructure/**/*",
         "https://github.com/dotnet/runtime/blob/main/**/*",
         "https://github.com/dotnet/runtime/blob/release/**/*",
         "https://github.com/dotnet/runtimelab/blob/docs/**/*",
@@ -418,12 +387,10 @@
         "https://github.com/dotnet/sdk/blob/rel/**/*",
         "https://github.com/dotnet/sdk/blob/release/**/*",
         "https://github.com/dotnet/sign/blob/main/**/*",
-        "https://github.com/dotnet/spa-templates/blob/main/**/*",
         "https://github.com/dotnet/spa-templates/blob/release/**/*",
         "https://github.com/dotnet/source-build-externals/blob/main/**/*",
         "https://github.com/dotnet/source-build-externals/blob/release/**/*",
         "https://github.com/dotnet/source-build-reference-packages/blob/main/**/*",
-        "https://github.com/dotnet/source-build-reference-packages/blob/pre-arcade/**/*",
         "https://github.com/dotnet/source-build-reference-packages/blob/release/**/*",
         "https://github.com/dotnet/source-build/blob/main/**/*",
         "https://github.com/dotnet/source-build/blob/release/**/*",
@@ -432,47 +399,28 @@
         "https://github.com/dotnet/sourcelink/blob/release/**/*",
         "https://github.com/dotnet/standard/blob/release/**/*",
         "https://github.com/dotnet/symreader-converter/blob/main/**/*",
-        "https://github.com/dotnet/symreader-converter/blob/release/**/*",
         "https://github.com/dotnet/symreader-portable/blob/main/**/*",
         "https://github.com/dotnet/symreader-portable/blob/release/**/*",
         "https://github.com/dotnet/symreader/blob/main/**/*",
         "https://github.com/dotnet/symreader/blob/release/**/*",
-        "https://github.com/dotnet/symstore/blob/main/**/*",
-        "https://github.com/dotnet/symstore/blob/release/**/*",
         "https://github.com/dotnet/systemweb-adapters/blob/main/**/*",
-        "https://github.com/dotnet/systemweb-adapters/blob/release/**/*",
         "https://github.com/dotnet/templating/blob/main/**/*",
         "https://github.com/dotnet/templating/blob/release/**/*",
         "https://github.com/dotnet/test-templates/blob/main/**/*",
         "https://github.com/dotnet/test-templates/blob/rel/**/*",
-        "https://github.com/dotnet/toolset/blob/release/**/*",
-        "https://github.com/dotnet/try-convert/blob/main/**/*",
-        "https://github.com/dotnet/try-convert/blob/release/**/*",
         "https://github.com/dotnet/try/blob/main/**/*",
-        "https://github.com/dotnet/try/blob/release/**/*",
         "https://github.com/dotnet/tye/blob/main/**/*",
-        "https://github.com/dotnet/tye/blob/release/**/*",
-        "https://github.com/dotnet/upgrade-assistant/blob/main/**/*",
-        "https://github.com/dotnet/upgrade-assistant/blob/release/**/*",
         "https://github.com/dotnet/versions/blob/main/**/*",
         "https://github.com/dotnet/vscode-csharp/blob/main/**/*",
-        "https://github.com/dotnet/vscode-csharp/blob/patch/**/*",
         "https://github.com/dotnet/vscode-csharp/blob/release/**/*",
         "https://github.com/dotnet/vscode-csharp/blob/prerelease/**/*",
         "https://github.com/dotnet/vscode-dotnet-runtime/blob/main/**/*",
-        "https://github.com/dotnet/vscode-dotnet-runtime/blob/release/**/*",
-        "https://github.com/dotnet/vscode-dotnet-pack/blob/main/**/*",
-        "https://github.com/dotnet/vscode-dotnet-pack/blob/release/**/*",
-        "https://github.com/dotnet/vscode-dotnet-installer/blob/main/**/*",
-        "https://github.com/dotnet/vscode-dotnet-installer/blob/release/**/*",
         "https://github.com/dotnet/wasi-sdk/blob/dotnet/main/**/*",
         "https://github.com/dotnet/wcf/blob/main/**/*",
         "https://github.com/dotnet/wcf/blob/release/**/*",
         "https://github.com/dotnet/windowsdesktop/blob/main/**/*",
         "https://github.com/dotnet/windowsdesktop/blob/release/**/*",
         "https://github.com/dotnet/winforms-datavisualization/blob/main/**/*",
-        "https://github.com/dotnet/winforms-designer/blob/main/**/*",
-        "https://github.com/dotnet/winforms-designer/blob/release/**/*",
         "https://github.com/dotnet/winforms/blob/main/**/*",
         "https://github.com/dotnet/winforms/blob/release/**/*",
         "https://github.com/dotnet/workload-versions/blob/main/**/*",
@@ -485,32 +433,24 @@
         "https://github.com/dotnet/xdt/blob/release/**/*",
         "https://github.com/dotnet/xharness/blob/main/**/*",
         "https://github.com/dotnet/xharness/blob/release/**/*",
-        "https://github.com/dotnet/xharness/blob/xcode/**/*",
-        "https://github.com/dotnet/xliff-tasks/blob/main/**/*",
-        "https://github.com/dotnet/xliff-tasks/blob/release/**/*",
         "https://github.com/Microsoft/clrmd/blob/main/**/*",
         "https://github.com/Microsoft/clrmd/blob/release/**/*",
         "https://github.com/Microsoft/dotnet-framework-docker/blob/main/**/*",
         "https://github.com/microsoft/fluentui-blazor/blob/main/**/*",
         "https://github.com/microsoft/fluentui-blazor/blob/dev/**/*",
         "https://github.com/microsoft/fluentui-blazor/blob/archives-v3/**/*",
-        "https://github.com/microsoft/go-images/blob/dev/official/**/*",
         "https://github.com/microsoft/go-images/blob/microsoft/main/**/*",
         "https://github.com/microsoft/go-images/blob/microsoft/nightly/**/*",
         "https://github.com/microsoft/go-infra-images/blob/main/**/*",
         "https://github.com/microsoft/go-infra/blob/main/**/*",
-        "https://github.com/microsoft/go-pdb/blob/main/**/*",
-        "https://github.com/microsoft/go/blob/dev/official/**/*",
         "https://github.com/microsoft/go/blob/microsoft/dev.boringcrypto/**/*",
         "https://github.com/microsoft/go/blob/microsoft/main/**/*",
         "https://github.com/microsoft/go/blob/microsoft/release-branch./**/*",
         "https://github.com/microsoft/reverse-proxy/blob/main/**/*",
         "https://github.com/microsoft/reverse-proxy/blob/release/**/*",
         "https://github.com/microsoft/testfx/blob/main/**/*",
-        "https://github.com/microsoft/testfx/blob/pre/**/*",
         "https://github.com/microsoft/testfx/blob/rel/**/*",
         "https://github.com/microsoft/vstest/blob/main/**/*",
-        "https://github.com/microsoft/vstest/blob/pre/**/*",
         "https://github.com/microsoft/vstest/blob/rel/**/*",
         "https://github.com/mono/mono.posix/blob/main/**/*",
         "https://github.com/nuget/packageSourceMapper/blob/dev/**/*",
@@ -549,23 +489,6 @@
           "GithubRepoName": "<trigger-repo>",
           "HeadBranch": "<trigger-branch>",
           "BaseBranch": "release/8.0-staging",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate merging runtime release/7.0 branch into release/7.0-staging
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/runtime/blob/release/7.0/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/7.0-staging",
           "ExtraSwitches": "-QuietComments"
         }
       }
@@ -1183,7 +1106,7 @@
     // Merge mirrored branches (to internal/) in dnceng Azure Devops
     {
       "triggerPaths": [
-        "https://github.com/dotnet/aspnetcore/blob/release/2/**/*",
+        "https://github.com/dotnet/aspnetcore/blob/release/2.1/**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/6.0/**/*",
         "https://github.com/dotnet/aspnetcore/blob/release/8.0/**/*",
         "https://github.com/aspnet/BuildTools/blob/release/**/*",
@@ -1229,7 +1152,6 @@
         "https://github.com/dotnet/arcade-services/blob/production/**/*",
         "https://github.com/dotnet/arcade-pool-provider/blob/production/**/*",
         "https://github.com/dotnet/helix-service/blob/production/**/*",
-        "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/production/**/*"
       ],
       "action": "github-dnceng-branch-merge-pr-generator",
       "actionArguments": {
@@ -1472,40 +1394,6 @@
           "GithubRepo": "<trigger-repo>",
           "BranchToMirror": "<trigger-branch>",
           "CommitsToMirror": "<trigger-commitlist>"
-        }
-      }
-    },
-    // Automate opening PRs to merge winforms-designer release/16.10p4 to release/16.11p1
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/winforms-designer/blob/release/16.10p4/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/16.11p1",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge winforms-designer release/16.11 preview branches to main
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/winforms-designer/blob/release/16.11/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "main",
-          "ExtraSwitches": "-QuietComments"
         }
       }
     }

--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -326,7 +326,6 @@
         "https://github.com/dotnet/extensions/blob/dev/**/*",
         "https://github.com/dotnet/extensions/blob/main/**/*",
         "https://github.com/dotnet/extensions/blob/release/**/*",
-        "https://github.com/dotnet/format/blob/archive/**/*",
         "https://github.com/dotnet/format/blob/release/**/*",
         "https://github.com/dotnet/fsharp/blob/main/**/*",
         "https://github.com/dotnet/fsharp/blob/release/**/*",


### PR DESCRIPTION
I removed subscriptions which
- don't map to existing branches in GitHub
- repo in github doesn't exist
- repo in azdo doesn't exist
- repo in azdo is archived

Few smaller tweaks

Continuation of https://github.com/dotnet/versions/pull/973/

This is just based on my exploration, not authoritative. Let's bring in somebody who could validate.