### PR TITLE
Remove insertions client from the mirror

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -354,7 +354,6 @@
         "https://github.com/dotnet/icu/blob/dotnet/main/**/*",
         "https://github.com/dotnet/icu/blob/dotnet/release/**/*",
         "https://github.com/dotnet/icu/blob/dotnet/test/**/*",
-        "https://github.com/dotnet/insertions-client/blob/main/**/*",
         "https://github.com/dotnet/install-scripts/blob/main/**/*",
         "https://github.com/dotnet/install-scripts-monitoring/blob/main/**/*",
         "https://github.com/dotnet/installer/blob/main/**/*",


### PR DESCRIPTION
I actually didn't know that this had a public GH version. I've made all changes to the internal repo. Since this repo only exists for VS insertions, I'm not sure why it was created in GH at all so I'm going to archive the public GH repo and continue to work in the AzDO version.