### PR TITLE
Offboard dotnet/extensions from inter-branch merge

### DIFF
--- a/Maestro/subscriptions.json
+++ b/Maestro/subscriptions.json
@@ -59,40 +59,6 @@
         }
       }
     },
-    // Automate opening PRs to merge extensions release/8.0 branch back to main
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/extensions/blob/release/8.0//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "main",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
-    // Automate opening PRs to merge extensions main branch back to dev
-    {
-      "triggerPaths": [
-        "https://github.com/dotnet/extensions/blob/main//**/*"
-      ],
-      "action": "github-dnceng-branch-merge-pr-generator",
-      "actionArguments": {
-        "vsoSourceBranch": "main",
-        "vsoBuildParameters": {
-          "GithubRepoOwner": "dotnet",
-          "GithubRepoName": "<trigger-repo>",
-          "HeadBranch": "<trigger-branch>",
-          "BaseBranch": "dev",
-          "ExtraSwitches": "-QuietComments"
-        }
-      }
-    },
     // Automate opening PRs to merge extensions-samples release/8.0 branch back to main
     {
       "triggerPaths": [


### PR DESCRIPTION
The PRs onboarding the dotnet/extensions repository are merged: https://github.com/dotnet/extensions/pull/5239
The run from main to dev: https://github.com/dotnet/extensions/actions/runs/9747690241/job/26900966700
Resulted PR: https://github.com/dotnet/extensions/pull/5256

FYI: @joperezr, @RussKie