### PR TITLE
Offboard dotnet/aspire not active sub

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -586,23 +586,6 @@
         }
       }
     },
-    // Automate opening PRs to merge aspire release/8.0-preview5 branch back to release/8.0
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/aspire/blob/release/8.0-preview5//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "release/8.0",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
     // Automate opening PRs to merge extensions-samples release/8.0 branch back to main
     {
       "triggerPaths": [


### PR DESCRIPTION
### Context
The legacy inter-branch merge functionality is going to be deprecated soon. There is an effort in progress to transition to new InterBranch merge functionality based on GitHub actions.

### Why removing
This item (subscription) to inter-branch merge using legacy flow is :
Merge changes from `release/8.0-preview5` to `release/8.0`.

Based on the conversation: https://github.com/dotnet/aspire/pull/4609#discussion_r1647840549 
This flow from preview5 to release8 is no longer needed. 

FYI: @joperezr  @eerhardt 