### PR TITLE
Offboard dotnet/arcade-services from legacy inter-branch merge flow

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -235,22 +235,6 @@
         }
       }
     },
-    // Automate opening PRs to merge services' production branches into main
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/arcade-services/blob/production/**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "main"
-        }
-      }
-    },
     // MSBuild servicing chain from oldest supported through currently-supported to main
     // Automate opening PRs to merge msbuild's vs16.11 (VS until 4/2029) into vs17.0 (SDK 6.0.1xx)
     {


### PR DESCRIPTION
### Context
The legacy inter-branch merge functionality is going to be deprecated soon. There is an effort in progress to transition to new InterBranch merge functionality based on GitHub actions.

### Why removing
dotnet/arcade-services is already onboarded on the new inter-branch flow, hence removing it from the legacy flow. 
Onboarding PRs: 
https://github.com/dotnet/arcade-services/pull/3669
https://github.com/dotnet/arcade-services/pull/3668

New flow generated PRs: https://github.com/dotnet/arcade-services/pull/3681

FYI: @premun @oleksandr-didyk