### PR TITLE
Remove the BrowserLink & Scaffolding subs to github inter-branch merge

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -536,23 +536,6 @@
         }
       }
     },
-    // Automate opening PRs to merge aspnet release/2.1 branches back to release/3.0 or release/3.1.
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/BrowserLink/blob/release/2.1//**/*",
-        "https://github.com/dotnet/Scaffolding/blob/release/2.1//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/3.0"
-        }
-      }
-    },
     // Automate opening PRs to merge Asp.Net/EF release branches back to main
     {
       "triggerPaths": [


### PR DESCRIPTION
Currently only `main` branch is active, hence there is no need in this functionality. 

Based on the discussion in PRs:

- https://github.com/aspnet/BrowserLink/pull/115
- https://github.com/aspnet/BrowserLink/pull/116
- https://github.com/dotnet/Scaffolding/pull/2818
- https://github.com/dotnet/Scaffolding/pull/2819

FYI @wtgodbe 