### PR TITLE
Offboard buildTools from GitHub Merge Flow

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -536,23 +536,6 @@
         }
       }
     },
-    // Automate opening PRs to merge Asp.Net/EF release branches back to main
-    {
-      "triggerPaths": [
-        "https://github.com/aspnet/BuildTools/blob/release/2.1//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "aspnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "main",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
     {
       "triggerPaths": [
         "https://github.com/dotnet/ef6/blob/release/6.5//**/*",


### PR DESCRIPTION
### Context
The legacy inter-branch merge functionality is going to be deprecated soon. There is an effort in progress to transition to new InterBranch merge functionality based on GitHub actions. 

### Why removing
This item (subscription) to inter-branch merge using legacy flow is : 
Merge changes from `release/2.1` to `main`. 

There is no `main` branch in this repository: https://github.com/aspnet/BuildTools/branches, hence the merge flow will fail. 

FYI @wtgodbe 
