### PR TITLE
go-images image-info: populate full initial file

### DIFF
--- a/build-info/microsoft/go-images/image-info.microsoft-go-images-main.json
+++ b/build-info/microsoft/go-images/image-info.microsoft-go-images-main.json
@@ -1,4 +1,1566 @@
 {
   "schemaVersion": "1.0",
-  "repos": []
+  "repos": [
+    {
+      "repo": "oss/go/microsoft/golang",
+      "images": [
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:003f5b00bbaf1381963165bfa5a2b86267389754c7fd345268f4c072b9fae5dd",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1",
+              "1-bookworm",
+              "1.21",
+              "1.21-bookworm",
+              "1.21.12",
+              "1.21.12-1",
+              "1.21.12-1-bookworm",
+              "1.21.12-bookworm",
+              "bookworm",
+              "latest"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-bookworm-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c1025f939a62365f3aca2b29c63165330f8f53cd920148046b02403e873ba58b",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:49a47828cd3d55213ea82274cbbe0613854d13d3b332a6040b769bbe695d3d78",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:53.0549417Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:e76469fad0c750056556556cff01bee8db769ab3a29b3217556f5cd5fd1f30e7",
+                "sha256:ff794ed45c05c72e88470f0c2ec810e9a8eee43fbb3793e090d5d06ad0454a67",
+                "sha256:a69ed45e1f6163e2d97f2ee9a8b1e4f29068a0c00b0a2e68c143b9d13387fdf7",
+                "sha256:3dbed71fc5444cf6889a21b002de3e7805e810aa88f91a9ca941b4e3880246d1",
+                "sha256:58b365fa3e8dc16e70d89fab0e91f5242feb38ae3cfeb6655e654209ea109333",
+                "sha256:e9aef93137af6e967e7242f3b3c8ecd8e6f571d1e6fdd9e72db0befeeae3cf13"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-bookworm-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:7f53199f997f0d2c7fc777ad94d15f0b4a119eb4d7a5160d2667e17518669970",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:49a47828cd3d55213ea82274cbbe0613854d13d3b332a6040b769bbe695d3d78",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:24:49.7317277Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:258df31e9f97a4bc4a79f17e4b1e9335f0b999f6619c13e11995fcbdd05b7642",
+                "sha256:99fa0b6fc4850c55ee90b2ae51254e0f665df6b1a5123ed27add4f374d9630f8",
+                "sha256:86c2a6400e50439128d89adb757e68d393e1f4e41815106d6a6f16394f3b6d36",
+                "sha256:ce4650a14deed524a46f7f7b410ff5d81e5ff66e51c7345e2b05887b6e3f4030",
+                "sha256:0aa30b2bcbde45c2fc67abf425197af3af3e67d55296f168143343ef1b0e2d3e",
+                "sha256:335f2c484898b910fac13d5650ed3c78e5e673fe8dab1b06a071c71478a153d0"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-bookworm-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d110443c7b2e75b416a98b4980a06f37be3a9cba88621223745d9a761d7e3a23",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:49a47828cd3d55213ea82274cbbe0613854d13d3b332a6040b769bbe695d3d78",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:24:59.8162908Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:36843e763cefaade109cfecced868b34f71c10533ecc6aaaed69b53634814836",
+                "sha256:4bdc6da94765b43554be7eb90f4c64282682cb249589c15fb5e077e4ad6d3cd6",
+                "sha256:790124a993e40b572760d54d43794756e21554a2ef434b9d0faca18dff98bb73",
+                "sha256:64a6ab51b82df5ee608db374a16686eefb99bc53834af17064184653121729b3",
+                "sha256:b16610496e73ba3d120d519598b53fa8a2db4c80ccc097a5016ad44aedd0654b",
+                "sha256:0bd1f8180c504ba389021ce74895ed487ccd8c70e2d9af3707934bc801ba28d8"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:8889ebad93effd468495760182d6da17fe0304a72d24f989713f82f05878bbc3",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-bullseye",
+              "1.21-bullseye",
+              "1.21.12-1-bullseye",
+              "1.21.12-bullseye",
+              "bullseye"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-bullseye-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:267bc4fd5e9f48aa84e0d51aa9594c8eb448f9402b5bf925674acd0f9bccd6e9",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff08d266b8fd2358fc78cd35acf4b4e08ac7031f31badaa20a649495b588e2fc",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:26:32.5292297Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:7819facfc17bfd81b546d4e191969f8b7e13d69c35dab33606bdff259876ea3e",
+                "sha256:0bb12c81c3b9b92f8ce16463f58bcae663887018d94205e1f2b3cbf1bd4c2b8e",
+                "sha256:3cf0d64e6519716258790d6241a226d59985e968a1891bcb65f7f8ccc108c952",
+                "sha256:da238dd9d1f579bf4f3cd6589e3ab75747f8ea35be2bf50403f8f3fafa942eea",
+                "sha256:8a305f523084f0a28b5daf532a5216d9be05d863c6bd3f5bd2969965eb7e9a27",
+                "sha256:c1c1a7d83fb1e16686c4e98df3d6f88b37beb4d65daae1ddd715f95d7ac4db5c"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-bullseye-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:18af7c292cc3ac8914484af9a54561870f0a527521a0e9dee1bcaf2808ade025",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff08d266b8fd2358fc78cd35acf4b4e08ac7031f31badaa20a649495b588e2fc",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:25:02.4914576Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:9ad0489ba27404f63a60eef62a51235f708063c911d32aba6043315f738ec05f",
+                "sha256:306ebc3f93f6ea7a20795f9bab15490a0652fb2130f096e41f8406c5f8079fe8",
+                "sha256:5b5e5643eaff10b9d40efbb006f96265c888358887db0355f7fe96e2e8d94fcf",
+                "sha256:577c5fe1f5243a6910c54b7b4a338cc9cbae0cfeba74a350b011d2a467e49daf",
+                "sha256:c5c595e4d8c2d2c7ad66ab723b54c73c6a0aa876b01511358ec8af1aed8c8b94",
+                "sha256:a0610bbe9cb80952dba5ef5efb55f03668fd4f8ab63ade3ba30e22a4c03c42da"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-bullseye-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d2c6f2626e0c4d4aa1aaada05a25d54d9fb04ca6104f5a4e4ba3d6326533bf9d",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff08d266b8fd2358fc78cd35acf4b4e08ac7031f31badaa20a649495b588e2fc",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:27.3584505Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:8b450bbaab2eac5202137698cc56d6c465da7e8e6be42c79e95b81483e915c9a",
+                "sha256:a031ff8cb5c34f72d9ac712c0f76d1b206585a2b647245fe813e7fcb44b5447c",
+                "sha256:2b940067984c9fe8c0dce03b31a9e0d61b140711f51d7a466b1cc6d8ac0125ea",
+                "sha256:e1eeecfcb7b2ee9a8806953208440dbffd4b9110e5d2950924c7395e7ea3c070",
+                "sha256:699d9ac7785741df545f96a8744d3a9a5c29f75a171fb8de0a0bae196294ad50",
+                "sha256:a4cd3ad66f7873241881d2ddd4efa6521034245e95e2b0b4a059817345151048"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:9e888295575fd1425afbca86f7293d1da04d9b3f7fb541e1b3a6ebfa78a41062",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-cbl-mariner2.0",
+              "1.21-cbl-mariner2.0",
+              "1.21.12-1-cbl-mariner2.0",
+              "1.21.12-cbl-mariner2.0",
+              "cbl-mariner2.0"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-cbl-mariner2.0-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:a2990547e994f7c08849d26d7f6b3da8c8c78079af7a5d8bd120a1a098ebde32",
+              "baseImageDigest": "mcr.microsoft.com/cbl-mariner/base/core@sha256:2c467e0ec65d452cbd21cfbb5768acdab434e0f89c3ac034c683b2f69b783985",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:28:02.4810877Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:bf47f4c97072a358e65928bd2cf2b669d1c5e3fb1ef86df7f2d84e3fa9d581b9",
+                "sha256:eab3a6b04d9d9f29daa3efbb74b5b07d302bf4f0d2b581d388034d53b6d9d46f",
+                "sha256:cde7cc0af3d79087059bc81e06ef75c80653c9493ae5ad66a7a7ab079dbcc0ed",
+                "sha256:2198f5e753541cd263f84594ddd886cf0586a0447f6590813a35fd69d8da3509",
+                "sha256:d97bf7ca0b44c41054c6595b4e59b362ad7ebb8519a18598e99e0c6082a06248"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-cbl-mariner2.0-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:753b985e4adc767ea3ad686b659d80401d2980fcbfa379cdfc68a57aa3f55d5a",
+              "baseImageDigest": "mcr.microsoft.com/cbl-mariner/base/core@sha256:2c467e0ec65d452cbd21cfbb5768acdab434e0f89c3ac034c683b2f69b783985",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:58.7210056Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:ef2bf2b1ff8b53ac98f9230bd85bf4d17151209ecd99b381ce9db35da8e449e0",
+                "sha256:aee8b970f54501a522087a9340471951a4673c852e893b9848cd7280c0d1e7ed",
+                "sha256:1f81c3471ae40089b0384e0abf7bda1b3fdb3f6987db3795bc1e854800ca601a",
+                "sha256:1001b1e941a614b6e1af12a163dbfe16fc8d287352d8c08152c54400006eb35c",
+                "sha256:df492779e7cbf64ff3894b6f97cc437ce5a3acfd8a2d5e435cf0b9b4772b8bca"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:66a66730ab93d4033262b9d09aaaf922d651a6ea2ced6e98f0985abdae1f92d9",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-fips-bookworm",
+              "1.21-fips-bookworm",
+              "1.21.12-1-fips-bookworm",
+              "1.21.12-fips-bookworm",
+              "fips-bookworm"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/fips/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-bookworm-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:1fd7452ef7d03586ad72494ce9923fbbbf914f0087fc4e0a29911ffbdbbf92a4",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c1025f939a62365f3aca2b29c63165330f8f53cd920148046b02403e873ba58b",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:53.0549417Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:e76469fad0c750056556556cff01bee8db769ab3a29b3217556f5cd5fd1f30e7",
+                "sha256:ff794ed45c05c72e88470f0c2ec810e9a8eee43fbb3793e090d5d06ad0454a67",
+                "sha256:a69ed45e1f6163e2d97f2ee9a8b1e4f29068a0c00b0a2e68c143b9d13387fdf7",
+                "sha256:3dbed71fc5444cf6889a21b002de3e7805e810aa88f91a9ca941b4e3880246d1",
+                "sha256:58b365fa3e8dc16e70d89fab0e91f5242feb38ae3cfeb6655e654209ea109333",
+                "sha256:e9aef93137af6e967e7242f3b3c8ecd8e6f571d1e6fdd9e72db0befeeae3cf13"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/fips/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-bookworm-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d3bf676752b1ec7c30a77e54bed119902135d2efb8836026311ced950729c544",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:7f53199f997f0d2c7fc777ad94d15f0b4a119eb4d7a5160d2667e17518669970",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:24:49.7317277Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:258df31e9f97a4bc4a79f17e4b1e9335f0b999f6619c13e11995fcbdd05b7642",
+                "sha256:99fa0b6fc4850c55ee90b2ae51254e0f665df6b1a5123ed27add4f374d9630f8",
+                "sha256:86c2a6400e50439128d89adb757e68d393e1f4e41815106d6a6f16394f3b6d36",
+                "sha256:ce4650a14deed524a46f7f7b410ff5d81e5ff66e51c7345e2b05887b6e3f4030",
+                "sha256:0aa30b2bcbde45c2fc67abf425197af3af3e67d55296f168143343ef1b0e2d3e",
+                "sha256:335f2c484898b910fac13d5650ed3c78e5e673fe8dab1b06a071c71478a153d0"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/fips/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-bookworm-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:f8f5e697e1a9add76824fac300bd8990c467e937af1bb77f9749ce0651973d2b",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d110443c7b2e75b416a98b4980a06f37be3a9cba88621223745d9a761d7e3a23",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:24:59.8162908Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:36843e763cefaade109cfecced868b34f71c10533ecc6aaaed69b53634814836",
+                "sha256:4bdc6da94765b43554be7eb90f4c64282682cb249589c15fb5e077e4ad6d3cd6",
+                "sha256:790124a993e40b572760d54d43794756e21554a2ef434b9d0faca18dff98bb73",
+                "sha256:64a6ab51b82df5ee608db374a16686eefb99bc53834af17064184653121729b3",
+                "sha256:b16610496e73ba3d120d519598b53fa8a2db4c80ccc097a5016ad44aedd0654b",
+                "sha256:0bd1f8180c504ba389021ce74895ed487ccd8c70e2d9af3707934bc801ba28d8"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:285c585f16d8f44926e7f50fc836416492b5eff78dca5502f6b2d5b3118d4bf4",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-fips-bullseye",
+              "1.21-fips-bullseye",
+              "1.21.12-1-fips-bullseye",
+              "1.21.12-fips-bullseye",
+              "fips-bullseye"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/fips/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-bullseye-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:8a9bf1eb4c3d0c8de7410d09b49abdac5a8fb3e2b96c65a000f855d57b8ca24e",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:267bc4fd5e9f48aa84e0d51aa9594c8eb448f9402b5bf925674acd0f9bccd6e9",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:26:32.5292297Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:7819facfc17bfd81b546d4e191969f8b7e13d69c35dab33606bdff259876ea3e",
+                "sha256:0bb12c81c3b9b92f8ce16463f58bcae663887018d94205e1f2b3cbf1bd4c2b8e",
+                "sha256:3cf0d64e6519716258790d6241a226d59985e968a1891bcb65f7f8ccc108c952",
+                "sha256:da238dd9d1f579bf4f3cd6589e3ab75747f8ea35be2bf50403f8f3fafa942eea",
+                "sha256:8a305f523084f0a28b5daf532a5216d9be05d863c6bd3f5bd2969965eb7e9a27",
+                "sha256:c1c1a7d83fb1e16686c4e98df3d6f88b37beb4d65daae1ddd715f95d7ac4db5c"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/fips/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-bullseye-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:4021b238aceb2ffbb82b4d9e1b971e0ac0497962fa9de1a43c2b45fa13efc6c3",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:18af7c292cc3ac8914484af9a54561870f0a527521a0e9dee1bcaf2808ade025",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:25:02.4914576Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:9ad0489ba27404f63a60eef62a51235f708063c911d32aba6043315f738ec05f",
+                "sha256:306ebc3f93f6ea7a20795f9bab15490a0652fb2130f096e41f8406c5f8079fe8",
+                "sha256:5b5e5643eaff10b9d40efbb006f96265c888358887db0355f7fe96e2e8d94fcf",
+                "sha256:577c5fe1f5243a6910c54b7b4a338cc9cbae0cfeba74a350b011d2a467e49daf",
+                "sha256:c5c595e4d8c2d2c7ad66ab723b54c73c6a0aa876b01511358ec8af1aed8c8b94",
+                "sha256:a0610bbe9cb80952dba5ef5efb55f03668fd4f8ab63ade3ba30e22a4c03c42da"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/fips/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-bullseye-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:965e7010f17ca0454ff587ee45c85e064f842b71b8d04455efa4b6646da4b973",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d2c6f2626e0c4d4aa1aaada05a25d54d9fb04ca6104f5a4e4ba3d6326533bf9d",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:27.3584505Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:8b450bbaab2eac5202137698cc56d6c465da7e8e6be42c79e95b81483e915c9a",
+                "sha256:a031ff8cb5c34f72d9ac712c0f76d1b206585a2b647245fe813e7fcb44b5447c",
+                "sha256:2b940067984c9fe8c0dce03b31a9e0d61b140711f51d7a466b1cc6d8ac0125ea",
+                "sha256:e1eeecfcb7b2ee9a8806953208440dbffd4b9110e5d2950924c7395e7ea3c070",
+                "sha256:699d9ac7785741df545f96a8744d3a9a5c29f75a171fb8de0a0bae196294ad50",
+                "sha256:a4cd3ad66f7873241881d2ddd4efa6521034245e95e2b0b4a059817345151048"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:a1d0b47479a31e3a2bf71619c27ef98cd71037c9965bd5909a6aaea9c3659b4f",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-fips-cbl-mariner2.0",
+              "1.21-fips-cbl-mariner2.0",
+              "1.21.12-1-fips-cbl-mariner2.0",
+              "1.21.12-fips-cbl-mariner2.0",
+              "fips-cbl-mariner2.0"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/fips/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-cbl-mariner2.0-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:37e8a858c83044f21abaed38b6e8f57db8690babdc670e4c00e4a2487e286d07",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:a2990547e994f7c08849d26d7f6b3da8c8c78079af7a5d8bd120a1a098ebde32",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:28:02.4810877Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:bf47f4c97072a358e65928bd2cf2b669d1c5e3fb1ef86df7f2d84e3fa9d581b9",
+                "sha256:eab3a6b04d9d9f29daa3efbb74b5b07d302bf4f0d2b581d388034d53b6d9d46f",
+                "sha256:cde7cc0af3d79087059bc81e06ef75c80653c9493ae5ad66a7a7ab079dbcc0ed",
+                "sha256:2198f5e753541cd263f84594ddd886cf0586a0447f6590813a35fd69d8da3509",
+                "sha256:d97bf7ca0b44c41054c6595b4e59b362ad7ebb8519a18598e99e0c6082a06248"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.21/fips/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-cbl-mariner2.0-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:b07f0be7169e92438e45b671a9f36d347a3b835fa2b1b0b7af9b6fb15042474b",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:753b985e4adc767ea3ad686b659d80401d2980fcbfa379cdfc68a57aa3f55d5a",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:58.7210056Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/fips/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:ef2bf2b1ff8b53ac98f9230bd85bf4d17151209ecd99b381ce9db35da8e449e0",
+                "sha256:aee8b970f54501a522087a9340471951a4673c852e893b9848cd7280c0d1e7ed",
+                "sha256:1f81c3471ae40089b0384e0abf7bda1b3fdb3f6987db3795bc1e854800ca601a",
+                "sha256:1001b1e941a614b6e1af12a163dbfe16fc8d287352d8c08152c54400006eb35c",
+                "sha256:df492779e7cbf64ff3894b6f97cc437ce5a3acfd8a2d5e435cf0b9b4772b8bca"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:f8d151436797a91c56ccded1cda31c7caadd8ca5b03ef17de6e97914d0061b84",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-fips-nanoserver-1809",
+              "1.21-fips-nanoserver-1809",
+              "1.21.12-1-fips-nanoserver-1809",
+              "1.21.12-fips-nanoserver-1809",
+              "fips-nanoserver-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/fips/nanoserver-1809/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-nanoserver-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:51f065c9f430903016022b7cdffea5bb5654d25559387d5b70352136db6acc10",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:a411b702095d2089d1892ddb96e9227d7d4d79ab776c8e2b344a5b27cacd7ba0",
+              "osType": "Windows",
+              "osVersion": "nanoserver-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:49:46.2327485Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/fips/nanoserver-1809/Dockerfile",
+              "layers": [
+                "sha256:d34a06e1c308f57b11a247e1e4a3f3e734c6efddebc22120f88e113af7ac2960",
+                "sha256:71e49e3007beb3a03283f2265e1e81573e2f246751627fb291a9bd43c3dc9e26",
+                "sha256:bcb1fbc4e94da03db63e1ff20c5a7c2df10d2766066629997b32cb39a68c4dd0",
+                "sha256:9b3b54fed777d8d6605182e064e54a84b0c4198b60b66dd0b61c56ea44085829",
+                "sha256:4c7b050fc864e182a7d88bb849aeb792efa615b8de0042732d55f48173531952",
+                "sha256:3b19334fbc4277c224372f5af06b5aacd827eb7be11d2dba33e401c4260b02e5",
+                "sha256:38f5f800a9f2263e5d9a5fdc9fe977e08884085008183226f025e83b31ae2cf6",
+                "sha256:6c83a3fb3dc131de1f76b555e254c64744dc287d3773b6bfc1dc5b61c5a9250f",
+                "sha256:a860bb2e84a2308868820616001bb74c3759dd7267beaa20db3acc36642b1f81",
+                "sha256:f0d66dba96bc9bafe789d171d05e9a8f06e132c3afac75605e395d8e234528d4",
+                "sha256:4f703ea968d7f7434cf61e5d835cb3c507a6364ff8c7b3b96b73391b22115615"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:e377a6de5240433299eee2a1d9cc4820d149e59d7fd2fd7754f0bffe246b25a2",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-fips-nanoserver-ltsc2022",
+              "1.21-fips-nanoserver-ltsc2022",
+              "1.21.12-1-fips-nanoserver-ltsc2022",
+              "1.21.12-fips-nanoserver-ltsc2022",
+              "fips-nanoserver-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/fips/nanoserver-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-nanoserver-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:6978316aed1d0a0d5f78d6b13b192f371f465774e0d1cc1b99bb5cf045a0eb31",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:8a3eaa7decc9ab330f6b203cb8ffd170878443bf3611383c33dcb0f507aa0ea0",
+              "osType": "Windows",
+              "osVersion": "nanoserver-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:42:20.8391848Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/fips/nanoserver-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:83ef3e2d66fbc123909aade5f38967b7039c325d81497f0dbe0ffee84802db5d",
+                "sha256:3b817173e42de8fe7a0368eb7227c4004fc5a4ea6229987113360f905e8e8d7f",
+                "sha256:5b12110e084d92ff338c5dcf8d59f7f45147782a07f84094e406d15114b59bcd",
+                "sha256:5e34d9fab7b3aa3021dfca55803a0537d4bee9487ee570718b6031550a6c359e",
+                "sha256:c9646963e57522f8d40a567885bd6f2bc6c00155cd430c7c8d8a6e526e17082a",
+                "sha256:465a5bf8360230e20ca61ed0fe5e82fffdb7829a99833995151a4d07d20b9b7b",
+                "sha256:d9b7cb6ed4046ed1cf35863dcbb5a1d6d465851a708573257e6163f5ff0090e6",
+                "sha256:205b48c64d7c586a79599d467e31ea7c4449b35503fcfe78723533d0c9469947",
+                "sha256:a3b6603c8c960b5099123c0799e3496210c65c4206725b2d2955053e571984a3",
+                "sha256:912772c4dff4fe236dc499e8223be6e526b0ac421cc634609896fbfabf478678",
+                "sha256:a8c295c425a912de308ded279124ae45fec44d55a451843fe5877155417f453c"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:4dfdfd78ea9678aa1c05f8741de25e368042280a9409e6480a7a660ed40818ac",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-fips-windowsservercore-1809",
+              "1.21-fips-windowsservercore-1809",
+              "1.21.12-1-fips-windowsservercore-1809",
+              "1.21.12-fips-windowsservercore-1809",
+              "fips-windowsservercore-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/fips/windowsservercore-1809/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-windowsservercore-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:1739a5ea4fd86ae659870b2073067505763090eb7f64e45171a24a9d90430481",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:0676625f071dab365ef1109b3fd9ccfe2c98466ce3f2e3bfffcd7c5e8332f0c6",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:49:44.6184204Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/fips/windowsservercore-1809/Dockerfile",
+              "layers": [
+                "sha256:7aa9f5e97a7d8dcac7f0eefca396f8a8ad0434df6d9107f038c8eb8318558d95",
+                "sha256:82d93fcfcfd629b299df6c79f4229fca028bebd7e7f7903b9787e4067c114f51",
+                "sha256:01a42134db3c27ea19feaf0bbc1e0f5bee4fd9b2b933d9f3d55ea7dd3ab37dbe",
+                "sha256:2490ad372e7f064764ee6e0e8a1191bb526e2a54d9e9fa8be2f3e8444397e3a5",
+                "sha256:c86d58895761f8c6189333690b2b369de0b175d5f8dfb55e91359798dc34c521",
+                "sha256:028fb1b5d9c958c28ab92a97f6df23d43eef80cb8cce5853e185f86693c26596",
+                "sha256:e0ae809be3d4150385d31facc62f9fe24c161ce4d84bd5465599cb8b27a66010",
+                "sha256:5c2eacfa8d65d129475c2198568ab1c5ef134263319d2c12be0bbcae3f8ba224",
+                "sha256:c7564cb484808271d2ff5c3ca562cdadf17493e9881f10cc3b482488b4ad1cf8",
+                "sha256:438f7f758f85c80bc600d02a56f482afce2e3d41ebce2830c4335ddb6dde8e1b",
+                "sha256:4af1417517a1f16a5cb3edd14ad647ac27f8deff89c9177961d0840203cc21ef",
+                "sha256:0d3311d1cf41c05c79cf87449eb168786f0e7f8126519c0614e4d06231144ff6",
+                "sha256:56a5fd77f8cb6921d3e283f98213bf8c163d3502a75b4a8e4a809a15654f7d1a",
+                "sha256:c9226d61d3bdbf9f09821b32f5878623b8daaa5fb4f875cb63c199f87a26d57e"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:74df7a148cf8c1cc232dfe54af5b145c5c86f01e21155e7154baea08d00d42f8",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-fips-windowsservercore-ltsc2022",
+              "1.21-fips-windowsservercore-ltsc2022",
+              "1.21.12-1-fips-windowsservercore-ltsc2022",
+              "1.21.12-fips-windowsservercore-ltsc2022",
+              "fips-windowsservercore-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/fips/windowsservercore-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-fips-windowsservercore-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:cabbbeaeb7384916af122d5baf062254581bbe4ce833651a41c95f9c6a0873c5",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:648a501ffeb10c13ad47943ef665ace1cb6141bbdeec8523413ee5cd206175c1",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:42:19.7460576Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/fips/windowsservercore-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:cc1d8bb50688dd0c0ceb51ee59099883ce30b6bd93347fa4716409864188b6f7",
+                "sha256:a995f3154ce2ff7ce6e0237dc2ddbd0f001c23d7567bbf7b0f4c02b904d2d979",
+                "sha256:e19cb523f23f74e0daef35cbb0e69e4857169caa9fad8e524e710339a52ea419",
+                "sha256:c5bafe6684784112d3ff2981a02dbda508164e5a6cc0b835c10a2427a9635562",
+                "sha256:af4c0557fa30be244e4ce73eb6c5f666a715e1e0349c8a2a660227a712794264",
+                "sha256:14e88c1b383707ae7069513aae444d8f1b3cdca87b2605c03a469a617d5fe4c6",
+                "sha256:f31cb4e131a5a9f8e9da7a4357445a9152663cb5950b57edecb5dd9985d56eef",
+                "sha256:e5af4eafa5564e5477dcee6663272ce516cfdb3c170f21cf2b043b9f3063ae2f",
+                "sha256:9867eadd7071f0160236717921b7183b2cb5ea898d13944565b9fe72f14b08ff",
+                "sha256:308bb90b450837d9838ff5a2bcde330740ee0e2cd70924995bfe483c294cd787",
+                "sha256:2cc45e518a70a738c8d7ffde8b8a51934f4daa6c335b0a26220fab32970ec2b3",
+                "sha256:c19e36d3004efa60b4372cd316d327f9506f1028c478560731af6cbfb997c9a1",
+                "sha256:eb373ec9afdfc5f09b9380d981e0c61f9c7b48537b887135c7c66810086e705e",
+                "sha256:7c76e5cf7755ce357ffb737715b0da6799a50ea468cc252c094f4d915d426b3f"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:88262f6f479810bb9116c1f252dd688bb9f8a39dcdd874cfcb70495859933f55",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-nanoserver-1809",
+              "1.21-nanoserver-1809",
+              "1.21.12-1-nanoserver-1809",
+              "1.21.12-nanoserver-1809",
+              "nanoserver-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/nanoserver-1809/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-nanoserver-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:a411b702095d2089d1892ddb96e9227d7d4d79ab776c8e2b344a5b27cacd7ba0",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:f31fa317b1851ae16ffdb87450e5e51b61e186f898b949cea32d77e1c8b638a3",
+              "osType": "Windows",
+              "osVersion": "nanoserver-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:49:43.0549258Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/nanoserver-1809/Dockerfile",
+              "layers": [
+                "sha256:71e49e3007beb3a03283f2265e1e81573e2f246751627fb291a9bd43c3dc9e26",
+                "sha256:bcb1fbc4e94da03db63e1ff20c5a7c2df10d2766066629997b32cb39a68c4dd0",
+                "sha256:9b3b54fed777d8d6605182e064e54a84b0c4198b60b66dd0b61c56ea44085829",
+                "sha256:4c7b050fc864e182a7d88bb849aeb792efa615b8de0042732d55f48173531952",
+                "sha256:3b19334fbc4277c224372f5af06b5aacd827eb7be11d2dba33e401c4260b02e5",
+                "sha256:38f5f800a9f2263e5d9a5fdc9fe977e08884085008183226f025e83b31ae2cf6",
+                "sha256:6c83a3fb3dc131de1f76b555e254c64744dc287d3773b6bfc1dc5b61c5a9250f",
+                "sha256:a860bb2e84a2308868820616001bb74c3759dd7267beaa20db3acc36642b1f81",
+                "sha256:f0d66dba96bc9bafe789d171d05e9a8f06e132c3afac75605e395d8e234528d4",
+                "sha256:4f703ea968d7f7434cf61e5d835cb3c507a6364ff8c7b3b96b73391b22115615"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:a699a498eb4f2a0d69be7bf474f928cea85861aa2f723c414bcd6d09d7962984",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-nanoserver-ltsc2022",
+              "1.21-nanoserver-ltsc2022",
+              "1.21.12-1-nanoserver-ltsc2022",
+              "1.21.12-nanoserver-ltsc2022",
+              "nanoserver-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/nanoserver-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-nanoserver-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:8a3eaa7decc9ab330f6b203cb8ffd170878443bf3611383c33dcb0f507aa0ea0",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:31c8aa02d47af7d65c11da9c3a279c8407c32afd3fc6bec2e9a544db8e3715b3",
+              "osType": "Windows",
+              "osVersion": "nanoserver-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:42:18.1751594Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/nanoserver-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:3b817173e42de8fe7a0368eb7227c4004fc5a4ea6229987113360f905e8e8d7f",
+                "sha256:5b12110e084d92ff338c5dcf8d59f7f45147782a07f84094e406d15114b59bcd",
+                "sha256:5e34d9fab7b3aa3021dfca55803a0537d4bee9487ee570718b6031550a6c359e",
+                "sha256:c9646963e57522f8d40a567885bd6f2bc6c00155cd430c7c8d8a6e526e17082a",
+                "sha256:465a5bf8360230e20ca61ed0fe5e82fffdb7829a99833995151a4d07d20b9b7b",
+                "sha256:d9b7cb6ed4046ed1cf35863dcbb5a1d6d465851a708573257e6163f5ff0090e6",
+                "sha256:205b48c64d7c586a79599d467e31ea7c4449b35503fcfe78723533d0c9469947",
+                "sha256:a3b6603c8c960b5099123c0799e3496210c65c4206725b2d2955053e571984a3",
+                "sha256:912772c4dff4fe236dc499e8223be6e526b0ac421cc634609896fbfabf478678",
+                "sha256:a8c295c425a912de308ded279124ae45fec44d55a451843fe5877155417f453c"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:45e2bf437c6f9457332211b68cb00a6c5b50eb821fac84bbe8e6d018b78be45b",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-windowsservercore-1809",
+              "1.21-windowsservercore-1809",
+              "1.21.12-1-windowsservercore-1809",
+              "1.21.12-windowsservercore-1809",
+              "windowsservercore-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/windowsservercore-1809/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-windowsservercore-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:0676625f071dab365ef1109b3fd9ccfe2c98466ce3f2e3bfffcd7c5e8332f0c6",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:0d52390e8497ea6238500afbf60054bd731b12818e6440d31fe6ff4e2eefc5ad",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:47:07.7886221Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/windowsservercore-1809/Dockerfile",
+              "layers": [
+                "sha256:82d93fcfcfd629b299df6c79f4229fca028bebd7e7f7903b9787e4067c114f51",
+                "sha256:01a42134db3c27ea19feaf0bbc1e0f5bee4fd9b2b933d9f3d55ea7dd3ab37dbe",
+                "sha256:2490ad372e7f064764ee6e0e8a1191bb526e2a54d9e9fa8be2f3e8444397e3a5",
+                "sha256:c86d58895761f8c6189333690b2b369de0b175d5f8dfb55e91359798dc34c521",
+                "sha256:028fb1b5d9c958c28ab92a97f6df23d43eef80cb8cce5853e185f86693c26596",
+                "sha256:e0ae809be3d4150385d31facc62f9fe24c161ce4d84bd5465599cb8b27a66010",
+                "sha256:5c2eacfa8d65d129475c2198568ab1c5ef134263319d2c12be0bbcae3f8ba224",
+                "sha256:c7564cb484808271d2ff5c3ca562cdadf17493e9881f10cc3b482488b4ad1cf8",
+                "sha256:438f7f758f85c80bc600d02a56f482afce2e3d41ebce2830c4335ddb6dde8e1b",
+                "sha256:4af1417517a1f16a5cb3edd14ad647ac27f8deff89c9177961d0840203cc21ef",
+                "sha256:0d3311d1cf41c05c79cf87449eb168786f0e7f8126519c0614e4d06231144ff6",
+                "sha256:56a5fd77f8cb6921d3e283f98213bf8c163d3502a75b4a8e4a809a15654f7d1a",
+                "sha256:c9226d61d3bdbf9f09821b32f5878623b8daaa5fb4f875cb63c199f87a26d57e"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.21",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:4589fda6acc9087d8c68d5d69f4ff20f89215d0deed12ca98994c7ae3f3795f1",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1-windowsservercore-ltsc2022",
+              "1.21-windowsservercore-ltsc2022",
+              "1.21.12-1-windowsservercore-ltsc2022",
+              "1.21.12-windowsservercore-ltsc2022",
+              "windowsservercore-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.21/windows/windowsservercore-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.21.12-1-windowsservercore-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:648a501ffeb10c13ad47943ef665ace1cb6141bbdeec8523413ee5cd206175c1",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:92c6ddbf87a6d6696a83f26e3df912983477844e22dd686c3e82bac4cf5b49c2",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:39:43.7761127Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/b674b7d4d89fd640c0bb131b8f4660e337d5fb43/src/microsoft/1.21/windows/windowsservercore-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:a995f3154ce2ff7ce6e0237dc2ddbd0f001c23d7567bbf7b0f4c02b904d2d979",
+                "sha256:e19cb523f23f74e0daef35cbb0e69e4857169caa9fad8e524e710339a52ea419",
+                "sha256:c5bafe6684784112d3ff2981a02dbda508164e5a6cc0b835c10a2427a9635562",
+                "sha256:af4c0557fa30be244e4ce73eb6c5f666a715e1e0349c8a2a660227a712794264",
+                "sha256:14e88c1b383707ae7069513aae444d8f1b3cdca87b2605c03a469a617d5fe4c6",
+                "sha256:f31cb4e131a5a9f8e9da7a4357445a9152663cb5950b57edecb5dd9985d56eef",
+                "sha256:e5af4eafa5564e5477dcee6663272ce516cfdb3c170f21cf2b043b9f3063ae2f",
+                "sha256:9867eadd7071f0160236717921b7183b2cb5ea898d13944565b9fe72f14b08ff",
+                "sha256:308bb90b450837d9838ff5a2bcde330740ee0e2cd70924995bfe483c294cd787",
+                "sha256:2cc45e518a70a738c8d7ffde8b8a51934f4daa6c335b0a26220fab32970ec2b3",
+                "sha256:c19e36d3004efa60b4372cd316d327f9506f1028c478560731af6cbfb997c9a1",
+                "sha256:eb373ec9afdfc5f09b9380d981e0c61f9c7b48537b887135c7c66810086e705e",
+                "sha256:7c76e5cf7755ce357ffb737715b0da6799a50ea468cc252c094f4d915d426b3f"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:efd6f7f91cffc59f023b385e76157856c11a180ddfa33e09308911f9582b1d8d",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22",
+              "1.22-bookworm",
+              "1.22.5",
+              "1.22.5-1",
+              "1.22.5-1-bookworm",
+              "1.22.5-bookworm"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-bookworm-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:cf91c766efd246d348e891d1a38b131624995cc4b24f96373fa1105d6eacc57a",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:49a47828cd3d55213ea82274cbbe0613854d13d3b332a6040b769bbe695d3d78",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:46.1323304Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:f2a6608a21f3ebf1579eca4e920d4292bbe2c8b8e85d51c16d42348a1221380b",
+                "sha256:f02e93448e8c48729479dd670b1057481e6772d15489c730ee2a1be016a77630",
+                "sha256:00f5fe009b8e16baa0c21a37b273a2d29bf33c67432f15bce68ba1e0a46f0083",
+                "sha256:3dbed71fc5444cf6889a21b002de3e7805e810aa88f91a9ca941b4e3880246d1",
+                "sha256:58b365fa3e8dc16e70d89fab0e91f5242feb38ae3cfeb6655e654209ea109333",
+                "sha256:e9aef93137af6e967e7242f3b3c8ecd8e6f571d1e6fdd9e72db0befeeae3cf13"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-bookworm-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:308c960e34131a3cc5d7266f7a5bd9b05e133718595a8fec3f9655a9944ff991",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:49a47828cd3d55213ea82274cbbe0613854d13d3b332a6040b769bbe695d3d78",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:23:55.9054826Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:cc1574688fa9f188655d8593c005adeef03ce4b98fbcfdccfa3ba7ee8a433a39",
+                "sha256:673d75f20e032b81bb46244eb1d7c036e42262d77c31510500c92d6c1b7b9461",
+                "sha256:b7d2a43f04005d051617243ea75f8851331c235c382251668257fca1a072ddcd",
+                "sha256:ce4650a14deed524a46f7f7b410ff5d81e5ff66e51c7345e2b05887b6e3f4030",
+                "sha256:0aa30b2bcbde45c2fc67abf425197af3af3e67d55296f168143343ef1b0e2d3e",
+                "sha256:335f2c484898b910fac13d5650ed3c78e5e673fe8dab1b06a071c71478a153d0"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-bookworm-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c15bece3705f7baac31376dd68d5b546e05e5bee1dbbc343d9eac51b35dd3d03",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:49a47828cd3d55213ea82274cbbe0613854d13d3b332a6040b769bbe695d3d78",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:00.7380935Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:34ff8f663ca38857b6e265104c4edaf6afdf7d583a1f633619671ad74d34fb18",
+                "sha256:19875b2ccbf1d3a7b3af769c6c13202c266cb52e0ad4446e4b6feaca077f14de",
+                "sha256:10e2af91b5419c157d0111677b1f7b2ea4e27f11191fdaa5dbff61d42640d25c",
+                "sha256:64a6ab51b82df5ee608db374a16686eefb99bc53834af17064184653121729b3",
+                "sha256:b16610496e73ba3d120d519598b53fa8a2db4c80ccc097a5016ad44aedd0654b",
+                "sha256:0bd1f8180c504ba389021ce74895ed487ccd8c70e2d9af3707934bc801ba28d8"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:6a105b8e2f9af02776d47f3a6cecc0a5fedd14148c413c914e4a4af6d1b0747d",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-bullseye",
+              "1.22.5-1-bullseye",
+              "1.22.5-bullseye"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-bullseye-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:fcc745eb25c987047c9bcc6694e747c26d550f6a667558e1e6e87d246e8409ea",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff08d266b8fd2358fc78cd35acf4b4e08ac7031f31badaa20a649495b588e2fc",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:24.3203366Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:c4df3123c9c1c8e718623cd39a7589a473b8a48307745e1a038a2710d4c5f596",
+                "sha256:35ef5b56c99c53fcc85bd2332ea60b3dd6114a5ee3ec8c81ab9acdba23f79f8a",
+                "sha256:bd3020e8d55c76db3940e0aff36e4bbaf74285701a8507ce6e58a364abcf8c8e",
+                "sha256:da238dd9d1f579bf4f3cd6589e3ab75747f8ea35be2bf50403f8f3fafa942eea",
+                "sha256:8a305f523084f0a28b5daf532a5216d9be05d863c6bd3f5bd2969965eb7e9a27",
+                "sha256:c1c1a7d83fb1e16686c4e98df3d6f88b37beb4d65daae1ddd715f95d7ac4db5c"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-bullseye-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d57d932d3ccbea1937f7f53d6d411819420b1b4fe593dd1f4dbfc50302b3aa8f",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff08d266b8fd2358fc78cd35acf4b4e08ac7031f31badaa20a649495b588e2fc",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:24:46.663967Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:d231210f6f9e133f1c30539609f9cb55f15ad23824a9dffe4e24865e026d4ead",
+                "sha256:4e59da99dc2b7fab9a369a4fe9c84c54bfeac6df61a040fdea92e6a7cbefb0f5",
+                "sha256:c305bddebe56aa35c5d9f266b511b77b4f6084e1fffe03fe6f23249c879501b3",
+                "sha256:577c5fe1f5243a6910c54b7b4a338cc9cbae0cfeba74a350b011d2a467e49daf",
+                "sha256:c5c595e4d8c2d2c7ad66ab723b54c73c6a0aa876b01511358ec8af1aed8c8b94",
+                "sha256:a0610bbe9cb80952dba5ef5efb55f03668fd4f8ab63ade3ba30e22a4c03c42da"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-bullseye-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:b9e22d6ca3ee07e02e60c2ad257d3e6acac20bdff8f4fb990d7d6b25d687adbd",
+              "baseImageDigest": "mcr.microsoft.com/mirror/docker/library/buildpack-deps@sha256:ff08d266b8fd2358fc78cd35acf4b4e08ac7031f31badaa20a649495b588e2fc",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:09.1178631Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:f6477acdafee40d2f3aeaf1c8589a74e7356952744e33c140387617c2a5982e9",
+                "sha256:a3cb7f6530835b0c42cd7fd78c2e699493230c520fa47eba6ac442a751cdb737",
+                "sha256:a0bd4d9ee736905c3915c88668d424c84ade42b986de611b4596320ae449c942",
+                "sha256:e1eeecfcb7b2ee9a8806953208440dbffd4b9110e5d2950924c7395e7ea3c070",
+                "sha256:699d9ac7785741df545f96a8744d3a9a5c29f75a171fb8de0a0bae196294ad50",
+                "sha256:a4cd3ad66f7873241881d2ddd4efa6521034245e95e2b0b4a059817345151048"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:522408a80e6077df178c53435912052366902798edb51759a48ca21113004bd0",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-cbl-mariner2.0",
+              "1.22.5-1-cbl-mariner2.0",
+              "1.22.5-cbl-mariner2.0"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-cbl-mariner2.0-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:8fcca67cecdb2122c95bf9ec095308cf76b440f947a741cc3e6a8496d8818137",
+              "baseImageDigest": "mcr.microsoft.com/cbl-mariner/base/core@sha256:2c467e0ec65d452cbd21cfbb5768acdab434e0f89c3ac034c683b2f69b783985",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:43.2427026Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:61e4fd10d6121fc0ab617c05c3b72be0a070e1a348b3eeb2d8c7918b42758f81",
+                "sha256:faffad440d6f318cc434ce13b90f570042c9ff840e62c47d1857c135d8b966c3",
+                "sha256:2cfc97f2c256079c171fe4aa8576ebb3f4b6b50dd5efbf1d9ec5be1a1ab427f2",
+                "sha256:2198f5e753541cd263f84594ddd886cf0586a0447f6590813a35fd69d8da3509",
+                "sha256:d97bf7ca0b44c41054c6595b4e59b362ad7ebb8519a18598e99e0c6082a06248"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-cbl-mariner2.0-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c37cf45a8df4adeae74979f995d1daa9ad0e54418b3934c9628d652ba0d0c2dc",
+              "baseImageDigest": "mcr.microsoft.com/cbl-mariner/base/core@sha256:2c467e0ec65d452cbd21cfbb5768acdab434e0f89c3ac034c683b2f69b783985",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:58.0192606Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:48833be1eac3af6815d1b95b7e0102fad5714cb21452ab0e349cca1c0bf46885",
+                "sha256:4bc3a954b9ebdbbe9bfcc03e8afc05a2c46a5501e247a3d1e23f52f0c217b31c",
+                "sha256:7e4ccd8bbd063abce51b636e8a25a8ed6f6d3163b2dcbda6b1c8c51ea8ffed90",
+                "sha256:1001b1e941a614b6e1af12a163dbfe16fc8d287352d8c08152c54400006eb35c",
+                "sha256:df492779e7cbf64ff3894b6f97cc437ce5a3acfd8a2d5e435cf0b9b4772b8bca"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:b88481fc77fb2cec9bedebc537a167fda98ec9b9afd768024ab64a6e973401e1",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-fips-bookworm",
+              "1.22.5-1-fips-bookworm",
+              "1.22.5-fips-bookworm"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/fips/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-bookworm-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:2599090b4556c82830686ae5dbb281e40ff90c8c38a119465cfeb918c64dd69f",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:cf91c766efd246d348e891d1a38b131624995cc4b24f96373fa1105d6eacc57a",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:46.1323304Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:f2a6608a21f3ebf1579eca4e920d4292bbe2c8b8e85d51c16d42348a1221380b",
+                "sha256:f02e93448e8c48729479dd670b1057481e6772d15489c730ee2a1be016a77630",
+                "sha256:00f5fe009b8e16baa0c21a37b273a2d29bf33c67432f15bce68ba1e0a46f0083",
+                "sha256:3dbed71fc5444cf6889a21b002de3e7805e810aa88f91a9ca941b4e3880246d1",
+                "sha256:58b365fa3e8dc16e70d89fab0e91f5242feb38ae3cfeb6655e654209ea109333",
+                "sha256:e9aef93137af6e967e7242f3b3c8ecd8e6f571d1e6fdd9e72db0befeeae3cf13"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/fips/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-bookworm-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:3c5de468c666b97c9d8495fb2847e9c9f3dd73b0a984d79752d754b9d3e5cd30",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:308c960e34131a3cc5d7266f7a5bd9b05e133718595a8fec3f9655a9944ff991",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:23:55.9054826Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:cc1574688fa9f188655d8593c005adeef03ce4b98fbcfdccfa3ba7ee8a433a39",
+                "sha256:673d75f20e032b81bb46244eb1d7c036e42262d77c31510500c92d6c1b7b9461",
+                "sha256:b7d2a43f04005d051617243ea75f8851331c235c382251668257fca1a072ddcd",
+                "sha256:ce4650a14deed524a46f7f7b410ff5d81e5ff66e51c7345e2b05887b6e3f4030",
+                "sha256:0aa30b2bcbde45c2fc67abf425197af3af3e67d55296f168143343ef1b0e2d3e",
+                "sha256:335f2c484898b910fac13d5650ed3c78e5e673fe8dab1b06a071c71478a153d0"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/fips/bookworm/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-bookworm-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:e9c0798e858f677ebc4e9a7def519bb18b99b969ee6dd5ab8cb20e1472245790",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c15bece3705f7baac31376dd68d5b546e05e5bee1dbbc343d9eac51b35dd3d03",
+              "osType": "Linux",
+              "osVersion": "bookworm",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:00.7380935Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/bookworm/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:34ff8f663ca38857b6e265104c4edaf6afdf7d583a1f633619671ad74d34fb18",
+                "sha256:19875b2ccbf1d3a7b3af769c6c13202c266cb52e0ad4446e4b6feaca077f14de",
+                "sha256:10e2af91b5419c157d0111677b1f7b2ea4e27f11191fdaa5dbff61d42640d25c",
+                "sha256:64a6ab51b82df5ee608db374a16686eefb99bc53834af17064184653121729b3",
+                "sha256:b16610496e73ba3d120d519598b53fa8a2db4c80ccc097a5016ad44aedd0654b",
+                "sha256:0bd1f8180c504ba389021ce74895ed487ccd8c70e2d9af3707934bc801ba28d8"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:fb0d8ad8da71e1da254a5db038f07212d76786d80b158e4e1b74ddb579382d9c",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-fips-bullseye",
+              "1.22.5-1-fips-bullseye",
+              "1.22.5-fips-bullseye"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/fips/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-bullseye-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:5cf6b5d42e105f7052e7a8f71ee563b8af6201f0dba1a9c6a3b09569faef56da",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:fcc745eb25c987047c9bcc6694e747c26d550f6a667558e1e6e87d246e8409ea",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:24.3203366Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:c4df3123c9c1c8e718623cd39a7589a473b8a48307745e1a038a2710d4c5f596",
+                "sha256:35ef5b56c99c53fcc85bd2332ea60b3dd6114a5ee3ec8c81ab9acdba23f79f8a",
+                "sha256:bd3020e8d55c76db3940e0aff36e4bbaf74285701a8507ce6e58a364abcf8c8e",
+                "sha256:da238dd9d1f579bf4f3cd6589e3ab75747f8ea35be2bf50403f8f3fafa942eea",
+                "sha256:8a305f523084f0a28b5daf532a5216d9be05d863c6bd3f5bd2969965eb7e9a27",
+                "sha256:c1c1a7d83fb1e16686c4e98df3d6f88b37beb4d65daae1ddd715f95d7ac4db5c"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/fips/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-bullseye-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:a1703606d00ada9d279a9a6e15e34c498bb382c4c8db06107b4dc90eb22d1674",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d57d932d3ccbea1937f7f53d6d411819420b1b4fe593dd1f4dbfc50302b3aa8f",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm32",
+              "created": "2024-07-06T00:24:46.663967Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:d231210f6f9e133f1c30539609f9cb55f15ad23824a9dffe4e24865e026d4ead",
+                "sha256:4e59da99dc2b7fab9a369a4fe9c84c54bfeac6df61a040fdea92e6a7cbefb0f5",
+                "sha256:c305bddebe56aa35c5d9f266b511b77b4f6084e1fffe03fe6f23249c879501b3",
+                "sha256:577c5fe1f5243a6910c54b7b4a338cc9cbae0cfeba74a350b011d2a467e49daf",
+                "sha256:c5c595e4d8c2d2c7ad66ab723b54c73c6a0aa876b01511358ec8af1aed8c8b94",
+                "sha256:a0610bbe9cb80952dba5ef5efb55f03668fd4f8ab63ade3ba30e22a4c03c42da"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/fips/bullseye/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-bullseye-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:286dd4d46a6af1484cbcba1f074ca581b70240dd85034257c4b3664df1c0b421",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:b9e22d6ca3ee07e02e60c2ad257d3e6acac20bdff8f4fb990d7d6b25d687adbd",
+              "osType": "Linux",
+              "osVersion": "bullseye",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:09.1178631Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/bullseye/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:f6477acdafee40d2f3aeaf1c8589a74e7356952744e33c140387617c2a5982e9",
+                "sha256:a3cb7f6530835b0c42cd7fd78c2e699493230c520fa47eba6ac442a751cdb737",
+                "sha256:a0bd4d9ee736905c3915c88668d424c84ade42b986de611b4596320ae449c942",
+                "sha256:e1eeecfcb7b2ee9a8806953208440dbffd4b9110e5d2950924c7395e7ea3c070",
+                "sha256:699d9ac7785741df545f96a8744d3a9a5c29f75a171fb8de0a0bae196294ad50",
+                "sha256:a4cd3ad66f7873241881d2ddd4efa6521034245e95e2b0b4a059817345151048"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:35cbb48ffa2f9fce7c9ba67d7236db54f2c2b8eba9e9d126535dc2e1c50a2d53",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-fips-cbl-mariner2.0",
+              "1.22.5-1-fips-cbl-mariner2.0",
+              "1.22.5-fips-cbl-mariner2.0"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/fips/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-cbl-mariner2.0-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fe199960c23d9466e91499316f17ecfb68b1fb0bcb6687a24631f00ec11a83d",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:8fcca67cecdb2122c95bf9ec095308cf76b440f947a741cc3e6a8496d8818137",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:27:43.2427026Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:61e4fd10d6121fc0ab617c05c3b72be0a070e1a348b3eeb2d8c7918b42758f81",
+                "sha256:faffad440d6f318cc434ce13b90f570042c9ff840e62c47d1857c135d8b966c3",
+                "sha256:2cfc97f2c256079c171fe4aa8576ebb3f4b6b50dd5efbf1d9ec5be1a1ab427f2",
+                "sha256:2198f5e753541cd263f84594ddd886cf0586a0447f6590813a35fd69d8da3509",
+                "sha256:d97bf7ca0b44c41054c6595b4e59b362ad7ebb8519a18598e99e0c6082a06248"
+              ]
+            },
+            {
+              "dockerfile": "src/microsoft/1.22/fips/cbl-mariner2.0/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-cbl-mariner2.0-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:d9cc84d7e60d95e20371bf49063bc1d490a6a0414a4353ffab837437fbce0cf3",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c37cf45a8df4adeae74979f995d1daa9ad0e54418b3934c9628d652ba0d0c2dc",
+              "osType": "Linux",
+              "osVersion": "cbl-mariner2.0",
+              "architecture": "arm64",
+              "created": "2024-07-06T00:25:58.0192606Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/fips/cbl-mariner2.0/Dockerfile",
+              "layers": [
+                "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
+                "sha256:48833be1eac3af6815d1b95b7e0102fad5714cb21452ab0e349cca1c0bf46885",
+                "sha256:4bc3a954b9ebdbbe9bfcc03e8afc05a2c46a5501e247a3d1e23f52f0c217b31c",
+                "sha256:7e4ccd8bbd063abce51b636e8a25a8ed6f6d3163b2dcbda6b1c8c51ea8ffed90",
+                "sha256:1001b1e941a614b6e1af12a163dbfe16fc8d287352d8c08152c54400006eb35c",
+                "sha256:df492779e7cbf64ff3894b6f97cc437ce5a3acfd8a2d5e435cf0b9b4772b8bca"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:3aced3f44d3a7bcb9b5252debb97da50bf6dcdc8af0e167cf022db0d7ca120b6",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-fips-nanoserver-1809",
+              "1.22.5-1-fips-nanoserver-1809",
+              "1.22.5-fips-nanoserver-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/fips/nanoserver-1809/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-nanoserver-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:e0fd4193a3edf4d93b14b2b651a7591848c3d658233c3d2127b419012d4f142f",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:e07117d78ed8ad2cac78a492a17a79028e24c4c0cd61e09545b9dc26e6c72817",
+              "osType": "Windows",
+              "osVersion": "nanoserver-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:49:44.4223635Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/fips/nanoserver-1809/Dockerfile",
+              "layers": [
+                "sha256:72bc969dbef3d7bf37c0cfc2cda4c17a5c0eea1ccd326f059e09bc1ad0e4c518",
+                "sha256:6429033e1a30758a0fcae7682500199ce4e0cdbcb6b623e5599b6d9e8d0de5ed",
+                "sha256:b5f920f14fd0628fc8d85ee57d390ead2b6b2e58c391235d5c2510f70f7d3e61",
+                "sha256:5bade94b9c3ff848a2f06a78e6434c5d2656391ff67e0d709efc2a5675191d6a",
+                "sha256:c3c72cb7f54bd9e26c82c1162507bc798bdb478c5fddc375a63993197763c53d",
+                "sha256:4e5a0553bc523b51f2dfdb47f3be4aee0013fc9ac90eb133b88ccf213d0aa52a",
+                "sha256:0a01988edbb737e8dbeb85eb68f8bc07bcb4285e3b48634b922d7fba49638020",
+                "sha256:4232b9683b87d3381c74d81cd754e961ced8fe75832eacdfbb0aaa6b83ccf65a",
+                "sha256:194af101ad356786851e86decbdf5578ba939d1e684eda3c1c3d9086931b39fb",
+                "sha256:fb2214f913c93b705adfd4a8888807f071e644bd8c82c69e0f97027585461575",
+                "sha256:4f703ea968d7f7434cf61e5d835cb3c507a6364ff8c7b3b96b73391b22115615"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:43eef9b4f7c132f413b58a7c5ebe99ca41b9e4f1e0a0f527f8815a07fc07a8b5",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-fips-nanoserver-ltsc2022",
+              "1.22.5-1-fips-nanoserver-ltsc2022",
+              "1.22.5-fips-nanoserver-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/fips/nanoserver-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-nanoserver-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:26ea4dbeb2b6298fc6932d2ceae6083b2539679b50c011eeddd63eefbb153770",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:e17db7eeffec668609ca01944723249cfa3b9ff6fc8d671f1c9a0a2ac2aac700",
+              "osType": "Windows",
+              "osVersion": "nanoserver-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:42:26.0330497Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/fips/nanoserver-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:24fb93b4a9e9aa3cd89b0be3bc36f9a2e85519b5ad7a3391f24cefe1a71492b2",
+                "sha256:0dfcaf559a17bafc9be63f5cc7a5545c84fce6246fe88fb0f9624f0ca69e6852",
+                "sha256:7df19e48a67882fc59c285558f35f5d0a006071fdd7159d2b3dff8ce7adffac1",
+                "sha256:a39372813d4bec321ed9d2b2c6e44e6209a3443a8cc3b780d2b9aeb797e70c19",
+                "sha256:54ef1d4a985bc2174d8ce4006af7715fc33c73dbebc12a345b69cd5902e4d45a",
+                "sha256:9df309cf0590a645bd7c9eadbb708f791663a3ff25a0ea1c34d348706059dd32",
+                "sha256:f2accddf39d3fff9051b624bb609408e501359852db1a6ab326ab5a0bcfff0c4",
+                "sha256:5c33e2f044e4864fd7665d8274f59614135883b297e1958cefc3b1d04570de2e",
+                "sha256:13303e24afb24a4c11d4ec392bf08e2579b2722dc3c674c259a72425aee4a9be",
+                "sha256:a71f1e015b5a3fac44ed26f09ef6e4f34d45ebca6a122e3737a34c8291ef19e8",
+                "sha256:a8c295c425a912de308ded279124ae45fec44d55a451843fe5877155417f453c"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:5a6c311b1098e9e05ef519a97e953f60e564cdd9da816c3db8ed69c96b4d52d7",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-fips-windowsservercore-1809",
+              "1.22.5-1-fips-windowsservercore-1809",
+              "1.22.5-fips-windowsservercore-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/fips/windowsservercore-1809/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-windowsservercore-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:ea9fa550f3952e9b6454ee3585b6737704975a0845d6e6bd927838b7e992a385",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:ee16c2a64f3d7771ced60e558082196fda27e5bba0e17c459aa688ef6270ce23",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:49:43.408611Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/fips/windowsservercore-1809/Dockerfile",
+              "layers": [
+                "sha256:778e48beac3c265dc92247b76de5fc6432d488664b9304b6a506078accf371e6",
+                "sha256:7c3fc60bdd89da503f53834fc7f5fd1e4b0d7906632bcb7080ecca1af08d0c07",
+                "sha256:33bd680181ef14424b1fdd55ecabcd604d03d9e4d11913b7669333ec113cfe19",
+                "sha256:14c9f6741d88a3e2c642bb43f00b50d40a872e91b4c6d25b5d4224d7ba14aafd",
+                "sha256:5b8cbb8ebe7488c7c99e8ff147f13012d5c5086bb5f5318b1f7fa1c2dcec23dc",
+                "sha256:a5c7bc1d80aba94c12ba5ebaa6a36de83ab8163a92a7b55aea2bec72b3def8fb",
+                "sha256:4d78d95868c476253348b48a8630f52ac66d9241eeef866fb85be8169c245dd2",
+                "sha256:785630c3bc7cd862cf9f3710cc73bf0305c01509a74722eae198d448cacd4323",
+                "sha256:d0e1d748240012795d0d6423bf7f53b2e19ad2e146f09a6b24b19ced10e2c417",
+                "sha256:4e31b92d7cf7e6244362afbb854085871d9dca0abe9b79cfa84a62e6baddd6ac",
+                "sha256:6578da960da2bb30d6fb09af3335193f62ac17f0e6276a3cda3b647c03f42ac8",
+                "sha256:1b62215584bfb12fff911f7cb53cc966bcdd3189a1faafcc48d58831ce3a3367",
+                "sha256:56a5fd77f8cb6921d3e283f98213bf8c163d3502a75b4a8e4a809a15654f7d1a",
+                "sha256:c9226d61d3bdbf9f09821b32f5878623b8daaa5fb4f875cb63c199f87a26d57e"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:acfd7657e815f6336391575ce36d339cc4fa061e9e36254d103a1cb170566932",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-fips-windowsservercore-ltsc2022",
+              "1.22.5-1-fips-windowsservercore-ltsc2022",
+              "1.22.5-fips-windowsservercore-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/fips/windowsservercore-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-fips-windowsservercore-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c9a48ae6af82e5ff5f6a694c5b92966b1bb2962d3b7ba868132475c3f6217873",
+              "baseImageDigest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c4050cd30a235c987499d225f069fde7a784069807c2fd67380779deb039432c",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:42:25.0381786Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/fips/windowsservercore-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:37e857529f46b2e76a49c77987a24fca4f383f191adf9a4792ac229d959bd4fc",
+                "sha256:90fab16544965657fabb57d55d2fa172cb973f2e78a4fb12e5e885dc253763b9",
+                "sha256:f4c6f3592a288e54ea1cefbddd6581d63cd63956e223119981d9662bc073cca6",
+                "sha256:b06732428fcbb348e0ed135e5220f7fbb79d30b9cb1660bf6215e6780b4488ba",
+                "sha256:5cbc1e53e428d009a1b93df8c7f08960a3a8b543627c9d8ffaad02a87345ab6d",
+                "sha256:1dbd78df0067cfc6702d3174a86c58b18774e18d0b97eb8dfbc6dd45ae231054",
+                "sha256:8dcd43f9362fc3ded9c9f3b78b0d00df08843022661663630247c12683d475e3",
+                "sha256:69b4b071da233ccd31e6bb0b66481005cecc10210e2554defc6dcaf8e863311e",
+                "sha256:b42ce973e39ec3d535ea3e12c88afeaf9a5ea4784eace8c65f3de3557a9df810",
+                "sha256:542e7ea331f50b2b383757d3779809067042d01d2f6440f817748341783931f3",
+                "sha256:d8e5f346fb412523ee95e7b9a373aab719335e51b4bec08bb4549b4e3584de3b",
+                "sha256:067ef37a8423fc5496c464ff5ebc5f84865c1dac38009cd69f117d650f59c723",
+                "sha256:eb373ec9afdfc5f09b9380d981e0c61f9c7b48537b887135c7c66810086e705e",
+                "sha256:7c76e5cf7755ce357ffb737715b0da6799a50ea468cc252c094f4d915d426b3f"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:011651abc64d265698f3ee559f63f4cee2301cd814f802883edc5f136d8f9caf",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-nanoserver-1809",
+              "1.22.5-1-nanoserver-1809",
+              "1.22.5-nanoserver-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/nanoserver-1809/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-nanoserver-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:e07117d78ed8ad2cac78a492a17a79028e24c4c0cd61e09545b9dc26e6c72817",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:f31fa317b1851ae16ffdb87450e5e51b61e186f898b949cea32d77e1c8b638a3",
+              "osType": "Windows",
+              "osVersion": "nanoserver-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:49:42.1927675Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/nanoserver-1809/Dockerfile",
+              "layers": [
+                "sha256:6429033e1a30758a0fcae7682500199ce4e0cdbcb6b623e5599b6d9e8d0de5ed",
+                "sha256:b5f920f14fd0628fc8d85ee57d390ead2b6b2e58c391235d5c2510f70f7d3e61",
+                "sha256:5bade94b9c3ff848a2f06a78e6434c5d2656391ff67e0d709efc2a5675191d6a",
+                "sha256:c3c72cb7f54bd9e26c82c1162507bc798bdb478c5fddc375a63993197763c53d",
+                "sha256:4e5a0553bc523b51f2dfdb47f3be4aee0013fc9ac90eb133b88ccf213d0aa52a",
+                "sha256:0a01988edbb737e8dbeb85eb68f8bc07bcb4285e3b48634b922d7fba49638020",
+                "sha256:4232b9683b87d3381c74d81cd754e961ced8fe75832eacdfbb0aaa6b83ccf65a",
+                "sha256:194af101ad356786851e86decbdf5578ba939d1e684eda3c1c3d9086931b39fb",
+                "sha256:fb2214f913c93b705adfd4a8888807f071e644bd8c82c69e0f97027585461575",
+                "sha256:4f703ea968d7f7434cf61e5d835cb3c507a6364ff8c7b3b96b73391b22115615"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:4da943d7fefc478712ae6796dfc25feb07d59901ed73bc63cea5f10f0ff65308",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-nanoserver-ltsc2022",
+              "1.22.5-1-nanoserver-ltsc2022",
+              "1.22.5-nanoserver-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/nanoserver-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-nanoserver-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:e17db7eeffec668609ca01944723249cfa3b9ff6fc8d671f1c9a0a2ac2aac700",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:31c8aa02d47af7d65c11da9c3a279c8407c32afd3fc6bec2e9a544db8e3715b3",
+              "osType": "Windows",
+              "osVersion": "nanoserver-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:42:23.7702206Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/nanoserver-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:0dfcaf559a17bafc9be63f5cc7a5545c84fce6246fe88fb0f9624f0ca69e6852",
+                "sha256:7df19e48a67882fc59c285558f35f5d0a006071fdd7159d2b3dff8ce7adffac1",
+                "sha256:a39372813d4bec321ed9d2b2c6e44e6209a3443a8cc3b780d2b9aeb797e70c19",
+                "sha256:54ef1d4a985bc2174d8ce4006af7715fc33c73dbebc12a345b69cd5902e4d45a",
+                "sha256:9df309cf0590a645bd7c9eadbb708f791663a3ff25a0ea1c34d348706059dd32",
+                "sha256:f2accddf39d3fff9051b624bb609408e501359852db1a6ab326ab5a0bcfff0c4",
+                "sha256:5c33e2f044e4864fd7665d8274f59614135883b297e1958cefc3b1d04570de2e",
+                "sha256:13303e24afb24a4c11d4ec392bf08e2579b2722dc3c674c259a72425aee4a9be",
+                "sha256:a71f1e015b5a3fac44ed26f09ef6e4f34d45ebca6a122e3737a34c8291ef19e8",
+                "sha256:a8c295c425a912de308ded279124ae45fec44d55a451843fe5877155417f453c"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:97150634ce6cb3a9893f31780d9da52435cac23f0b09f6152f5fd211c80b334e",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-windowsservercore-1809",
+              "1.22.5-1-windowsservercore-1809",
+              "1.22.5-windowsservercore-1809"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/windowsservercore-1809/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-windowsservercore-1809-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:ee16c2a64f3d7771ced60e558082196fda27e5bba0e17c459aa688ef6270ce23",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:0d52390e8497ea6238500afbf60054bd731b12818e6440d31fe6ff4e2eefc5ad",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-1809",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:47:15.0691692Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/windowsservercore-1809/Dockerfile",
+              "layers": [
+                "sha256:7c3fc60bdd89da503f53834fc7f5fd1e4b0d7906632bcb7080ecca1af08d0c07",
+                "sha256:33bd680181ef14424b1fdd55ecabcd604d03d9e4d11913b7669333ec113cfe19",
+                "sha256:14c9f6741d88a3e2c642bb43f00b50d40a872e91b4c6d25b5d4224d7ba14aafd",
+                "sha256:5b8cbb8ebe7488c7c99e8ff147f13012d5c5086bb5f5318b1f7fa1c2dcec23dc",
+                "sha256:a5c7bc1d80aba94c12ba5ebaa6a36de83ab8163a92a7b55aea2bec72b3def8fb",
+                "sha256:4d78d95868c476253348b48a8630f52ac66d9241eeef866fb85be8169c245dd2",
+                "sha256:785630c3bc7cd862cf9f3710cc73bf0305c01509a74722eae198d448cacd4323",
+                "sha256:d0e1d748240012795d0d6423bf7f53b2e19ad2e146f09a6b24b19ced10e2c417",
+                "sha256:4e31b92d7cf7e6244362afbb854085871d9dca0abe9b79cfa84a62e6baddd6ac",
+                "sha256:6578da960da2bb30d6fb09af3335193f62ac17f0e6276a3cda3b647c03f42ac8",
+                "sha256:1b62215584bfb12fff911f7cb53cc966bcdd3189a1faafcc48d58831ce3a3367",
+                "sha256:56a5fd77f8cb6921d3e283f98213bf8c163d3502a75b4a8e4a809a15654f7d1a",
+                "sha256:c9226d61d3bdbf9f09821b32f5878623b8daaa5fb4f875cb63c199f87a26d57e"
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "1.22",
+          "manifest": {
+            "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:6f44812bf5e47f20e490da2bc8d0006733203e43bc9c1b6d34b106e359f668a7",
+            "created": "2024-07-06T01:22:51.9403909Z",
+            "sharedTags": [
+              "1.22-windowsservercore-ltsc2022",
+              "1.22.5-1-windowsservercore-ltsc2022",
+              "1.22.5-windowsservercore-ltsc2022"
+            ]
+          },
+          "platforms": [
+            {
+              "dockerfile": "src/microsoft/1.22/windows/windowsservercore-ltsc2022/Dockerfile",
+              "simpleTags": [
+                "1.22.5-1-windowsservercore-ltsc2022-amd64"
+              ],
+              "digest": "mcr.microsoft.com/oss/go/microsoft/golang@sha256:c4050cd30a235c987499d225f069fde7a784069807c2fd67380779deb039432c",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:92c6ddbf87a6d6696a83f26e3df912983477844e22dd686c3e82bac4cf5b49c2",
+              "osType": "Windows",
+              "osVersion": "windowsservercore-ltsc2022",
+              "architecture": "amd64",
+              "created": "2024-07-06T00:39:45.9646639Z",
+              "commitUrl": "https://github.com/microsoft/go/blob/a0c1174d55fc679b565f45dabe7be182fabd8254/src/microsoft/1.22/windows/windowsservercore-ltsc2022/Dockerfile",
+              "layers": [
+                "sha256:90fab16544965657fabb57d55d2fa172cb973f2e78a4fb12e5e885dc253763b9",
+                "sha256:f4c6f3592a288e54ea1cefbddd6581d63cd63956e223119981d9662bc073cca6",
+                "sha256:b06732428fcbb348e0ed135e5220f7fbb79d30b9cb1660bf6215e6780b4488ba",
+                "sha256:5cbc1e53e428d009a1b93df8c7f08960a3a8b543627c9d8ffaad02a87345ab6d",
+                "sha256:1dbd78df0067cfc6702d3174a86c58b18774e18d0b97eb8dfbc6dd45ae231054",
+                "sha256:8dcd43f9362fc3ded9c9f3b78b0d00df08843022661663630247c12683d475e3",
+                "sha256:69b4b071da233ccd31e6bb0b66481005cecc10210e2554defc6dcaf8e863311e",
+                "sha256:b42ce973e39ec3d535ea3e12c88afeaf9a5ea4784eace8c65f3de3557a9df810",
+                "sha256:542e7ea331f50b2b383757d3779809067042d01d2f6440f817748341783931f3",
+                "sha256:d8e5f346fb412523ee95e7b9a373aab719335e51b4bec08bb4549b4e3584de3b",
+                "sha256:067ef37a8423fc5496c464ff5ebc5f84865c1dac38009cd69f117d650f59c723",
+                "sha256:eb373ec9afdfc5f09b9380d981e0c61f9c7b48537b887135c7c66810086e705e",
+                "sha256:7c76e5cf7755ce357ffb737715b0da6799a50ea468cc252c094f4d915d426b3f"
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
* See https://github.com/dotnet/versions/pull/987
* For https://github.com/microsoft/go/issues/157

It turns out that `"repos": []` isn't enough to seed the file, and we got this error in a build:

```
-- Calculating new image info content
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.InvalidOperationException: Removal of out-of-date content resulted in there being no content remaining in the target image info file. Something is probably wrong with the logic.
...
```

(From [PublishImageInfoCommand.cs#L217-L221](https://github.com/dotnet/docker-tools/blob/78d1b28945c95cfaea6cd01b6333500939fab552/src/Microsoft.DotNet.ImageBuilder/src/Commands/PublishImageInfoCommand.cs#L217-L221))

This PR adds the full file generated by [the build that hit that exception](https://dev.azure.com/dnceng/internal/_build/results?buildId=2489359&view=results) as the seed, instead.

@gdams 

/cc @mthalman @lbussell 

(Please merge upon approval--I don't have merge permissions. Thanks!)