### PR TITLE
Update dotnet-buildtools-prereqs-docker manually

### DIFF
--- a/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
+++ b/build-info/docker/image-info.dotnet-dotnet-buildtools-prereqs-docker-main.json
@@ -11,29 +11,29 @@
               "simpleTags": [
                 "almalinux-10-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c2e2ae02c3b38fd19187e747ff43abdf446fa10e3d92938cf88994829be5fb6f",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:966597a050413765e94075879440a64433cf0b46dc4c49b6151282219891f539",
               "baseImageDigest": "library/almalinux@sha256:cc24bc5b6ac7e284f2f62a07bdaa1b15d3319fdcf46413c6b8fe9fa245068ddd",
               "osType": "Linux",
               "osVersion": "almalinux10",
               "architecture": "amd64",
-              "created": "2026-06-03T00:53:55.6130934Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/927007b34ba42fe60ac16e8ecb8eba6b8403b2d8/src/almalinux/10/helix/amd64/Dockerfile",
+              "created": "2026-06-24T20:28:12.2348617Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/almalinux/10/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:1cb1346165ca378b0c485a3a622327af032daabd171108ab6f2d47351abb63bc",
-                  "size": 21413317
+                  "digest": "sha256:d00f09f073d463c7703fffcc4cd9564c847a3371c717825e298a57ecc1633d07",
+                  "size": 21432209
                 },
                 {
-                  "digest": "sha256:7a87a484fb53656ee5fb7941442490272248e14d2f70dc2af352596f555556c3",
-                  "size": 4013960
+                  "digest": "sha256:53dc994cabaea774aa79e23ac8af8171c830b22b5316237ba79daee70f12cfc4",
+                  "size": 4013950
                 },
                 {
-                  "digest": "sha256:f04b82dc84ecc2a75b36e7da148c121b7c33e7a1e009206bf3a63c663624a584",
-                  "size": 1388
+                  "digest": "sha256:7be4fd99f840349895cf255b967f3762b246f13c0936e506da1743507dc8eb5f",
+                  "size": 1390
                 },
                 {
-                  "digest": "sha256:a2b48aa2897045cc626ce767078646798478a8d8b644097e5aa6b6bac7f4ca43",
-                  "size": 29829485
+                  "digest": "sha256:fac94aeb7f92a7f75837a2f947b5d4f3450ece9626936568296558c423d0e43c",
+                  "size": 40553267
                 },
                 {
                   "digest": "sha256:4224950577242fb7ff1faf31d7a6c1520d455ab1a1eecff8aed5766688091539",
@@ -69,100 +69,33 @@
         {
           "platforms": [
             {
-              "dockerfile": "src/almalinux/8/helix/amd64/Dockerfile",
-              "simpleTags": [
-                "almalinux-8-helix-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:10efa2f9ce0dd7f533ccfa73b1544a41bf2cc90088d0d1ce084a10fe74b194f8",
-              "baseImageDigest": "library/almalinux@sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb",
-              "osType": "Linux",
-              "osVersion": "almalinux8",
-              "architecture": "amd64",
-              "created": "2026-06-03T00:53:49.2503844Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/927007b34ba42fe60ac16e8ecb8eba6b8403b2d8/src/almalinux/8/helix/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:02ecd194e6f9053c11765ac0eca224196196831ef6a00ba94a01352cfc8ea121",
-                  "size": 34321453
-                },
-                {
-                  "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
-                  "size": 32
-                },
-                {
-                  "digest": "sha256:a3dbe8b3e7da41254f251871c2298d8c7de5551d02e1483e87b8867c4ca2e547",
-                  "size": 1357
-                },
-                {
-                  "digest": "sha256:01c8d194fbeb0790eddc271160353b6b7b028aa43dc218745e23b711db3e43e7",
-                  "size": 452
-                },
-                {
-                  "digest": "sha256:5d5065b42271f430dc571cbbce5b2b4420d07e751f8158d7f35cf76aa08caa79",
-                  "size": 39547942
-                },
-                {
-                  "digest": "sha256:a0ca16fa6f59daa991d1f4bac1474eee6feecd5a9d67c587c38ec0b4bd0f853f",
-                  "size": 72732747
-                }
-              ]
-            },
-            {
-              "dockerfile": "src/almalinux/8/source-build/amd64/Dockerfile",
-              "simpleTags": [
-                "almalinux-8-source-build",
-                "almalinux-8-source-build-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b2af10d9a9cebbd2136f0bf9692a78548f9e8813e401e0c3fbfa7b0e72f6251a",
-              "baseImageDigest": "library/almalinux@sha256:4a87d2615a770506e204c27d6248ac97f4df67f4e41e2e9c47c81f0ed0be98cb",
-              "osType": "Linux",
-              "osVersion": "almalinux8",
-              "architecture": "amd64",
-              "created": "2026-06-03T00:54:57.4653979Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cd5477b071518e27e5d8155f1ef606f341311484/src/almalinux/8/source-build/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:b62d48f67442b9e96dff3e277349a74231e1c43b207ffbb28ea71ffa7cbe00b5",
-                  "size": 627560537
-                },
-                {
-                  "digest": "sha256:a0ca16fa6f59daa991d1f4bac1474eee6feecd5a9d67c587c38ec0b4bd0f853f",
-                  "size": 72732747
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
               "dockerfile": "src/almalinux/9/helix/amd64/Dockerfile",
               "simpleTags": [
                 "almalinux-9-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:868d384cd8ad8d4546964a7352c6970f98c5b2c681b7b21021a954e0f234e9f8",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:30b17e02a0c7ab32a1aadd36d3e06c498a3d2cf2700e5f2af3475f38ae511b6f",
               "baseImageDigest": "library/almalinux@sha256:d2515c769e7b73f95c4fde38c0a505336ff38f14990c0b7253b77060a049a743",
               "osType": "Linux",
               "osVersion": "almalinux9",
               "architecture": "amd64",
-              "created": "2026-06-03T00:55:02.230009Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/almalinux/9/helix/amd64/Dockerfile",
+              "created": "2026-06-24T20:30:48.9030287Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/almalinux/9/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:e2e7e029104f5de6437734664b3741a5797ebf33bb1063800415fc10530e7b7a",
-                  "size": 18009807
+                  "digest": "sha256:ef2b021d02c535bbd28b2efd63f6671821527157628c0510d38945d521427e1b",
+                  "size": 18021305
                 },
                 {
-                  "digest": "sha256:772471e0be1465d825e435d7091c4b5067f6e4bdf4bd44837ed6738f5707a386",
-                  "size": 7646896
+                  "digest": "sha256:a78e8e53f4ecc1465503efcf475a88c45e6c0df4d3f83e89ed8a8865f89ab63a",
+                  "size": 7566723
                 },
                 {
-                  "digest": "sha256:99497b0d51290959c360a096f380cae4908ddf4e2ba3090f13893f751626ed41",
-                  "size": 1375
+                  "digest": "sha256:4a56a4b82efe2327b86598c33b1bfd7da0583572b68ae689be8bf2217f224646",
+                  "size": 1380
                 },
                 {
-                  "digest": "sha256:8ee43e8fe7e1cc23ce62130138c25c61df325e61e142579ab6e3e60fc5b76486",
-                  "size": 41273538
+                  "digest": "sha256:d0220526df31e7654427ebabd5468221791f5dfcd3195678bdd9dd7faf7b4116",
+                  "size": 42676723
                 },
                 {
                   "digest": "sha256:ef088ccc1026df79c46e07a07d9f45689603b478d1208aeb7f870476d07e0bad",
@@ -202,29 +135,68 @@
               "simpleTags": [
                 "alpine-3.23-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e2d14416a6640c78f480a4605a56515ea04a9dc877e22434aed97b8f3f1920ef",
-              "baseImageDigest": "amd64/alpine@sha256:25735e5ed514a296d2c8d52d458c2f74b081169d8848f0614b4fa24a3aefc843",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:7edc9226af8c18c5e5bbf88aeadd4aba8872b39079bdbb32409fd991e6baf985",
+              "baseImageDigest": "amd64/alpine@sha256:f834b19149456f530d448cd8942f2c8b66e240976fd1397113ae542fa8cabf06",
               "osType": "Linux",
               "osVersion": "alpine3.23",
               "architecture": "amd64",
-              "created": "2026-06-01T07:52:44.1466415Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4616ef5dd1cc16c2c932d38b14bac303e1e2d32a/src/alpine/3.23/amd64/Dockerfile",
+              "created": "2026-06-24T18:50:58.1028514Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.23/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:80490661efc6f49da4a389d0b6b20c03833c758b4ec6599b0ac097c527adeee1",
-                  "size": 171748827
+                  "digest": "sha256:3a83fd5e081cad4075d8f2854d826358826d2fd51cea665878cc19b0b7a7fe5a",
+                  "size": 167969774
                 },
                 {
-                  "digest": "sha256:2c39323c4e4a845697a66b5fab132ddcab5cd4549265c12d0720dcbbc571cec0",
-                  "size": 80422771
+                  "digest": "sha256:07cc9ebf9244193262737caa5c16a002ab9118b9eb2c2083f856a0951578ed59",
+                  "size": 80241545
                 },
                 {
-                  "digest": "sha256:d43190afe1217d083015296872c1a7cf3a650db492bc622455becb5fa8a8dfef",
-                  "size": 468356919
+                  "digest": "sha256:90889fd0d2d8cf391bf6e94548e9fa4d253661bb617df6e5ee1d222d70ba700f",
+                  "size": 468272275
                 },
                 {
-                  "digest": "sha256:6a0ac1617861a677b045b7ff88545213ec31c0ff08763195a70a4a5adda577bb",
-                  "size": 3864189
+                  "digest": "sha256:e6f31ffc071e5560b82a8685fba8214954e5721e3e49269d00958316edbe89fe",
+                  "size": 3844421
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.23/helix/Dockerfile",
+              "simpleTags": [
+                "alpine-3.23-helix-amd64"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:0d36ba3486dec6f44fe62b28e7f7e7688a1cc66021068457edbdcbe9b0524e3c",
+              "baseImageDigest": "library/alpine@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40",
+              "osType": "Linux",
+              "osVersion": "alpine3.23",
+              "architecture": "amd64",
+              "created": "2026-06-24T17:50:23.8536613Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.23/helix/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:da73e7056329ec5b098ca6c395de22a636436a7fb7fc5ccbaaa2aac5e37e5af8",
+                  "size": 21569660
+                },
+                {
+                  "digest": "sha256:cc2a3aeed4399b3022f48c4954f179005e73cdb6d23f9b47c119416862f86ca7",
+                  "size": 3932379
+                },
+                {
+                  "digest": "sha256:5b4b7409702d9e2df41676d6a21cd9e5ede4f9c3aee4418cd2d112da87182572",
+                  "size": 1055
+                },
+                {
+                  "digest": "sha256:d487d2701dfef1a92f3ab54584d1a51c4f8b2bb06bd7ea941a0f845b8cc59f33",
+                  "size": 223903427
+                },
+                {
+                  "digest": "sha256:e6f31ffc071e5560b82a8685fba8214954e5721e3e49269d00958316edbe89fe",
+                  "size": 3844421
                 }
               ]
             }
@@ -237,33 +209,33 @@
               "simpleTags": [
                 "alpine-3.23-helix-arm32v7"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4e30dd15e88a73f6532dab12c60c47d3e0756c128620de8439c9b6f4bec947e4",
-              "baseImageDigest": "library/alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d72e3eec2c525b55398fac0bcc8c72ecd97d9e8897d7783b89f09369e37a859a",
+              "baseImageDigest": "library/alpine@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40",
               "osType": "Linux",
               "osVersion": "alpine3.23",
               "architecture": "arm32",
-              "created": "2026-06-01T05:16:06.707122Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d0042b1524388ae51ef83745602357e07050a1df/src/alpine/3.23/helix/Dockerfile",
+              "created": "2026-06-24T16:53:25.2607114Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.23/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:87bba73ccd00628d225d711f50f7c0da4d4da8cb9147f5a727d98bed809fb372",
-                  "size": 17965838
+                  "digest": "sha256:f8ab1ab5b683f4eac7bfea51e00b62a5d6cece6c88c0aed6eaa62e31bdd84b46",
+                  "size": 17953272
                 },
                 {
-                  "digest": "sha256:f9af4e993949084f73f40e3c2acfe7d68e45a3bf9a8b8280ac1a82953d28812f",
-                  "size": 3931727
+                  "digest": "sha256:10938d8f8fd639ccb61ded9276c30ab396639ef89fcf0af7e1b6196c522f0154",
+                  "size": 3931679
                 },
                 {
-                  "digest": "sha256:ae72d87e1816a0bd60ecdc7995de122030619345f66dba5eab6aee255263a73e",
+                  "digest": "sha256:02dc2aafa2e244e75fe41f659dae80e3aa1983a0cc7e67d1815d6bf8a0b7cbba",
                   "size": 1054
                 },
                 {
-                  "digest": "sha256:56499ddf054defdaf28780c0e97f09bade652e47bf7b7024b556cb0eb85eabd9",
-                  "size": 202871288
+                  "digest": "sha256:aed79e601c2a3d195a6116ae5c9bfdefbb782ced3a4024f0eda5ccf61751aee9",
+                  "size": 202868405
                 },
                 {
-                  "digest": "sha256:c160e404c59d6d30c66a0d74bbd17337f178f5d898a9908e18c71ce3bbe28c99",
-                  "size": 3283123
+                  "digest": "sha256:177f8e1e6f831989320cf2b59b7eabd21cbf36804c79506912f3a81caff426f2",
+                  "size": 3261854
                 }
               ]
             }
@@ -276,33 +248,489 @@
               "simpleTags": [
                 "alpine-3.23-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:33d25e02f1ffcdbb2a9912ca04feea1f7248686326b4d123d80f09e38650a2fe",
-              "baseImageDigest": "library/alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6792a2200f6e2b0d7f79af582f8b4d0780c92e0a8bb6ecefadaa5459017dd135",
+              "baseImageDigest": "library/alpine@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40",
               "osType": "Linux",
               "osVersion": "alpine3.23",
               "architecture": "arm64",
-              "created": "2026-06-01T05:15:38.7001197Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d0042b1524388ae51ef83745602357e07050a1df/src/alpine/3.23/helix/Dockerfile",
+              "created": "2026-06-24T16:52:40.6062806Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.23/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:01779a5a89e5fef8fb834bb797f602c002bf7c3d305d9662793ce6e9137e7e2f",
-                  "size": 21449732
+                  "digest": "sha256:abecf087698e47a180ca03634b53f14cd23dfcbb01f604dff66dc80332519697",
+                  "size": 21463399
                 },
                 {
-                  "digest": "sha256:7f1fbf6006dbce126b9a75919982d51d93503e9b68450b36d89f2b25cf082060",
-                  "size": 3931792
+                  "digest": "sha256:152b38dbfc74d35a44470ae1d8f920c3d255d8762d13d22b1a5a78e02d7f996b",
+                  "size": 3931670
                 },
                 {
-                  "digest": "sha256:926035638372b9cb766021225d58a4e9a3316e8b391a938dfa3d1ccd2e430d55",
+                  "digest": "sha256:dd8a1429f98ed038c48498e9871a6494731fd3951261b125838bd0df1048f037",
+                  "size": 1053
+                },
+                {
+                  "digest": "sha256:94939dfd487ec5ace7d0a1fd3f0dc5e6e5bc67e9e7f2c9ea9391e9abcf1c939b",
+                  "size": 216385034
+                },
+                {
+                  "digest": "sha256:14a4754c352fba4c6c0da8e4f01bb990463c19f7ff63e090073c385bd2bc5046",
+                  "size": 4181860
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.24/amd64/Dockerfile",
+              "simpleTags": [
+                "alpine-3.24-amd64"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b10bded0baa0a8aa42ef0ff803c718752abc719c9f25328dab394cc8028e94ca",
+              "baseImageDigest": "amd64/alpine@sha256:a0a65670a97d4d6ffc87eed1175c9c7d699813489e0913d96c7b917d7b51e456",
+              "osType": "Linux",
+              "osVersion": "alpine3.24",
+              "architecture": "amd64",
+              "created": "2026-06-24T19:09:13.2162824Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.24/amd64/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:416d4e6dd257cd9ea1534065a25d7408c859bff062cf435d87291f42a1f8c94b",
+                  "size": 173638690
+                },
+                {
+                  "digest": "sha256:b31a149c47a29279719fc93fc87cf0882c049383cc56428f8b0dec24fad6e74f",
+                  "size": 80221045
+                },
+                {
+                  "digest": "sha256:6467649dfac55430cd06396448effd030b7581fb610fa27e30cb159898e97d56",
+                  "size": 498839419
+                },
+                {
+                  "digest": "sha256:55afa1ecc21d2bb5e5045f32dafee56272ffd89860bac26f6c32123439af26a4",
+                  "size": 3846391
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.24/helix/Dockerfile",
+              "simpleTags": [
+                "alpine-3.24-helix-amd64"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:98071fda069a2c23198e138f32b096d14074092f1c130477ce3c0ad83786de1c",
+              "baseImageDigest": "library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
+              "osType": "Linux",
+              "osVersion": "alpine3.24",
+              "architecture": "amd64",
+              "created": "2026-06-24T20:23:54.9934047Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.24/helix/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:2954adecfe44e083f350f726236b6b6f6f5d48a61728c34ed4708c67e13d0bed",
+                  "size": 22132935
+                },
+                {
+                  "digest": "sha256:33380b83d3ce4793164e55865259c14955fac0a2d97806dcdbf5e1f6c37b47bd",
+                  "size": 3927908
+                },
+                {
+                  "digest": "sha256:19f5d273d65e4f061fc3856031441f3718e81fd51f923c9a3889136c37fa600e",
+                  "size": 1051
+                },
+                {
+                  "digest": "sha256:147fbc641f7b19834d51445661819ea5acbaa1f355f3ec824d2e67e565fc8ac5",
+                  "size": 270494644
+                },
+                {
+                  "digest": "sha256:55afa1ecc21d2bb5e5045f32dafee56272ffd89860bac26f6c32123439af26a4",
+                  "size": 3846391
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.24/helix/Dockerfile",
+              "simpleTags": [
+                "alpine-3.24-helix-arm32v7"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a9b4b8ad8f21ddb158c3d98a3cfc112ec3c9a3d9522f7dc62825f9208c9d6099",
+              "baseImageDigest": "library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
+              "osType": "Linux",
+              "osVersion": "alpine3.24",
+              "architecture": "arm32",
+              "created": "2026-06-24T16:53:19.535904Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.24/helix/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:5961d44a4ecd69f9c2392d37aeb0549d490f8eb0b017c6aac2ad084a64721712",
+                  "size": 18500142
+                },
+                {
+                  "digest": "sha256:a1bc6fa0f15ca481d99c184a4aa04bf831bdc4ede25d08c596cb729b66ba1cbe",
+                  "size": 3931758
+                },
+                {
+                  "digest": "sha256:bb516bed90aa66dcde146a2b7c4c7493e56db0ac6825e41477e5d6d0554fa189",
                   "size": 1052
                 },
                 {
-                  "digest": "sha256:6d932864d1d182033359e5897594ee3278a67cffa41c4ed31fdf5623f0119fdc",
-                  "size": 216384622
+                  "digest": "sha256:171e7c2e8a506dc6a7bb7d03c3a13819b1afdacae68ac4b26ead54ada66afd01",
+                  "size": 247209370
                 },
                 {
-                  "digest": "sha256:d17f077ada118cc762df373ff803592abf2dfa3ddafaa7381e364dd27a88fca7",
-                  "size": 4199870
+                  "digest": "sha256:bc03a9e5b4dd452551f246e199537fe7afc1765f53f510bc81d26df9845e4008",
+                  "size": 3260615
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "10.0",
+          "platforms": [
+            {
+              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "simpleTags": [
+                "azurelinux-3.0-net10.0-source-build-test-amd64"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4b39e87a2001f59fcb7bb89f936a837051875d390bbc1069954732716cc9071a",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:ac4dfce5dbf3292de2c56ba80fd27377c91b583e7a1bf57bb72ff3e78eacaa7b",
+              "osType": "Linux",
+              "osVersion": "azurelinux3.0",
+              "architecture": "amd64",
+              "created": "2026-06-24T18:17:19.608286Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:3089360c179bc5407086322bf9765b6d5300ef093bcd0e5ae140f226e52dc599",
+                  "size": 231
+                },
+                {
+                  "digest": "sha256:ded9a572bd74bf7474768806b4fedb63f68c1cb298b35efb6b1d1a48ab0495bd",
+                  "size": 236
+                },
+                {
+                  "digest": "sha256:d3f5237762b2ad67a59fe80fd658cb4e7007c09ee8c19ec81d1a396b23b48dd8",
+                  "size": 31099321
+                },
+                {
+                  "digest": "sha256:cc75a28430e9a95d8d487de0930a44de296a9f125243433ad0cc97bbbb92e788",
+                  "size": 153955348
+                },
+                {
+                  "digest": "sha256:1ec20e7c6b132dbc558c5ce54903849c5f5bc4aa27db308f9e1f24ade4d587d7",
+                  "size": 18046079
+                },
+                {
+                  "digest": "sha256:3e86d40f5752b57c22063866e0f0e2b39b5aa402f1728d76a210ed28b0f64e5f",
+                  "size": 507
+                },
+                {
+                  "digest": "sha256:6110f50f0caa5f5da1b6403a8ce72055e99c3efd8bb1f98f0f308c44abd883fb",
+                  "size": 184606454
+                },
+                {
+                  "digest": "sha256:827f419704356e4d51c94447e39e9f138b391ad5ff99b8abc7c34ce3b018a232",
+                  "size": 42234754
+                },
+                {
+                  "digest": "sha256:05673ef141a445a71ffb90da31aa6eef909c76acc832ce0ca45b0ce8d11c60c3",
+                  "size": 12714979
+                },
+                {
+                  "digest": "sha256:d8a34f2778919f00fc240e9228d0b0460dc15448f8424875ae1b1baea43933f1",
+                  "size": 164
+                },
+                {
+                  "digest": "sha256:48c5b435b8eaa3a0953fe9eee0573026b7b87d2e858017ba5acbca00c867c17b",
+                  "size": 36583328
+                },
+                {
+                  "digest": "sha256:7de2c0d94b6ec885a6ac0ba246ce1bb5090196ee2b90694ebe4ca1d45b7a2519",
+                  "size": 756271
+                },
+                {
+                  "digest": "sha256:a0d7289fba340a34346c1b13f4968c585341b997abb1931253abe6e3998cfe9e",
+                  "size": 18220205
+                },
+                {
+                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
+                  "size": 31729766
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "11.0",
+          "platforms": [
+            {
+              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "simpleTags": [
+                "azurelinux-3.0-net11.0-source-build-test-amd64"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:de1bacd6233b5b37e8aa74fc66ae3c73cfd06122eb852bc60b31721132fea752",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:514d4ebd99f7114e1d15da949a7b736c9f2041762a920a5f9ca469e07b27984a",
+              "osType": "Linux",
+              "osVersion": "azurelinux3.0",
+              "architecture": "amd64",
+              "created": "2026-06-24T18:20:08.7685063Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:b43ef32c5d9fcb61e080a6b8a18111152c10e6526c82c489a4ba593c50b50eb9",
+                  "size": 232
+                },
+                {
+                  "digest": "sha256:659a38b905f7fd0698230c1ae5fe60d827ac4cce0a90d40b9dd142a4beeda795",
+                  "size": 237
+                },
+                {
+                  "digest": "sha256:f3359e97d538ab494d86bcf689b8ac1517f2415ef58987c44e0ae3bc84487e25",
+                  "size": 31099375
+                },
+                {
+                  "digest": "sha256:496a397d9e4aa2cc2addda95150486630701a277d33043c89c618985bd24a065",
+                  "size": 153953988
+                },
+                {
+                  "digest": "sha256:36a850f10f6b00233401378c996bc3a4138e4352ebc5e062ba3d28f60c93d389",
+                  "size": 18229147
+                },
+                {
+                  "digest": "sha256:cffc5533515feaa9397a17a0e91421d26eb249a5af1f0fcb766cbb5c17f8277c",
+                  "size": 758
+                },
+                {
+                  "digest": "sha256:4796f9fadb1d6871185cd886736ab1d1e3c3c2935476b3f37b41760c2bcef72b",
+                  "size": 143123225
+                },
+                {
+                  "digest": "sha256:945c63a4cf5fc5e8da67442f4614a37970935fd2c5605f061e999e6bd1fba1eb",
+                  "size": 42234674
+                },
+                {
+                  "digest": "sha256:389e65dedbd4fc2dac57aa81b8aba0a54acf52c49b1bc85b794ed0934f3ea7ec",
+                  "size": 12486194
+                },
+                {
+                  "digest": "sha256:013d9225a7225b90019fa2a5daf265b21932bea6ae35eb7f1e823d40b30f9de1",
+                  "size": 164
+                },
+                {
+                  "digest": "sha256:2e4934596bf9cc3000959518319ed1410802a2e67b232ccf3cb38130f06260c0",
+                  "size": 37500673
+                },
+                {
+                  "digest": "sha256:c92a669608b04236be4b103a6fbe2d6f46b590964b5bd1b13566a9d9d3676a40",
+                  "size": 756256
+                },
+                {
+                  "digest": "sha256:1d7bd9697b34b107becac9e2da93ee0b1b1d4e85adbd9bf261e2b71c5e0d92d0",
+                  "size": 18220094
+                },
+                {
+                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
+                  "size": 31729766
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "8.0",
+          "platforms": [
+            {
+              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "simpleTags": [
+                "azurelinux-3.0-net8.0-source-build-test-amd64"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a6ad049bad5ebf17dc79cd7663fe57ef5594b7825add9acb674c93d66538df7b",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:a596cf7ff2d0c73f7badf6df8f346790debade40b8d87791297f7f64153d2aca",
+              "osType": "Linux",
+              "osVersion": "azurelinux3.0",
+              "architecture": "amd64",
+              "created": "2026-06-24T18:11:41.7474435Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:d16bb65508ca50173bab82536785f81617a81137dd785e3a76b637d46e1f5e03",
+                  "size": 232
+                },
+                {
+                  "digest": "sha256:4400b08b80c5d33310630fe984c06b7b164f8a6485ec02fcf35baab072256c00",
+                  "size": 237
+                },
+                {
+                  "digest": "sha256:c32a16b7dee0beca687dfcc31ca26a752c8e338e9c97297702dd741077773716",
+                  "size": 31099046
+                },
+                {
+                  "digest": "sha256:a10672b65a8e7dc5a4908e884e7a4eb130b206ba89f1fceec5d3a182ea223850",
+                  "size": 153955416
+                },
+                {
+                  "digest": "sha256:cb3c502837b3682e75f811cd0dae6eeb0445649d91818edb1921c608fdd37fcb",
+                  "size": 17040335
+                },
+                {
+                  "digest": "sha256:c9408693f1cf4591c1d900d2cb6a06dc22157eaf5d14d65e8cf6527bb6283611",
+                  "size": 2635
+                },
+                {
+                  "digest": "sha256:838b656fca2379845311b219061997548ba673952be76d42828b2c4df1670403",
+                  "size": 177820825
+                },
+                {
+                  "digest": "sha256:76ce51ba10eadf0f144ca8a6d993c089dadd126c82601a1c82294d07106db937",
+                  "size": 42234566
+                },
+                {
+                  "digest": "sha256:8d36ff16ac10b04812aa1a0760c69a7f870f52e9450c63ee2df2c274731f364a",
+                  "size": 11096655
+                },
+                {
+                  "digest": "sha256:569c2971b67d4a335fc6cd7b5e051d623186644f53dfb870d415786213e36e70",
+                  "size": 165
+                },
+                {
+                  "digest": "sha256:f03ba433c613b68324bb7936e75dcd9f671780bd3ac683153c392005ee90ffb4",
+                  "size": 32258649
+                },
+                {
+                  "digest": "sha256:bd41ff05349078d091d7a8717fca2721a77cca45400e786559492beef956cb1a",
+                  "size": 756255
+                },
+                {
+                  "digest": "sha256:88502362a14b5fcaf2fbecca1f0975a1d41aafbde7d073c0edabc1daf7713215",
+                  "size": 18220207
+                },
+                {
+                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
+                  "size": 31729766
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "productVersion": "9.0",
+          "platforms": [
+            {
+              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "simpleTags": [
+                "azurelinux-3.0-net9.0-source-build-test-amd64"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:76370b9ffec332c8a74c85ac8e5a9d7c032df54c415759e2415007dd973a8b32",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:572c335a97c7b9c7178d84f62f4e9a03e809ae2998139d46e924d20d2cdd4a53",
+              "osType": "Linux",
+              "osVersion": "azurelinux3.0",
+              "architecture": "amd64",
+              "created": "2026-06-24T18:14:32.2156117Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:c5537b60ac882bdbfa5efe283f3cce38539af89cb775d5da429bfdc9752a45c9",
+                  "size": 232
+                },
+                {
+                  "digest": "sha256:1099f6a952a0d32a652378965da0454d18b7f19270e2bd29e2303f47091864dc",
+                  "size": 237
+                },
+                {
+                  "digest": "sha256:80bd52c6f3a3f27a363c2bc41130f44c7a655553e8d745958eeac1791bed2b44",
+                  "size": 31099374
+                },
+                {
+                  "digest": "sha256:e00c7a98c0c57fa4f728f7f297b8d8588d41b5f4b43a230e577705b81fa6239e",
+                  "size": 153956180
+                },
+                {
+                  "digest": "sha256:e14e86d0bb9051744548bde6f062428fec3661f576ddc4b8085a16f38cab231d",
+                  "size": 17512013
+                },
+                {
+                  "digest": "sha256:cb406bd8e00978357f3a726928bbc9efc06296060b47178868f10460d5d282d9",
+                  "size": 2708
+                },
+                {
+                  "digest": "sha256:899a93f1c78237e41889ef618b9e90ee7eae2087f827f751befbed8b044276b4",
+                  "size": 176200657
+                },
+                {
+                  "digest": "sha256:be2bc4e25263bb486c8cdeb30fa80ff22b562cd423503d3660bf9fef10b9948e",
+                  "size": 42234391
+                },
+                {
+                  "digest": "sha256:26f5447d25eb0b108d0eeea9b4cc2b33d1a341ae7885c2bd6eeae69376aaeee0",
+                  "size": 11320827
+                },
+                {
+                  "digest": "sha256:f7407da8eef8cd520c272607ec768c4914d9eea0ce2bd8ff9e67330a375d185b",
+                  "size": 164
+                },
+                {
+                  "digest": "sha256:ec65fa280a425770bfe89a14159e5c12e82de294f213c0305f508e4ea55b1bab",
+                  "size": 34563299
+                },
+                {
+                  "digest": "sha256:1178e5826a3e2a203de404aa884733783c162ca19371977406d67e63022bc46b",
+                  "size": 756338
+                },
+                {
+                  "digest": "sha256:3925762f14134e98ce5bbe53efa6da7ff16be50d4ecf04f285f5651a9323bb39",
+                  "size": 18220182
+                },
+                {
+                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
+                  "size": 31729766
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "platforms": [
+            {
+              "dockerfile": "src/alpine/3.24/helix/Dockerfile",
+              "simpleTags": [
+                "alpine-3.24-helix-arm64v8"
+              ],
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:cb5214cec057ab8624bf2163554d799a2f1cb94d19c2c5b7faa2afbe97b915a6",
+              "baseImageDigest": "library/alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b",
+              "osType": "Linux",
+              "osVersion": "alpine3.24",
+              "architecture": "arm64",
+              "created": "2026-06-24T16:52:41.3897065Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/3.24/helix/Dockerfile",
+              "layers": [
+                {
+                  "digest": "sha256:9926ea51e1b104b684331e7e6109a5a7755d3bb1b1cf8fa285d9d9d394bcc6a4",
+                  "size": 22014775
+                },
+                {
+                  "digest": "sha256:95c0d278243cf07c0adf0bc60afcf228084fe09dad12c68b5a349515081d0373",
+                  "size": 3931696
+                },
+                {
+                  "digest": "sha256:86301229012d8479eb865597114729bd18bb50e377912e6a7b4dcfa60e6e492e",
+                  "size": 1052
+                },
+                {
+                  "digest": "sha256:0f95dd9680beb558089c33bacf328176ad346bad543e851263f53630ce836114",
+                  "size": 262655942
+                },
+                {
+                  "digest": "sha256:5de55e5ef9c033997441461efe7ba23a986db059c0bb78b38f84ee0d72b99167",
+                  "size": 4183037
                 }
               ]
             }
@@ -315,29 +743,29 @@
               "simpleTags": [
                 "alpine-edge-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:86fa38299b22ef8bb62ae4425bc248e716ce0e01a59166b0e8d9749a537b3404",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:69d2667a4d85abcbac8a577775ec488f29391a00424569098debb32c8e011b72",
               "baseImageDigest": "library/alpine@sha256:9a341ff2287c54b86425cbee0141114d811ae69d88a36019087be6d896cef241",
               "osType": "Linux",
               "osVersion": "alpine-edge",
               "architecture": "amd64",
-              "created": "2026-06-01T08:07:29.7422375Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/32757b76811bb158edf2944322d5b9499735f170/src/alpine/edge/helix/Dockerfile",
+              "created": "2026-06-24T18:56:30.4251272Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/edge/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:6302df6369de49c1c55dc6a99db27f2dc3d6ab51791f186944e2260add5dbd33",
-                  "size": 21968466
+                  "digest": "sha256:313fecaf7498633a5bec54e553713f8ef3711713b7d93c458f45515f7cf1fd31",
+                  "size": 22133184
                 },
                 {
-                  "digest": "sha256:60f37e82b42673f961a5c47efed9f16d3418842d2800e135fd0be5734b821369",
-                  "size": 3781433
+                  "digest": "sha256:8838c3cf7f63b8cc88950ba3a067afddeec28b4bfa4add1f4864aa7f5980de05",
+                  "size": 3927800
                 },
                 {
-                  "digest": "sha256:b8bc4592e69c3078ea27b7c2124e98ec4d77f9c2295fd8b47b13759d14d500d9",
-                  "size": 1052
+                  "digest": "sha256:8f11c09a524a48acddc636889fea27c7f8487b4af9d27ed835c54bdbe163a827",
+                  "size": 1056
                 },
                 {
-                  "digest": "sha256:af6f6563a0544fdbc5574194e3eb5f169df63cb545db44d790bf8fef91711958",
-                  "size": 273498348
+                  "digest": "sha256:b5f2f4113deca0dd4334e14224e316794e3cb3572a1943c9636ab1be12a8969b",
+                  "size": 273764819
                 },
                 {
                   "digest": "sha256:782e45fa39e33e126e833b143dfe1e0974da9fce6093625a4645d4c16cb9fc0c",
@@ -354,29 +782,29 @@
               "simpleTags": [
                 "alpine-edge-helix-arm32v7"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:be448dd2e601550f8d92de4e6938d21921fbf8918f6f7eb9915f0057cd04dc55",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d7d327ccdfd52923e9fb63d26ccab420d8c8cb55aecf03ebd72234b161f354e7",
               "baseImageDigest": "library/alpine@sha256:9a341ff2287c54b86425cbee0141114d811ae69d88a36019087be6d896cef241",
               "osType": "Linux",
               "osVersion": "alpine-edge",
               "architecture": "arm32",
-              "created": "2026-06-01T05:18:23.6649664Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/32757b76811bb158edf2944322d5b9499735f170/src/alpine/edge/helix/Dockerfile",
+              "created": "2026-06-24T16:53:10.6113507Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/edge/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:51745829bd8cae6e0bf3ffdbc59f8932f4ee621d6c8525bd7f2c78d95a25621a",
-                  "size": 18358829
+                  "digest": "sha256:006df2e89fc33a02452daf1e197abae3796ee912d8435ccd3acb082c34738f84",
+                  "size": 18500239
                 },
                 {
-                  "digest": "sha256:97d8ce3529a66d469d2c7bf70c362bfe2c203ade5e640a3feb5372be229e468f",
-                  "size": 3786990
+                  "digest": "sha256:018444286070464397fce2069ad2243557fb153a1aa977f5522fd43f09211e9f",
+                  "size": 3932145
                 },
                 {
-                  "digest": "sha256:c8c11a3dc4ac6fb89fd3fb1fea43e53a4df00ad506552db5edd18967a57ee9ae",
-                  "size": 1054
+                  "digest": "sha256:2457458afc85a42f62b48d5145b9da18cc15a2347e8383c7179ee0eb489628c5",
+                  "size": 1051
                 },
                 {
-                  "digest": "sha256:7e7fd3f6581ad70db463a46ea564804d66897c99fde0cc9853370e2372f76ccd",
-                  "size": 249693130
+                  "digest": "sha256:28dce4798dfcaca09b92b957a717bd3b0b88817eec162d39badc327895f4ac40",
+                  "size": 249887120
                 },
                 {
                   "digest": "sha256:0e582a9632f2b97cd452b53153880f1689c3400780444b42640f7d1dd9cffe3f",
@@ -393,29 +821,29 @@
               "simpleTags": [
                 "alpine-edge-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:5f09bbc937917a9f62c10c0edde482fc02af16385480b056d026d29bed3bffe3",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:39ea35cca9524945a3aa81c63b72a78f8e6faa9f1bb0fdba5ccb2e4af374709a",
               "baseImageDigest": "library/alpine@sha256:9a341ff2287c54b86425cbee0141114d811ae69d88a36019087be6d896cef241",
               "osType": "Linux",
               "osVersion": "alpine-edge",
               "architecture": "arm64",
-              "created": "2026-06-01T05:15:56.8163593Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/32757b76811bb158edf2944322d5b9499735f170/src/alpine/edge/helix/Dockerfile",
+              "created": "2026-06-24T16:53:11.9918544Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/alpine/edge/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:9b2478bbfead8a8fed736cda67ca6feb315e7e238674f19adc68fc3bb1febfe6",
-                  "size": 21854233
+                  "digest": "sha256:4facb70b4c92a244d1a98cfd3b4e08873192317cabf08993f05bbc0238392122",
+                  "size": 22014788
                 },
                 {
-                  "digest": "sha256:aa7fb05caf62179202058c5134abb1fe0b6f0832dec64cbae2f74bde6af6fb76",
-                  "size": 3786909
+                  "digest": "sha256:19da46eaa5eb2148cfbfc2aa16e7f7f9fbbdb26552f87c750a6642b225497e4a",
+                  "size": 3931848
                 },
                 {
-                  "digest": "sha256:2853221e7d13d0d8a6e74368a265bfb82345aa14df11af713e10c4b2563d4309",
-                  "size": 1053
+                  "digest": "sha256:75b4eae3d2cb8449a8cad63dd22cec5d187b206a3f1ecca3a56acef9201b5ec1",
+                  "size": 1055
                 },
                 {
-                  "digest": "sha256:6816ed480ea374bbcd834f998e89f6e624cfff5629a31ebd93096d474d5700c8",
-                  "size": 266010704
+                  "digest": "sha256:fe7bee885b97abf1fe179c83fb25317391f4b68c072e1b48959fa4e3708a3cb5",
+                  "size": 266246812
                 },
                 {
                   "digest": "sha256:20158f18ba671f0bb300620f1a8427c9359a60a2a718fda83d2d973470c0a428",
@@ -432,33 +860,33 @@
               "simpleTags": [
                 "azurelinux-3.0-binlog-mcp-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c3d7ef9d74a82d6d76f7db14f5d1a56212cbeea2ac7ec20b996671a734424471",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:3b63c797f9cbb1d46f547f09695b53f0f14d30e25563c6086d3e91c0729b12bb",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:65323dc3f0c160c8476e68746b5c8e29dbf45d74292ee7902d493e06b2ee881b",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime@sha256:30a8c40c480930bdb3e9f01870f5ab742679982134807c780b4671af5a5c4959",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T14:23:44.844752Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/e07d5d509ddcdd14677cc97fcf3cbbab86858c94/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile",
+              "created": "2026-06-24T20:23:49.2115356Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d18b106ff799a44957a9654a70fe73c62111a14b/src/azurelinux/3.0/binlog-mcp/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:700eee6cc3273c9f2ebd36e6786bcc68eda503acfced14090f9c8d15f8fa57da",
-                  "size": 10812461
+                  "digest": "sha256:2b284fcc52c7edf6e57a58d49340aec14da5e77dbdadfaf87ae98cfd70fa7f83",
+                  "size": 23289498
                 },
                 {
-                  "digest": "sha256:5b7a3bf3c041b0200884662c87437634bd1ed1808d64f9d3e3338934880c62dd",
-                  "size": 151
+                  "digest": "sha256:c1d384b03e5855cdb76d9059bf3b5743907b27c8af2b94c9bf0c9b290e6d91c2",
+                  "size": 152
                 },
                 {
-                  "digest": "sha256:0902a051a11aae921ca4156b9536f2bd7eac6df9bc8f0c7724f86d4965c01195",
-                  "size": 36594079
+                  "digest": "sha256:b5758454af12c2d300a6e03c972e8e41454af89d92bab5333f7aefbf8c8b1ab7",
+                  "size": 36583323
                 },
                 {
-                  "digest": "sha256:6f7d1450cd9c21f3060c8b0c8ceca73064e96a5277ec5845cf4b2d362f043e50",
-                  "size": 120
+                  "digest": "sha256:241a69b14372f77245f7fcd491eeb66f2a9d7cdff05f1f042101e9e57d0b3773",
+                  "size": 121
                 },
                 {
-                  "digest": "sha256:73d165141ab1a5ec1894a173e244fcee0559f6e33514c702b3a10110e1bf1291",
-                  "size": 10795914
+                  "digest": "sha256:58f22cd21f840d07f3b6bd281a427e441107d9592beff426d1ff37eae0b3aaa9",
+                  "size": 10795857
                 },
                 {
                   "digest": "sha256:f2edbcbc413768c0f68b5bf0055bba1e3bb84048aecf3a03d9a10c379137a863",
@@ -470,8 +898,8 @@
         },
         {
           "manifest": {
-            "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:2a354b04a16c600e610add0ca111fe62811b84803bdaf26fc65d69b927eada55",
-            "created": "2026-06-09T08:33:53.3672286Z",
+            "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:ba05335d810d32bcd39dd96dae747ab22b38050bb2b55f401d486f4df589152d",
+            "created": "2026-06-24T22:18:13.5907549Z",
             "sharedTags": [
               "azurelinux3.0-docker-testrunner"
             ]
@@ -483,21 +911,21 @@
                 "azurelinux-3.0-docker-testrunner-amd64",
                 "azurelinux3.0-docker-testrunner-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:3ad60a484cf40ce08bc88a2c73c1b378bc683196370ef7eef85adb5b2404e278",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:846cfa3da6856ed63cb304f268974f47c4fed615fba02f579b1d9abeef572958",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:55:53.4890668Z",
+              "created": "2026-06-24T17:04:38.5929221Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/docker-testrunner/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:0f6d44aa3bffa1ad8bc057919a5f759c9e07e8c73fb417293e546a5de23660e2",
-                  "size": 369210923
+                  "digest": "sha256:b0303b8c7bd7f93dd7f409e3c48b2ea85bcf66d8b0c0b830446ef0bc92ae5279",
+                  "size": 374470035
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             },
@@ -507,21 +935,21 @@
                 "azurelinux-3.0-docker-testrunner-arm64v8",
                 "azurelinux3.0-docker-testrunner-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8a73a7c7376a14c125ead47937a2c45d24e30bb0622f845b6d5f2591ed14880b",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:dd5367a42105bb57048a0abd471a42216619cf1f1e19eb384b8b76975809ba06",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "arm64",
-              "created": "2026-06-08T14:22:11.2698138Z",
+              "created": "2026-06-24T16:54:07.4373291Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/docker-testrunner/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:889b4215f167fb5d8869a357ca05eeddf010420d4182c381a86cdf6f5c8aa52c",
-                  "size": 348615168
+                  "digest": "sha256:ed7fdd0b851a86d9c78654b849378f444b849b8a07a05e68899e73f0e3388671",
+                  "size": 353689943
                 },
                 {
-                  "digest": "sha256:979c983c11d35673f9e4fdba50bcb1c81f9fbc79265f90884ba8371e9c8528e9",
-                  "size": 29847599
+                  "digest": "sha256:4336f0edee41cc6096506b1220cf31c1964226edf5b608168ebffdae6180297c",
+                  "size": 29847615
                 }
               ]
             }
@@ -534,33 +962,33 @@
               "simpleTags": [
                 "azurelinux-3.0-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f18674245b203a113826aa92288c022ff2b90f2ff2c039a1880b0a931e8723e7",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1df000134a0d811c09d8ef0fd6f2fdacc233ebcf5cefd27bddea2430193fbdac",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:59:10.4390892Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/helix/Dockerfile",
+              "created": "2026-06-24T16:54:10.389194Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/3.0/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:995510757af2156c120d5b77eeda2efaf419478bd3589df2106b9db42d8ce8f5",
-                  "size": 21281931
+                  "digest": "sha256:f11e8c60daf6ac0534b8e020b1ae455d3bcf8b1226d1a83089f6e9dfb93a13fb",
+                  "size": 21293504
                 },
                 {
-                  "digest": "sha256:8bc1c798aa765fa0305396d3ff9707bc3f6fca480405abcf3488fcd3b2ac2bcc",
-                  "size": 3882725
+                  "digest": "sha256:0688133aaf4eb83b938c5e9bccf270739422458d176b6a08938df7e86a86f43d",
+                  "size": 3882596
                 },
                 {
-                  "digest": "sha256:8e5cb794c7c101187f4f3100c9692324365b3e6a86e1563d873731fc09fedf64",
-                  "size": 1272
+                  "digest": "sha256:eafae8b445d27ff54f343f082773dbaeeb2203d61b8ed84fbdeaddd0f9bb1d26",
+                  "size": 1274
                 },
                 {
-                  "digest": "sha256:58159759927062919a2a381402949ab0de150e905224e78e49caa04b597bc7d3",
-                  "size": 152613077
+                  "digest": "sha256:0567dc016474d8aa13c97be01729cde5e3fdf914302ac1615c59d01e132167e3",
+                  "size": 157916572
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -573,33 +1001,33 @@
               "simpleTags": [
                 "azurelinux-3.0-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8ca7622cc3c72ed97bd6f4b04e94d89256aacaaf4315ae7166483a41057026a8",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:bc7d54f4abed6c327bf35c4cfbea9be920eef68761aa4db4e3822940bc563839",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "arm64",
-              "created": "2026-06-08T14:22:43.4186861Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/helix/Dockerfile",
+              "created": "2026-06-24T16:54:15.0338401Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/3.0/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:a5a1fde08b67b37f8b13afbea84c557844a980d4ed8d5995fb7e1573506abd27",
-                  "size": 21268661
+                  "digest": "sha256:60634b7f77127abf2462babb97d34e3e978b63e546e474031d50e074e317bf8a",
+                  "size": 21281662
                 },
                 {
-                  "digest": "sha256:a0e049e8a43be76eb4dead1123877db2b967e14d6aa3b991502abd9c675cb40e",
-                  "size": 3880686
+                  "digest": "sha256:2e85fc91b63541b5b0f3bb377e1b9dffa2ccbbf2b96cc17b1763019bf0a281a1",
+                  "size": 3880591
                 },
                 {
-                  "digest": "sha256:9ba5d7e9fbecb8a5ade30473f7b9d506fb85df532b8a7efbc1f0077be6fdcacd",
-                  "size": 1290
+                  "digest": "sha256:c978e00dba75352d4a3afa1828d2cd500dcb083189997ad6d54e92242218f0f7",
+                  "size": 1291
                 },
                 {
-                  "digest": "sha256:c18d48e7950cca71629b33e93d877fd43d6399029b9117d50b79682e82e2d0d8",
-                  "size": 117667355
+                  "digest": "sha256:3daa689d8475ef4ce43e36054f70c053249649a1df724bde60fa5248c33878e0",
+                  "size": 122759487
                 },
                 {
-                  "digest": "sha256:979c983c11d35673f9e4fdba50bcb1c81f9fbc79265f90884ba8371e9c8528e9",
-                  "size": 29847599
+                  "digest": "sha256:4336f0edee41cc6096506b1220cf31c1964226edf5b608168ebffdae6180297c",
+                  "size": 29847615
                 }
               ]
             }
@@ -702,25 +1130,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net10.0-build-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:27b59e8ed441a5f70eb5b4517b3f1d085b0de37cfd31dbfa7a203872cf70e5d9",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:506a71bf8037d45e9d6ec2e832ca1a49a284bcb43d9176f72817dd12c907975d",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:875a1555ac01e3ff5c7bd3fcd5776946d8a08c9f939cd618ddecc11374e4db97",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:fdcf1cf22f8a0fe0eceaf4e80f552146546fbac1273858d1063699ec91b55a10",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:59:31.8405544Z",
+              "created": "2026-06-24T16:53:52.2145929Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net10.0/build/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:ca119eaa858472b5c167d967264bb1f487bb0e3ee7b4f0e6323a44bfe09cf6bd",
-                  "size": 271045071
+                  "digest": "sha256:6e88aa072ffe7b32d0329dd8accf004d7be42458d7683d53afe77ac19db93f2f",
+                  "size": 276326844
                 },
                 {
-                  "digest": "sha256:289270da7dbd1ffb00b00b317710c9290672aba30ee979f46c93a2850af6ccaa",
-                  "size": 756263
+                  "digest": "sha256:7de2c0d94b6ec885a6ac0ba246ce1bb5090196ee2b90694ebe4ca1d45b7a2519",
+                  "size": 756271
                 },
                 {
-                  "digest": "sha256:7a70862f007ce1ac3a5391220b152de68afa3c9036edc7f6185637c86a91299e",
-                  "size": 18220060
+                  "digest": "sha256:a0d7289fba340a34346c1b13f4968c585341b997abb1931253abe6e3998cfe9e",
+                  "size": 18220205
                 },
                 {
                   "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
@@ -760,349 +1188,6 @@
                 {
                   "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
                   "size": 31729766
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "productVersion": "10.0",
-          "platforms": [
-            {
-              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "simpleTags": [
-                "azurelinux-3.0-net10.0-source-build-test-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:210f360f35ab49d25ffee9c76b33f8612a7ec5366678b8bf60e0cb9b2f151fa6",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:50ebad991d0371ee29da6cfbc11fbd951966c6469644431b1f6e3968ec15f46d",
-              "osType": "Linux",
-              "osVersion": "azurelinux3.0",
-              "architecture": "amd64",
-              "created": "2026-06-08T15:27:13.2829859Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f92d3fc371241a66739de04254fa163266b763b5/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:d5db5aee39523e8a3ac4f87b8f2d110dd0f0e248c2da799d4ec258b8b326867f",
-                  "size": 234
-                },
-                {
-                  "digest": "sha256:70a9c62dd0fa1f1fc111de65d898a5e0b5e83a7d4dcfe03512fdd770a5aa5932",
-                  "size": 239
-                },
-                {
-                  "digest": "sha256:f78e667d1c3596984c7043eb2749d79c2b770531c11ffe6823525a0fc1b09607",
-                  "size": 14516904
-                },
-                {
-                  "digest": "sha256:66fb3965b191baa985d659e4b2e12d1085147a03786c9ec1d9850a99ad638a22",
-                  "size": 153909136
-                },
-                {
-                  "digest": "sha256:a510e5f1f21483d8f8bb60b5ed4a90dc6bca993926e80674f09788e14c25feff",
-                  "size": 18103131
-                },
-                {
-                  "digest": "sha256:7c7c8b59fee7432b9d28fdeeb1812ccae856126b332e18a7ea3d5d1ade335b3c",
-                  "size": 514
-                },
-                {
-                  "digest": "sha256:5748d73e67e6ba0001f94b87b887d5fb59935d3c3b1d0cf9bffcf50e844f28c0",
-                  "size": 185164549
-                },
-                {
-                  "digest": "sha256:121870bfe2b33458dcc0c6129d9eecb484d55ef4021158f45ac8ea096225f64d",
-                  "size": 42234912
-                },
-                {
-                  "digest": "sha256:99d220cbe23ce6413a8791852f522e222ffda11f49f839c07b52312491bd1927",
-                  "size": 12718822
-                },
-                {
-                  "digest": "sha256:6c3acddbbd8fd42c708b02d123af9849586d36d12c8d4e7537f6213994beaf23",
-                  "size": 164
-                },
-                {
-                  "digest": "sha256:23c1a56f8f4b3468b96ea920786d45bcd65d73a95fc73e916346e4c1270afb4e",
-                  "size": 36594075
-                },
-                {
-                  "digest": "sha256:289270da7dbd1ffb00b00b317710c9290672aba30ee979f46c93a2850af6ccaa",
-                  "size": 756263
-                },
-                {
-                  "digest": "sha256:7a70862f007ce1ac3a5391220b152de68afa3c9036edc7f6185637c86a91299e",
-                  "size": 18220060
-                },
-                {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "productVersion": "11.0",
-          "platforms": [
-            {
-              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "simpleTags": [
-                "azurelinux-3.0-net11.0-source-build-test-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a74ac074b01fbb7d7968c0a8a3c0ac9838d45e138a43cce04a8f5416b68dc7d9",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:fc0223b7f174ea4ef9f857eeaa0ffc513d71d54314e0f101edc03f701f338d49",
-              "osType": "Linux",
-              "osVersion": "azurelinux3.0",
-              "architecture": "amd64",
-              "created": "2026-06-08T15:29:18.6480445Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f92d3fc371241a66739de04254fa163266b763b5/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:a342fa6108b8025a12c5032f71eff0b0904389ba36389888c8ded8a88c180947",
-                  "size": 232
-                },
-                {
-                  "digest": "sha256:ffe0a6a32ba3d9164c299bd52a096056ffcc8e5025cd0de3c2f2f4fb875a974b",
-                  "size": 237
-                },
-                {
-                  "digest": "sha256:073bb0c8f2f08543d6f02c5777a9b06869d83185f498465ceeacd2cb1f4ecb12",
-                  "size": 14516974
-                },
-                {
-                  "digest": "sha256:47ffc8b2ab3ca4c06beeaccac701b16343ddd72ea0bbf854d4838a5be3c8de36",
-                  "size": 153910564
-                },
-                {
-                  "digest": "sha256:a1ad94fe059811c2dd263c16b4b7ddb415db3b9fca790e1e2f32490e8f418473",
-                  "size": 18076559
-                },
-                {
-                  "digest": "sha256:dd03ecbcfaadda3ab3268582d1b7aea8ae23d031d7159b8fe014bb3db4d2f993",
-                  "size": 755
-                },
-                {
-                  "digest": "sha256:cf1e305e3eb0f022adc3cea4151f464b4780c9b3ea83081701cca34899027450",
-                  "size": 142672836
-                },
-                {
-                  "digest": "sha256:45359bcb4fd0a7996e3c02f0b083231b84f7f4a85e232dd031cb343c6620700b",
-                  "size": 42234361
-                },
-                {
-                  "digest": "sha256:b4fe1872ae50b1840e50319958961e3a599e467944223e7fa15a2e84a622ff90",
-                  "size": 12446333
-                },
-                {
-                  "digest": "sha256:615b86ec0fc4d8f9b30eb271ef30747186b2cefc49ecf981d2cf311edc74b59b",
-                  "size": 164
-                },
-                {
-                  "digest": "sha256:be12c62417f3cb3be8ca504ebf178f9cea50d4d9ba8b4275577b13b90c4b46eb",
-                  "size": 37612051
-                },
-                {
-                  "digest": "sha256:c8bdcfa236e6c50f8e015e1dee8495bc75c937ab390f4b24598d42a862606bee",
-                  "size": 756214
-                },
-                {
-                  "digest": "sha256:551bb258e91a842df766e7064f08930db90ea162f86ac3a243c6e3ff892e1ff9",
-                  "size": 18220063
-                },
-                {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "productVersion": "8.0",
-          "platforms": [
-            {
-              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "simpleTags": [
-                "azurelinux-3.0-net8.0-source-build-test-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9dc793b428e16cced5a8884569f408decbf1aded00ec543d661d2c260ed42b15",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:6ffdbc384202ca67dd51597ffc5c9518c96ac8e2ec5a83d7161b03743c04cb37",
-              "osType": "Linux",
-              "osVersion": "azurelinux3.0",
-              "architecture": "amd64",
-              "created": "2026-06-08T15:23:08.5901305Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f92d3fc371241a66739de04254fa163266b763b5/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:5566e3475b27d24cb3bbdaff22d120c456bf3b828305786c92a660922b981d27",
-                  "size": 235
-                },
-                {
-                  "digest": "sha256:6773f059aed5e6ae154082dabad59bfbc5613d35dc54c50816dc07da1961db42",
-                  "size": 240
-                },
-                {
-                  "digest": "sha256:2c8d20952fce866d380dbe97de6f4b2933bd60052de0bc1968506452663bfb09",
-                  "size": 14516582
-                },
-                {
-                  "digest": "sha256:8731c0ab93e9510ce51664d5c6217a3ce6915c9611486802080788727dc0c44d",
-                  "size": 153911075
-                },
-                {
-                  "digest": "sha256:1ff2b9c7760c74230ce3793aa74c8923a3e7b395b82d06c83dbb2d2c83cb86cb",
-                  "size": 16987790
-                },
-                {
-                  "digest": "sha256:3695725dc35a0a984890c98fdd1d94417414454762f79dc3f45493957481cbf9",
-                  "size": 2670
-                },
-                {
-                  "digest": "sha256:2dcff8587a6f2b85f44386c682b8ba1344c0e56eb2e17489c09fc73b9a05d84a",
-                  "size": 177855562
-                },
-                {
-                  "digest": "sha256:854921f0dfadedea19ac797077c4916fd13b5c1ee1773b442d432e14ce62f2dc",
-                  "size": 42234819
-                },
-                {
-                  "digest": "sha256:bf9d82c39dd3df1ee8db227335e5c1e084ea435ab1623152a97a45e873666d01",
-                  "size": 11094906
-                },
-                {
-                  "digest": "sha256:778c5ff2ebbeb64f41ca9aafb8444024be38c55540692bf7a1595ba9570fb0c4",
-                  "size": 164
-                },
-                {
-                  "digest": "sha256:08647c991d63a08407787ae54caf65c050e0085ea34390ff75ff2bdc260d8729",
-                  "size": 32250183
-                },
-                {
-                  "digest": "sha256:5ba3ec4a2a544c7278e53c07ebb023fcacda4fe710b573b869e80e3b8c345da6",
-                  "size": 756258
-                },
-                {
-                  "digest": "sha256:3bc22359c7a8046b953b2e0c83bbfb22091640432c9da339f0ccca4ae8e3adc6",
-                  "size": 18220212
-                },
-                {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "productVersion": "9.0",
-          "platforms": [
-            {
-              "dockerfile": "src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "simpleTags": [
-                "azurelinux-3.0-net9.0-source-build-test-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:532c1b590c7915479047529bad1288db256f55c80c4965da00faa865433e9d69",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/sdk@sha256:bdd8e52fff3bd9633455a4dad34a160c6e4fb0cb0b99469d8235413103bee206",
-              "osType": "Linux",
-              "osVersion": "azurelinux3.0",
-              "architecture": "amd64",
-              "created": "2026-06-08T15:25:10.100723Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f92d3fc371241a66739de04254fa163266b763b5/src/azurelinux/3.0/net8.0/source-build-test/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:97906c60f20baa96d57c48c02c21609e116082f04405396524f359ee0327d752",
-                  "size": 232
-                },
-                {
-                  "digest": "sha256:540cb17fb344981b4679a9641487c648cd7e39f3b49a75480dd1f0aff0a63e02",
-                  "size": 237
-                },
-                {
-                  "digest": "sha256:a5c859f448a29044c47f7c134c44f31d08b8a8b72e199f8be69811e17ef49001",
-                  "size": 14516644
-                },
-                {
-                  "digest": "sha256:9685efe0393eca908df337920fa2a4edcb3f5eae992dc7f64e9a7790b7360c3d",
-                  "size": 153910902
-                },
-                {
-                  "digest": "sha256:e5fe6b7cf622f28ec21e588b038e449069111d1ae1c6b43547bac32bd3ad2d97",
-                  "size": 17442943
-                },
-                {
-                  "digest": "sha256:0b663768fc06c6f724a6c3d84a8aebac6104caceb456127bde798dc5e4fa3637",
-                  "size": 2657
-                },
-                {
-                  "digest": "sha256:869137de9c0c394112a8431274387079d0f8d68f1c63bce0ad9f6ce0141d402e",
-                  "size": 176209842
-                },
-                {
-                  "digest": "sha256:5f05f89ff6b2619621124c23046758ff077de11b6a1d0e4db0497f5a33ee8529",
-                  "size": 42234825
-                },
-                {
-                  "digest": "sha256:e872292ecd511b18c0624666f0e9ad9e9a7748bf0768fdef7d58f7003af0ae0a",
-                  "size": 11320397
-                },
-                {
-                  "digest": "sha256:f88e2776a53c38467bede414ce5fb1aab90d2920865ee7426873977eedb26891",
-                  "size": 165
-                },
-                {
-                  "digest": "sha256:0c33ebf90f6fb765a73800f7aad001499215d060ead73335479336f838f72ec3",
-                  "size": 34550755
-                },
-                {
-                  "digest": "sha256:fc9b1bbba4565f26a729a0b99a53c4e099d28d02b906815d54ecbd843193e660",
-                  "size": 756252
-                },
-                {
-                  "digest": "sha256:3bdbaf23fd49aabdc60ba9d88ba14223cee6973147600255e5b21381feb10f5e",
-                  "size": 18220173
-                },
-                {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/alpine/3.23/helix/Dockerfile",
-              "simpleTags": [
-                "alpine-3.23-helix-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:daedc4ed84012104bed0fbcfe8dc92191253bcc5d38490ce5e999427f98853a0",
-              "baseImageDigest": "library/alpine@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11",
-              "osType": "Linux",
-              "osVersion": "alpine3.23",
-              "architecture": "amd64",
-              "created": "2026-06-01T06:58:04.7590098Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d0042b1524388ae51ef83745602357e07050a1df/src/alpine/3.23/helix/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:05ac88ee20b42542f739c8ad872570d25433cbf70ae737dc02af78bffd21b69a",
-                  "size": 21551448
-                },
-                {
-                  "digest": "sha256:346f37c73e20617eec3c8c5c673960e8e56fe338f1a26937b76f55dac822e1b2",
-                  "size": 3932411
-                },
-                {
-                  "digest": "sha256:9aea4a4066702c0c335e8302712cd7e1bd6c5c8ba0517d035a99c4c3a51f04d9",
-                  "size": 1052
-                },
-                {
-                  "digest": "sha256:61ef9b6099f1497db2b66b51e762bb13490518695e9e48e31b7e67711a458040",
-                  "size": 223899843
-                },
-                {
-                  "digest": "sha256:6a0ac1617861a677b045b7ff88545213ec31c0ff08763195a70a4a5adda577bb",
-                  "size": 3864189
                 }
               ]
             }
@@ -1879,21 +1964,21 @@
               "simpleTags": [
                 "azurelinux-3.0-net10.0-fpm-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:2787efdaa8092890fb54254757573722ca902948f05fbcbf4bf21460c0782db9",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:acec8651f40274305e9fd7e1e5f1b0ce730f939105c6f0a7adbacfd05236ddd4",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T16:10:04.8359247Z",
+              "created": "2026-06-24T16:55:36.0220469Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net10.0/fpm/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:fd9eeb04d8421cc0c83dd4cee54b036b6f31e3cd50afe37a0110c4acd7b8063c",
-                  "size": 246329194
+                  "digest": "sha256:fd121f791da20cc789518dd4dcbaf2e603de80403620110b0dac26dc57414668",
+                  "size": 251593876
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -1906,25 +1991,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net10.0-opt-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:41fb10f6c990f578a37c43603fb7fa716a24e7ef597d7d6a2ffe001deac2008e",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a89ea5020a7789124ef7dbbd52c36c20705b37c430ab6c8d95b309ef92aaa3c6",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T16:27:49.7861705Z",
+              "created": "2026-06-24T17:19:32.4100883Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2df8d7824c63e17d9b10195f690c530c82b6e26a/src/azurelinux/3.0/net10.0/opt/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:6fe622ca037867495912e3af855645effb8a7cee467efe48620ca3ab1c92216a",
-                  "size": 479125029
+                  "digest": "sha256:d9d2586ce99b542168277c6701fc341f8b1b30a73396580562dfd9b165f673e0",
+                  "size": 479124791
                 },
                 {
-                  "digest": "sha256:eee350f6c3600470916b09c93749d45761c26a8d4a44beeaace5866f6176e42d",
-                  "size": 161115326
+                  "digest": "sha256:0a1931b79af34d77e575591b021c65c5acf456236eaef20b6bca32194c278896",
+                  "size": 172487356
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -1937,25 +2022,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net10.0-opt-arm64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:377371b06c22d4cca639f4744bbdcf018d348b8f13b775ae481d1a90cec21313",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6d21bd4f87cf6165bc52c869cc1297416e411dfa91bc1375f3094595b8f2e756",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "arm64",
-              "created": "2026-06-08T15:54:14.8556112Z",
+              "created": "2026-06-24T18:23:54.9393499Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2df8d7824c63e17d9b10195f690c530c82b6e26a/src/azurelinux/3.0/net10.0/opt/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:89142bb7e65d2bfa20448ff015ecd94f2ff4936668fed49a772b7ca75411868d",
-                  "size": 483875672
+                  "digest": "sha256:2b033b06dc8bd6aeff76445046beb0e4c309a58eff9c2341aa2099463890e528",
+                  "size": 483875120
                 },
                 {
-                  "digest": "sha256:523745999d9811a8f2032feda3348af85d775cb7717bf83ec5499402b54f66c1",
-                  "size": 174758915
+                  "digest": "sha256:cda2ee6c63fe27eed562be121f22a307bf1e41c6dfc5042a0e8a0a4e5f0e5438",
+                  "size": 187175450
                 },
                 {
-                  "digest": "sha256:979c983c11d35673f9e4fdba50bcb1c81f9fbc79265f90884ba8371e9c8528e9",
-                  "size": 29847599
+                  "digest": "sha256:4336f0edee41cc6096506b1220cf31c1964226edf5b608168ebffdae6180297c",
+                  "size": 29847615
                 }
               ]
             }
@@ -2117,25 +2202,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net11.0-build-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f4a9607761c24069fbf3840db90bbd55140b3f44c36b40c2ddbd5d702f7e2a3e",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:506a71bf8037d45e9d6ec2e832ca1a49a284bcb43d9176f72817dd12c907975d",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:535f3c44d086a3be293db617ea1a436585245b3b08e9828da170da3556f8071d",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:fdcf1cf22f8a0fe0eceaf4e80f552146546fbac1273858d1063699ec91b55a10",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T16:14:05.8035707Z",
+              "created": "2026-06-24T17:15:03.6529523Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net11.0/build/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:e2bfad15bfada07aad3ea2ad74d27c0bf2a2d68a737be244ae0da1e7a9a1a4ac",
-                  "size": 271042863
+                  "digest": "sha256:d79d3149a8f8b3616b80cb429fd90003acca5af6778b624b9c3cb8da69bfe42b",
+                  "size": 276325073
                 },
                 {
-                  "digest": "sha256:289270da7dbd1ffb00b00b317710c9290672aba30ee979f46c93a2850af6ccaa",
-                  "size": 756263
+                  "digest": "sha256:7de2c0d94b6ec885a6ac0ba246ce1bb5090196ee2b90694ebe4ca1d45b7a2519",
+                  "size": 756271
                 },
                 {
-                  "digest": "sha256:7a70862f007ce1ac3a5391220b152de68afa3c9036edc7f6185637c86a91299e",
-                  "size": 18220060
+                  "digest": "sha256:a0d7289fba340a34346c1b13f4968c585341b997abb1931253abe6e3998cfe9e",
+                  "size": 18220205
                 },
                 {
                   "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
@@ -3017,21 +3102,21 @@
               "simpleTags": [
                 "azurelinux-3.0-net11.0-fpm-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:2da8ca8b44389cdad293d99abd23632db1d6fa3f3959738abd6c1df6ccb5c575",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:5df269a8a5d0ad7751ba4539a7b9ffd34d1b920209e2a859d66bb9c39a1d3faf",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T14:36:45.9588185Z",
+              "created": "2026-06-24T17:27:03.780765Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net11.0/fpm/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:8e1557a8f51a00f6786779b46850d1247ba40f9c5c65687e6d347a43f961e3eb",
-                  "size": 246325510
+                  "digest": "sha256:2de77c7e72978822623012cb533c688a4bfca10eae9c3c657c7deb6c090e7828",
+                  "size": 251594073
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -3044,25 +3129,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net11.0-opt-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c140c716d9cb9917461b8abbfa25750276134347e6bc53e49d0e92d0806f931f",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:eccf86c180f1c7c856f50b80245d22059c609cbf69259b89b47ddfce7c550708",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T14:48:35.4507397Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/c49665eaffaa97ebdbbafe07a28d85bced3210bf/src/azurelinux/3.0/net11.0/opt/Dockerfile",
+              "created": "2026-06-24T17:45:51.1220451Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/9947573b2c9eced182b64ad62d341a51aca18ced/src/azurelinux/3.0/net11.0/opt/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:26b835eca9b165e8aa1ded5a6e30ceb6ac57ce9c83c17bbe1da6474bd7ceabbf",
-                  "size": 526245788
+                  "digest": "sha256:e167f2307ff12dff0206debadeb23b0c2956e1876ff2cb3f46f2086d9a224e5c",
+                  "size": 526240194
                 },
                 {
-                  "digest": "sha256:110f058684e570701d165d3d918fb8523a6691aa1397192537cbeea6c214a03c",
-                  "size": 161115612
+                  "digest": "sha256:ad0182aedc62669b32a50bc5a8a6789b2f71fe8dbaee0210a30c8d1292d50612",
+                  "size": 172487126
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -3075,25 +3160,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net11.0-opt-arm64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:83dd37434ff0e4901fa29aa3b8e69b7372d8dc1888a64430328233460bf0a9a2",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:54f25614d0abf1ad232c2feae249709c59c0de3d023db2e9adca2240d2869cb4",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "arm64",
-              "created": "2026-06-08T16:04:05.1800735Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/c49665eaffaa97ebdbbafe07a28d85bced3210bf/src/azurelinux/3.0/net11.0/opt/Dockerfile",
+              "created": "2026-06-24T18:37:25.4217208Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/9947573b2c9eced182b64ad62d341a51aca18ced/src/azurelinux/3.0/net11.0/opt/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:7317f2b77c60a5a936b1745ec4912917076f2e1f103795c8276089349355218a",
-                  "size": 530601957
+                  "digest": "sha256:b436ada2f52bf451dcee5504d7ae4d1a390cb3cc9265eb7af09c1c6925ad0c34",
+                  "size": 530607918
                 },
                 {
-                  "digest": "sha256:1fa8d1676e25f733a501074377fd320466ea3724e6f7abc22cc13d72e573be03",
-                  "size": 174758883
+                  "digest": "sha256:2c1e59c116df6ee2e15b570fa08117acdd28ac97aa437a233b6b93230b61adc8",
+                  "size": 187175571
                 },
                 {
-                  "digest": "sha256:979c983c11d35673f9e4fdba50bcb1c81f9fbc79265f90884ba8371e9c8528e9",
-                  "size": 29847599
+                  "digest": "sha256:4336f0edee41cc6096506b1220cf31c1964226edf5b608168ebffdae6180297c",
+                  "size": 29847615
                 }
               ]
             }
@@ -3255,25 +3340,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net8.0-build-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e92f931c70e3c1b828433e65ce946fa0cd717a082acf55db102fcd8ce8a5178f",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:11001c01744a07bb92b83b71bf426bcabacc4f384bb9b2d08c33835cf4071f61",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:14534fe712395be583884c98c3bf270d60ee2507bc6cf45558136d83792675b8",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:600ae87256edad233fa2badf4faf9d65c1f674360d4799a8dfe5b2ed7c1e482b",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:01:14.7596771Z",
+              "created": "2026-06-24T17:38:53.2842704Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net8.0/build/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:c71c54d218d8af28ca9f2fa57b36ee6c52c84ea7267a90ccfb176a4e2435b140",
-                  "size": 268040586
+                  "digest": "sha256:debd7d58627962d9db45c29572cb7bc1cf0fcc7f8177c8adafa36c969b9beae0",
+                  "size": 273321731
                 },
                 {
-                  "digest": "sha256:5ba3ec4a2a544c7278e53c07ebb023fcacda4fe710b573b869e80e3b8c345da6",
-                  "size": 756258
+                  "digest": "sha256:bd41ff05349078d091d7a8717fca2721a77cca45400e786559492beef956cb1a",
+                  "size": 756255
                 },
                 {
-                  "digest": "sha256:3bc22359c7a8046b953b2e0c83bbfb22091640432c9da339f0ccca4ae8e3adc6",
-                  "size": 18220212
+                  "digest": "sha256:88502362a14b5fcaf2fbecca1f0975a1d41aafbde7d073c0edabc1daf7713215",
+                  "size": 18220207
                 },
                 {
                   "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
@@ -3934,21 +4019,21 @@
               "simpleTags": [
                 "azurelinux-3.0-net8.0-fpm-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:903235d33321a9cef218798561329f8ada2a54b7058a0d77fc14f96e653ba7c3",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8b934bd2e50cf91b3fb50646a5255b9156b3f10a48286c8ef9bafa8edcc8d65c",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:19:50.8691934Z",
+              "created": "2026-06-24T17:57:19.8823015Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net8.0/fpm/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:abc59fb27f00544eb5d274ef85ed4d7acfaad0f92170cdf6bb3c34033c4cb5c7",
-                  "size": 419664257
+                  "digest": "sha256:b35aacf18b6da71bea6ba76edd31e888dfba26844227ab5c7caea73d9a3a46b5",
+                  "size": 424958859
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -4119,25 +4204,25 @@
               "simpleTags": [
                 "azurelinux-3.0-net9.0-build-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1d0b932a32ffd8feea46aaa811b4da39dbcfeddb9d01a22bb97756e94283b67a",
-              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:cd61f34aa01d1a1810126293f9b4ac7fa613d8edb0258b2de15a1795dfcd4482",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:64004f5401b825d1be823cf463b79b8c1aedc83a994c1e57f8ad732e4ea01fce",
+              "baseImageDigest": "mcr.microsoft.com/dotnet/runtime-deps@sha256:fe9afda6d483cfc2e8449d25f01864a5ec7d7640a28734b414921d7810f1d4d4",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:44:00.7837474Z",
+              "created": "2026-06-24T18:30:22.4188936Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net9.0/build/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:a4bea6341f8a2eddf409cddaef66d768f66edbdc4531ef9e2e158c285c64b3f9",
-                  "size": 268037694
+                  "digest": "sha256:b44d937427d68dc9a6da0ea16ee10481687da28b66cc3100c6b3961f9b2f47ad",
+                  "size": 273326562
                 },
                 {
-                  "digest": "sha256:fc9b1bbba4565f26a729a0b99a53c4e099d28d02b906815d54ecbd843193e660",
-                  "size": 756252
+                  "digest": "sha256:1178e5826a3e2a203de404aa884733783c162ca19371977406d67e63022bc46b",
+                  "size": 756338
                 },
                 {
-                  "digest": "sha256:3bdbaf23fd49aabdc60ba9d88ba14223cee6973147600255e5b21381feb10f5e",
-                  "size": 18220173
+                  "digest": "sha256:3925762f14134e98ce5bbe53efa6da7ff16be50d4ecf04f285f5651a9323bb39",
+                  "size": 18220182
                 },
                 {
                   "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
@@ -4884,21 +4969,21 @@
               "simpleTags": [
                 "azurelinux-3.0-net9.0-fpm-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9a36374e145ab8a0fd34dbfb642666c93e0a5befae12bf60d0ba4f2c40b98fb9",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d59601f7c7eafc843f52c9d47e2016355a03c4c69b86303aa970ba3b30a73cb5",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:45:19.7845668Z",
+              "created": "2026-06-24T18:34:21.5417684Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2eba9bb2156ba455b5664109640bb4114a09a135/src/azurelinux/3.0/net9.0/fpm/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:044036a3306c8e724060b86001badfd0242afdd19f9c28a45a217c170670be0f",
-                  "size": 419664217
+                  "digest": "sha256:45a553c93ef6f5693403b39385c721ef67b218a8918e9c685c03154c0e55986b",
+                  "size": 424960724
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -4911,21 +4996,21 @@
               "simpleTags": [
                 "azurelinux-3.0-net9.0-opt-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:aa004d720d3ef3a9da623f582c24d32828b1a1997b351334667906f8939a9d84",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e64566ff22b7c151a80cc14915c2e467597b914f8f8c13269d7d6dd48be831bc",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "amd64",
-              "created": "2026-06-08T15:48:14.7399479Z",
+              "created": "2026-06-24T18:38:56.1987322Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/b56538974bbc7951a27237d38a8d894753b69235/src/azurelinux/3.0/net9.0/opt/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:8fa05b8482fd3ffbad68ad4f35cc4408f9b3d121fed30a3adbf7222dddfe98d0",
-                  "size": 229481879
+                  "digest": "sha256:69e2cc95164ff35ce484b881c94ca9135cff6815954c0e0d3b3ebb1becc2ab0d",
+                  "size": 240846083
                 },
                 {
-                  "digest": "sha256:3c683299341caf3a9a0897a690e8b61b492064d5127705120d499eaa9220c419",
-                  "size": 31729766
+                  "digest": "sha256:ae749037e73864fade5391c9a74d5e2fd19dc55dfce18e505bc6b26d93577a06",
+                  "size": 31729835
                 }
               ]
             }
@@ -4938,21 +5023,21 @@
               "simpleTags": [
                 "azurelinux-3.0-net9.0-opt-arm64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:5c3e68e434a98c19c076b66918c1055f2a4b93af4a2efa780400ab394c052c73",
-              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:cd38424f36dd2db09d0ccd4b0d6fa2203b3dcf7282fb4c06ea1663b23dcaf7df",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c387496d69fafad382b6e745622eb34a0011286d24a1099cb56b1bec768c0f4d",
+              "baseImageDigest": "mcr.microsoft.com/azurelinux/base/core@sha256:1c56f09437dfc2910faad39abaaed336265d246cf183e2adb362d4cb3b881ab6",
               "osType": "Linux",
               "osVersion": "azurelinux3.0",
               "architecture": "arm64",
-              "created": "2026-06-08T14:24:59.5536412Z",
+              "created": "2026-06-24T16:53:07.6458081Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/b56538974bbc7951a27237d38a8d894753b69235/src/azurelinux/3.0/net9.0/opt/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:760e412e1768b0722a4a8ef3de748438bb541cee1d9e3fe3e3beb6866832f931",
-                  "size": 239943389
+                  "digest": "sha256:895ca6e3f5ebd9ecd8672fc358e716b255e9da43a2686c5a87d1de06b0c06032",
+                  "size": 252357387
                 },
                 {
-                  "digest": "sha256:979c983c11d35673f9e4fdba50bcb1c81f9fbc79265f90884ba8371e9c8528e9",
-                  "size": 29847599
+                  "digest": "sha256:4336f0edee41cc6096506b1220cf31c1964226edf5b608168ebffdae6180297c",
+                  "size": 29847615
                 }
               ]
             }
@@ -5056,37 +5141,37 @@
               "simpleTags": [
                 "azurelinux-4.0-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:3ef360160bddc130dab5dfa5ba765bddb21fc8b056ba83e8d5d841d58ccc3439",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:620c418df61b5c9371bb497b6d87a62711cdf048483f77713a74286c6fc883a1",
               "baseImageDigest": "mcr.microsoft.com/azurelinux-beta/base/core@sha256:63ef5dda2fb5681ae3aa5c9597a8c4b24364da91ec459b419fa3c38160595fae",
               "osType": "Linux",
               "osVersion": "azurelinux4.0",
               "architecture": "amd64",
-              "created": "2026-06-01T07:11:27.7444622Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f2842d71c33c10fc5a736988e66911c13d59fb32/src/azurelinux/4.0/helix/Dockerfile",
+              "created": "2026-06-24T18:45:50.1462807Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/4.0/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:f69290acd777170c2f7a93b9a890c22c93c23f6f861fd0448861dd3f351d5680",
-                  "size": 21488328
+                  "digest": "sha256:288f084b2f8f1fe36caff7eac7520652bb0e0ea98147a6b5a31e16ca7a6782d6",
+                  "size": 21494783
                 },
                 {
-                  "digest": "sha256:5bd4ae0fcd4d1b0feb33a1d39ec5a157ee2561208239139a7e58511cabdf90a5",
-                  "size": 3538282
+                  "digest": "sha256:2498be768104025042e9d4daf8386376acfe3af77d4af8a2f1c732c21e52822f",
+                  "size": 3538268
                 },
                 {
-                  "digest": "sha256:0ede3e7cc52ade5d9292463a8d4e938289776d3e07e520727116ebf5600de1d6",
+                  "digest": "sha256:b9019343a8df32cbe9e27bc3051245e2b8423cfb0941889ed36853e653e0922b",
                   "size": 1697
                 },
                 {
-                  "digest": "sha256:3612945dcec06e9330ef2ac4150676aad458cea2225a8a16cf75713bc788ca0c",
-                  "size": 7499475
+                  "digest": "sha256:fc5a1460fd1b71e82171f74838d9cda8af4d90c6cdcebbafa37e32c8acf3669e",
+                  "size": 7525243
                 },
                 {
-                  "digest": "sha256:9d8af30d4e6269b9a3dfe4dd209adaa5857f67ac6a54c8a3cfabee61987e971c",
-                  "size": 893
+                  "digest": "sha256:b210833fcbcdae9e3f597fcb4c3df4ff34007763900cb2bcd6c5807f17157987",
+                  "size": 892
                 },
                 {
-                  "digest": "sha256:6465d901a2bf7640931921a53828ef8d21fd096272caac0c0db6604e0af08e96",
-                  "size": 137920659
+                  "digest": "sha256:f3fd764dd963c69050416bc0d6e77f2ede9d6b38c20484c4dd396774761b232d",
+                  "size": 137916470
                 },
                 {
                   "digest": "sha256:a05d569e90256879a3ae35fa0bb41331050b088f851f1f4195671ff80f861ffd",
@@ -5103,37 +5188,37 @@
               "simpleTags": [
                 "azurelinux-4.0-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:758044964d09d7317586802f01edb2629c532694b14fb6a771b5aad6e7a7d27c",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:14c207d55b66d89b0b7211edf26b1c2baf5d2d5f6057f9dd977ed32a88fd238e",
               "baseImageDigest": "mcr.microsoft.com/azurelinux-beta/base/core@sha256:63ef5dda2fb5681ae3aa5c9597a8c4b24364da91ec459b419fa3c38160595fae",
               "osType": "Linux",
               "osVersion": "azurelinux4.0",
               "architecture": "arm64",
-              "created": "2026-06-01T05:15:53.5342418Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/f2842d71c33c10fc5a736988e66911c13d59fb32/src/azurelinux/4.0/helix/Dockerfile",
+              "created": "2026-06-24T16:53:02.4464784Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/azurelinux/4.0/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:bb3e9ae8f1ee50363e69017f4f39627970411c6b200c1e8df0b2fbc6a39f9184",
-                  "size": 21481903
+                  "digest": "sha256:f326afc316ae3e871bb70d757df23c10be13de2595b0bfcec6c00ee5f00be1d0",
+                  "size": 21490637
                 },
                 {
-                  "digest": "sha256:6ee9d8820bf80e1c017eed5c984e72782c130f0497a05c2a849d9375e6bacbf5",
-                  "size": 3537960
+                  "digest": "sha256:e59cc7426fe7648c894baf36a0ded28e5ee046a0a734cf503620677521cc61db",
+                  "size": 3537940
                 },
                 {
-                  "digest": "sha256:c990d4fab28b949ee16495c726160a4aaa62e93aeebb6ea816ed90fa7cb2f47b",
-                  "size": 1725
+                  "digest": "sha256:cd11df267fde493ab8c50e4120f17522ad9ffd76055431c6536cfe163ff932ea",
+                  "size": 1724
                 },
                 {
-                  "digest": "sha256:9b9a103b4da8efd62b9256b99dc125061234f850a540c0b02e22d43b2bc70555",
-                  "size": 7198633
+                  "digest": "sha256:6c63cfee775e9f7a81e2cec61cd5a50e9f424b692d394670e98c86d9dc607e81",
+                  "size": 7227104
                 },
                 {
-                  "digest": "sha256:19f3b8dcacac2e88a4a649a544f9d81ec266e00dfc4770536b1a08cfb4533150",
+                  "digest": "sha256:2b4e249b183c9c22b96a884b5352150fe120df70e37b11da5a24fca361f4b36c",
                   "size": 892
                 },
                 {
-                  "digest": "sha256:efcf4ec8182b10ba7d030854742a98b8b29f9ed891192b032cbe86afa5ae4c8e",
-                  "size": 135984811
+                  "digest": "sha256:42370dfbf987f3e3f10514ca5f5682365b3a47fdb89248878391f26097e45348",
+                  "size": 135980681
                 },
                 {
                   "digest": "sha256:209755fc009d3da2e1819637e54093398625abfb0e358c6da185a58a9da2d659",
@@ -5150,21 +5235,21 @@
               "simpleTags": [
                 "centos-stream-10-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1849c00a1347f17dbdd167bc8d025b9e2c31273a1f8c2eddbfac3f2197932ee7",
-              "baseImageDigest": "quay.io/centos/centos@sha256:5447ea37452c3808d076fa292a2a098a47f19327174234795a2bc6a39501bf57",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:22d0eb3b7a8976c0a771302703007836d1bc7c3f2da104a8a62b4c16e8bc043e",
+              "baseImageDigest": "quay.io/centos/centos@sha256:43d9ff49ab90f401e427c50e14dd43443a6158f2f676bac0d176cc95f6891931",
               "osType": "Linux",
               "osVersion": "centos-stream10",
               "architecture": "amd64",
-              "created": "2026-06-02T04:24:09.7894475Z",
+              "created": "2026-06-24T20:38:09.173723Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cd5477b071518e27e5d8155f1ef606f341311484/src/centos-stream/10/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:b362defa26a0fa52cac5790235ed24b34fa198b3e10601eb12d01e1572034125",
-                  "size": 727849932
+                  "digest": "sha256:a72783435ed9ebd2671dd46d22a758171c9cd88fdf02fc614a3a76f506ceb6ae",
+                  "size": 727828532
                 },
                 {
-                  "digest": "sha256:aab838bc78cde5e01feb7e289687823416e834a44c90570654cf7b9830022537",
-                  "size": 112051452
+                  "digest": "sha256:a2c080825904a71f918ebf6433d11925b9137def829ddc1ee544495008bf351e",
+                  "size": 112065821
                 }
               ]
             }
@@ -5177,33 +5262,33 @@
               "simpleTags": [
                 "centos-stream-10-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6e8b95d5b6f7224489aa8dad55a26c004c8571b99e5209bc58594706927962b1",
-              "baseImageDigest": "quay.io/centos/centos@sha256:5447ea37452c3808d076fa292a2a098a47f19327174234795a2bc6a39501bf57",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:08781d765b2167c25e4384afddf3e69c6e20f0048d69cc1edfc1e85ba4e2b279",
+              "baseImageDigest": "quay.io/centos/centos@sha256:43d9ff49ab90f401e427c50e14dd43443a6158f2f676bac0d176cc95f6891931",
               "osType": "Linux",
               "osVersion": "centos-stream10",
               "architecture": "amd64",
-              "created": "2026-06-02T04:24:58.4887126Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/centos-stream/10/helix/Dockerfile",
+              "created": "2026-06-24T17:11:50.2061228Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/centos-stream/10/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:00b5f3a264c66cad56fe954c7f3bf64ccf56fb48b65ddf5922cc337d07755d61",
-                  "size": 21412910
+                  "digest": "sha256:3aebe668743f24bb15a1bbf105928cb0eb7a0d07143790fb300a10e736772eff",
+                  "size": 21430468
                 },
                 {
-                  "digest": "sha256:5328aa49dd679aceb400ef61b757a4d1ce60ce0139d1def1044a1b7b1cff45c0",
-                  "size": 4013947
+                  "digest": "sha256:28374364c5ebcf13903bff065254af03d495ed85c6057cb9a3ca004780fd69b3",
+                  "size": 4013934
                 },
                 {
-                  "digest": "sha256:9abcc878d8c28d6dcdc7ce10e17cba2d119b2157f431fd75fef16e1630a64b6a",
-                  "size": 1425
+                  "digest": "sha256:95d1ed2ea39edaacac155e456d5139d01b8d24442d0ace27388b66495d2fc9b3",
+                  "size": 1427
                 },
                 {
-                  "digest": "sha256:71831365ae0b100ca1ed57788a99470121c4174524732559fdac19511b41fe91",
-                  "size": 461345363
+                  "digest": "sha256:26f7f29d74d98014252969fd8051ef55c2936b40a01a4da73d2d827f0519fce4",
+                  "size": 461307938
                 },
                 {
-                  "digest": "sha256:aab838bc78cde5e01feb7e289687823416e834a44c90570654cf7b9830022537",
-                  "size": 112051452
+                  "digest": "sha256:a2c080825904a71f918ebf6433d11925b9137def829ddc1ee544495008bf351e",
+                  "size": 112065821
                 }
               ]
             }
@@ -5216,33 +5301,33 @@
               "simpleTags": [
                 "centos-stream-10-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6887a574e33266689425ec44ba4bfea5a26b65d5cf36830660d6474ef6379f30",
-              "baseImageDigest": "quay.io/centos/centos@sha256:5447ea37452c3808d076fa292a2a098a47f19327174234795a2bc6a39501bf57",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:953ea152f39c2afc6f7e1479dc422af3e364b960e931faede6de5459237f2418",
+              "baseImageDigest": "quay.io/centos/centos@sha256:43d9ff49ab90f401e427c50e14dd43443a6158f2f676bac0d176cc95f6891931",
               "osType": "Linux",
               "osVersion": "centos-stream10",
               "architecture": "arm64",
-              "created": "2026-06-02T04:22:55.278397Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/centos-stream/10/helix/Dockerfile",
+              "created": "2026-06-24T16:54:21.4546819Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/centos-stream/10/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:648656e5240adffb2fa49bc1af95b7cac69a45728768921c9c23c5903b66b00d",
-                  "size": 21405959
+                  "digest": "sha256:396eeb4bec94b4d1bf5fd36595214d57c26ab3e786298c147d91bc62de16a156",
+                  "size": 21410748
                 },
                 {
-                  "digest": "sha256:d010bdf55115e1efad7a060d219d624dead177530afe1384de953e3d5b76ff57",
-                  "size": 4013461
+                  "digest": "sha256:95a64a0c48ce4c178a120551ca536fff479890ccb51094cb381db455295319d5",
+                  "size": 4013515
                 },
                 {
-                  "digest": "sha256:a42782d0023bc3f9c2c5efc4a2448c4a937e5d46aedf031284ce22826004f15a",
-                  "size": 1811
+                  "digest": "sha256:e51ffed56658a5af65dbf33a473cd5d7775c1fe118d2c9d0f1a7eeced5ce363f",
+                  "size": 1814
                 },
                 {
-                  "digest": "sha256:81a6ac415a4711084ec5d68798cb6d54c2f17b71e60b29c258f0c9af2b06e87c",
-                  "size": 438398316
+                  "digest": "sha256:d05f0d49e6532cad61f80dffa5a9b0310c9a7666310b0096a6a3c69280fc7c1e",
+                  "size": 438340877
                 },
                 {
-                  "digest": "sha256:f32496c004e215d8862e2fcfeee0ea28a05cc913b3ac5719530b1e83b7a31bac",
-                  "size": 110244686
+                  "digest": "sha256:40ac553e24781b6b3b63777eaa0576fda87996a8a8b4cda6fa984d02838ffdf8",
+                  "size": 110304198
                 }
               ]
             }
@@ -5257,21 +5342,21 @@
                 "centos-stream-9-amd64",
                 "centos-stream9"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:744cc1209548fa1def573338997180c2189103866bb32e9ecbf5bc8c35533ab6",
-              "baseImageDigest": "quay.io/centos/centos@sha256:2ec5fc9b994c9f370b10e7bf07d3c1a7740e934d3c8f3d78c105b5e635d3cffb",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d2b90ac4bcd616e4399574219b336227ef606be2a1713ecd566630635ec62a18",
+              "baseImageDigest": "quay.io/centos/centos@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0",
               "osType": "Linux",
               "osVersion": "centos-stream9",
               "architecture": "amd64",
-              "created": "2026-06-02T12:24:12.8822464Z",
+              "created": "2026-06-24T20:43:01.2456985Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/c788df6b90eb6594bcecf4cbd620470043744006/src/centos-stream/9/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:e34e73f8e60835783e29a64082c54c619975c08725585e627071041013a0fbca",
-                  "size": 887146874
+                  "digest": "sha256:b99d2a6463cd2f93369f2633373929fc24cb552d2d0dcef358e04e9d0307a551",
+                  "size": 887159661
                 },
                 {
-                  "digest": "sha256:c83045208be8e8b971841845571f3468d6c8db24f74cfdf85e1956a33c82aab9",
-                  "size": 61908832
+                  "digest": "sha256:8fde447c06f30adbf4b925491549af5ea5def89146c7869e395f6f86b15dc344",
+                  "size": 61923651
                 }
               ]
             }
@@ -5286,37 +5371,37 @@
                 "centos-stream-9-helix-amd64",
                 "centos-stream9-helix"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d8e630ca525d3a154e7a627f6484474222bfc8dd381630741733321610438af2",
-              "baseImageDigest": "quay.io/centos/centos@sha256:2ec5fc9b994c9f370b10e7bf07d3c1a7740e934d3c8f3d78c105b5e635d3cffb",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:286729b5975d497d7fddc5d3ba977e6249db3f8ed0c032d45806dcd833a86b5d",
+              "baseImageDigest": "quay.io/centos/centos@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0",
               "osType": "Linux",
               "osVersion": "centos-stream9",
               "architecture": "amd64",
-              "created": "2026-06-02T12:22:57.5043301Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/centos-stream/9/helix/amd64/Dockerfile",
+              "created": "2026-06-24T20:47:40.3927951Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/centos-stream/9/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:829bf344b297e4ce14343ac3dd116aec8ec6c3cbc310983d9172706587073dcb",
-                  "size": 34319516
+                  "digest": "sha256:ab27d85d87e0d8348d222eb2ff0dbbd99b271ab2e00cee189c858e501c36efb5",
+                  "size": 33501166
                 },
                 {
                   "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
                   "size": 32
                 },
                 {
-                  "digest": "sha256:21adc06c971cbbc61084ca6427b1fac5f6c247a9895aa0a74d451394f549e1bb",
-                  "size": 1333
+                  "digest": "sha256:8913f9ca5ca50a17d5fab3286f505aae1b06c539b13a224f8adcd66e918aad7e",
+                  "size": 1336
                 },
                 {
-                  "digest": "sha256:a2a431861b197c1d3167d96cecfee22a4c787a16d2b72f790cf88e2384848389",
-                  "size": 154
+                  "digest": "sha256:919348973fb48542d23576b68f4fb708314d3131693768dbb34ab64fadc4c151",
+                  "size": 153
                 },
                 {
-                  "digest": "sha256:614caf5b04aa0dc1503b07b200faea509878ac6a698a5c6ec522d658cad4dd4b",
-                  "size": 262502231
+                  "digest": "sha256:afa310c15a7390490319baf2af2535dc40698b97c8af8be649c0dd37272a4446",
+                  "size": 262530749
                 },
                 {
-                  "digest": "sha256:c83045208be8e8b971841845571f3468d6c8db24f74cfdf85e1956a33c82aab9",
-                  "size": 61908832
+                  "digest": "sha256:8fde447c06f30adbf4b925491549af5ea5def89146c7869e395f6f86b15dc344",
+                  "size": 61923651
                 }
               ]
             }
@@ -5331,41 +5416,41 @@
                 "centos-stream-9-mlnet-helix-amd64",
                 "centos-stream9-mlnet-helix"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:960fb46caa6bb67cda9a8a93b27a0a619d13159bdd1d13ad24e442fcd37e1ade",
-              "baseImageDigest": "quay.io/centos/centos@sha256:2ec5fc9b994c9f370b10e7bf07d3c1a7740e934d3c8f3d78c105b5e635d3cffb",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d6267f7972e63f14de4cf8703c0e52b11c03d1379aec6f3cbe292a2b03a91c38",
+              "baseImageDigest": "quay.io/centos/centos@sha256:5665c076f25172d372d6fb7934f49f9f99b36aa6117afd1935186ccb9fb88cb0",
               "osType": "Linux",
               "osVersion": "centos-stream9",
               "architecture": "amd64",
-              "created": "2026-06-02T12:22:52.5110007Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/centos-stream/9/mlnet/helix/amd64/Dockerfile",
+              "created": "2026-06-24T20:44:05.3999729Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/centos-stream/9/mlnet/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:f0bf6be5acabd5e5bdf775a8994f2c562c467c201ca07dcbec2fadab1d75835a",
-                  "size": 34320055
+                  "digest": "sha256:32801cbc29dd19f9767c728af1c7e93c31b2313a0bcb51b8a9ffa6c940cc6eb5",
+                  "size": 33501148
                 },
                 {
                   "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
                   "size": 32
                 },
                 {
-                  "digest": "sha256:e4ff563c0822e2bf6307e011794a6a77967cd9f5ccb328956d5e0fd9d9dd850c",
-                  "size": 2038
+                  "digest": "sha256:82718786a6b54df73306136dd242a4c0ec063bb9d42df5b634a4f841946ebbf5",
+                  "size": 2040
                 },
                 {
-                  "digest": "sha256:89160a15c79e144b882c832053790452a4cba32559c2074cd3f4cfff9c995fe8",
+                  "digest": "sha256:64e2773136cf0d5cbc1859b861d2d8de55827edb3b537e5529d8eb67718d52b0",
                   "size": 154
                 },
                 {
-                  "digest": "sha256:12eb23c0c39bb6c653a999da8dd963056d3680c8b94d45ef119b0f26f7611ebb",
-                  "size": 290772
+                  "digest": "sha256:a1c214926f512f4eb33a8a32c9da3330434658b1f70bc0981a95d0aedd865b68",
+                  "size": 290773
                 },
                 {
-                  "digest": "sha256:5642a641581df46e66a3ab4ec1011b3e2ffa973bed8b72a580312c2f2d93af07",
-                  "size": 694929833
+                  "digest": "sha256:60d4e08362e026fb43cd2a437d55fe668da008e82c66ee54c881539930c0b86c",
+                  "size": 694953730
                 },
                 {
-                  "digest": "sha256:c83045208be8e8b971841845571f3468d6c8db24f74cfdf85e1956a33c82aab9",
-                  "size": 61908832
+                  "digest": "sha256:8fde447c06f30adbf4b925491549af5ea5def89146c7869e395f6f86b15dc344",
+                  "size": 61923651
                 }
               ]
             }
@@ -5378,53 +5463,53 @@
               "simpleTags": [
                 "debian-12-gcc13-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:cb80fa006df44a077263203b93184876af8626011e03986de0191d77826b70df",
-              "baseImageDigest": "library/gcc@sha256:b9471b5da62a3cdfa3f415e85baa78e0bb4a8ec3fd1aeac3aa0eefda318911c8",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:37579b2f469ebe7e8ff944b431c324db9485e9d4d77d750ecbdbe5201803e30b",
+              "baseImageDigest": "library/gcc@sha256:4c78ffe0be6a4536e082b782f264d67c8d112423400c558f7cf14fda5dc1c569",
               "osType": "Linux",
               "osVersion": "bookworm",
               "architecture": "amd64",
-              "created": "2026-06-01T08:20:37.0662841Z",
+              "created": "2026-06-24T20:49:36.6755316Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/debian/12/gcc13/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:2bddb77d57a15a6b6daaa03506344723776e48560fea75ac538d7d1b26a880a8",
+                  "digest": "sha256:0b418546e9c780060d0cb0ad3b821b5c3eeaafe06afc0e15f363e586b79ad341",
                   "size": 172
                 },
                 {
-                  "digest": "sha256:3a4d8c77a4fe7b781e9875833cf79143140db0cf97b0abbca34add861c7b949d",
-                  "size": 545347578
+                  "digest": "sha256:10cadcb6d554f7347be0bbcf8550d426bb6a096b7abe6fd11eea62bb1b083c13",
+                  "size": 534363988
                 },
                 {
-                  "digest": "sha256:4fb5e66d11c942c1591028091921df39d34e3fd27f5e523507fa311ec6441d36",
-                  "size": 1805
+                  "digest": "sha256:e4745806432cf58d2e8bb9f6fac1e401e946f96f7efb7c9f8ee743280209403d",
+                  "size": 1798
                 },
                 {
-                  "digest": "sha256:3705707a4fe172315488a0290e01a7284273c8871735eb9a598efae5ca1a75b7",
-                  "size": 8919
+                  "digest": "sha256:5dfefae5f4960a21744b4121265db773dcbb1f0804c2c5f6e8d84e2ca38e6b31",
+                  "size": 9629
                 },
                 {
-                  "digest": "sha256:f13c9e62d7a2a5394578f530164622c6e6813ef19f1521e7380fe61d1d12adb6",
-                  "size": 145765539
+                  "digest": "sha256:230b19c2682399056e7e19e0cc099b076515ae0ec1321b7e10b9cbb01d2c5fde",
+                  "size": 145765576
                 },
                 {
-                  "digest": "sha256:73be008d90a8a5ee105db046fda2f5127f1b90dc9e13c3cd0bd1a2401feac7b9",
-                  "size": 2813890
+                  "digest": "sha256:8e52655550d455b1ec5f444e0cd16c92e2ed62564588390778abe68939106a4f",
+                  "size": 2813862
                 },
                 {
-                  "digest": "sha256:0ce041001b8968f31ff00bb8f9dbd68f72d4bdc378a1309e38eb3dfe97cc1498",
-                  "size": 211586305
+                  "digest": "sha256:9eb598f63f1e9867f81313f86224109c84b2af9646d8fca29113217b94315956",
+                  "size": 211602331
                 },
                 {
-                  "digest": "sha256:a234579dfb0d2a4c7e869bc6c39c06f306aa019f90ec3e79f682671badaeb4f3",
-                  "size": 64404451
+                  "digest": "sha256:791c68bc2063683c3d15907b8ed1b777cf14ca153c6f8e5b12db0868dfa7e38a",
+                  "size": 64404017
                 },
                 {
-                  "digest": "sha256:2e51c50554dce9c9549d76c40bfea45780a8342aea81ba8b270ba1bf46a2aec5",
-                  "size": 24043374
+                  "digest": "sha256:f4fd7bf6f6036613e20f62549df75ed694b99118002358bea5a81baf3929d1ff",
+                  "size": 24044046
                 },
                 {
-                  "digest": "sha256:4887723d153cfd7fd9e356c8730311c36a64e4f9329f9d3ae1929e05715f2e73",
-                  "size": 48495432
+                  "digest": "sha256:425befdf76e52426879d2abe42093a00dca59a893e7b4fa2a7679b0180b71d4b",
+                  "size": 48502210
                 }
               ]
             }
@@ -5535,33 +5620,33 @@
               "simpleTags": [
                 "debian-12-helix-arm32v7"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8c61be1f208b8cd293f145dc1ee61925acb41dedeb353a8212f90b16f4d8d865",
-              "baseImageDigest": "library/debian@sha256:ed4fcc40bb1162b6d2d32e7bec15044d13963779abbe63f67f1cd62b06220519",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:3ab037448ab588b71ad54d1f90957f3eb664a6722537588322e4022b4bc08ca4",
+              "baseImageDigest": "library/debian@sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168",
               "osType": "Linux",
               "osVersion": "bookworm",
               "architecture": "arm32",
-              "created": "2026-06-01T05:17:55.1467251Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/debian/12/helix/arm32v7/Dockerfile",
+              "created": "2026-06-24T16:53:10.6576846Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/debian/12/helix/arm32v7/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:ff5d45887bb5c1d329376c66d6cfef7c47287b570d915ab9c76be1ce268bce49",
-                  "size": 20622202
+                  "digest": "sha256:f8f8c025490b071a7c491f22a737727f39d14c190c33b588a5a33178edd76f5b",
+                  "size": 20625768
                 },
                 {
-                  "digest": "sha256:52285005c4e066bc8f88effdaeb57c21cc0014886bf19a89ca6780e30ad7bfd2",
-                  "size": 9156781
+                  "digest": "sha256:8ef93acce562178e776e43a2ea5da561d7808530ebba7ecd5431ae4b571420e6",
+                  "size": 9041107
                 },
                 {
-                  "digest": "sha256:e6786a819619685fea08ba2e0a70484b193001e0f108c8d4e568b7480a18e573",
-                  "size": 3691
+                  "digest": "sha256:c0ce8b2074bae7288205bac0e5224d72e9264fe204c288f4a145487d0cb9e0d7",
+                  "size": 3686
                 },
                 {
-                  "digest": "sha256:899c6398ae37959bac43a5c9feb335b699fe262b509a76fca6a5d5be0df0433c",
-                  "size": 489146325
+                  "digest": "sha256:c586f183aaab6868da688cb7491f9737b9e4762236835798e6ef013587f1d9ab",
+                  "size": 486833084
                 },
                 {
-                  "digest": "sha256:1af0b8b84389f4347663cc563bc1f6d59fe6d6f21081f428bafa1a09f6a276ce",
-                  "size": 44209154
+                  "digest": "sha256:3622debffba3838b917703fb6dd9c161a4d93d9fd97c61d3e8400a2245f93c67",
+                  "size": 44208145
                 }
               ]
             }
@@ -5574,33 +5659,33 @@
               "simpleTags": [
                 "debian-12-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:bde84b4b2e8501680138c4fad8640f87ab383d5cc5456533f4e8ab01acd4cf36",
-              "baseImageDigest": "library/debian@sha256:ed4fcc40bb1162b6d2d32e7bec15044d13963779abbe63f67f1cd62b06220519",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:f43dc72d5b284cfc74bb6651fe03400efd260a2890a63b97ce0a6dccf424b2b2",
+              "baseImageDigest": "library/debian@sha256:30482e873082e906a4908c10529180aefb6f77620aea7404b909829fadc5d168",
               "osType": "Linux",
               "osVersion": "bookworm",
               "architecture": "arm64",
-              "created": "2026-06-01T05:18:22.8500216Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/debian/12/helix/arm64v8/Dockerfile",
+              "created": "2026-06-24T16:55:44.2976638Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/debian/12/helix/arm64v8/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:0dac7b44db480756392561fee31cf6d24952af6e0f7eafe7c645fd53718c6355",
-                  "size": 21576087
+                  "digest": "sha256:1a6a9063398c5aed049db9cd764b98d64f1f2d852fbb0877a840e8f17d50e39b",
+                  "size": 21579621
                 },
                 {
-                  "digest": "sha256:3ec3cbc0ea8913c370c6012c46ee175e3bd8134fcac9e37f9f742fe9f6faf56b",
-                  "size": 9156936
+                  "digest": "sha256:c5518437e7676988b558664d1e39f58c910a05c310c0ccb30ccb403bfe304269",
+                  "size": 9040232
                 },
                 {
-                  "digest": "sha256:a155fa30c72b5af32aff2ac9bc3ec444732f4d9449bb119c3fc01ae44e78ed44",
-                  "size": 3692
+                  "digest": "sha256:2fc0ebfdd9685ffff25dd0891f7f174f803a8036194de8618d843d41db7839e8",
+                  "size": 3693
                 },
                 {
-                  "digest": "sha256:2272a0f38f0a96bc5086c5ad4c032833a64e55d752c49081ff302d7b029047e7",
-                  "size": 526293334
+                  "digest": "sha256:ef1dfd932847d4c654afddc7386cc372bf3caf1800bce2ed06f70438aeb56600",
+                  "size": 523741955
                 },
                 {
-                  "digest": "sha256:1fbcdab7270278c1f989ae72190255d85d2117e990efb76cde6eb206b803672c",
-                  "size": 48379432
+                  "digest": "sha256:0fb1189398e2e4b474d43aac6502510d0da0318e70137a377c21087f198814db",
+                  "size": 48389201
                 }
               ]
             }
@@ -5613,49 +5698,49 @@
               "simpleTags": [
                 "debian-13-gcc14-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:00da0353132a08057d53480a7f774503467e44026bdb23652af1e91e877afcb0",
-              "baseImageDigest": "library/gcc@sha256:06e8ae332eba8e22eba929a61025e68ff62a92fd84bfb97f2be7db6a068b77cf",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:10847427f282af8f4505a82e80201cb18049289a6d68baff8a7c7986c6576e7b",
+              "baseImageDigest": "library/gcc@sha256:8a3d24948c7b0165aaddd81def50e86b294f7f7568bd13da6c7f288e26924eab",
               "osType": "Linux",
               "osVersion": "trixie",
               "architecture": "amd64",
-              "created": "2026-06-01T05:38:27.8674025Z",
+              "created": "2026-06-24T20:52:08.5929461Z",
               "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/debian/13/gcc14/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:fe42ffee6a69e5c1f50af08d66263a2a42484b50fe691ec328500f6d83ad7093",
-                  "size": 777444428
+                  "digest": "sha256:0abb775efa7ed7cfe28d725ee80a05a122242b2bdb2f240fd981a286b0181952",
+                  "size": 765340023
                 },
                 {
-                  "digest": "sha256:ae4bbc91bab1798222de32ef6c2d94afa0530e9fc2443bcad5e20f384aff8137",
-                  "size": 2007
+                  "digest": "sha256:dfa04675b39702962b76a2264b5b0381521b94c056442679b217beb7d367e3f9",
+                  "size": 2000
                 },
                 {
-                  "digest": "sha256:2da58c7b0bb0599ea495f734cd191dbec167d0732f8c80ac3b4c9120dc89bd89",
-                  "size": 10643
+                  "digest": "sha256:2b92045218544f704df081fafe2964a921fb9708dc3b0f7695fd1577b6a9b21c",
+                  "size": 10624
                 },
                 {
-                  "digest": "sha256:fd1151253c492fbd451cede436cd68befb5684595c940750dc4113605128faca",
-                  "size": 156712334
+                  "digest": "sha256:1e35739ecd896a5d2ed066296e2c95e804e586bce3198099351ade7a3924ed37",
+                  "size": 156710705
                 },
                 {
-                  "digest": "sha256:e92a221bc8322e604bafbef6f0c4d581d3daa284c731882cc28e07ec1a325052",
-                  "size": 4592072
+                  "digest": "sha256:913bb0fd85013fd13d8afafa1a59b5b0cacbe0296b13b39eeb7458d727c9114d",
+                  "size": 4592102
                 },
                 {
-                  "digest": "sha256:8d6d44b254dab2063c4226fc8a0849d5527402d24d3bea80d644a1e4ac3a47e5",
-                  "size": 236176097
+                  "digest": "sha256:0252e6abaf0ff12562710faa97dc617e372a424bf144947f39dcb38700423e9f",
+                  "size": 236248824
                 },
                 {
-                  "digest": "sha256:b53089dca50590292ecc77bf803152a5799650e734717e4b706cb812a02073ba",
-                  "size": 67777732
+                  "digest": "sha256:30d0db852850114cc79598cc8ab1ec19da54691d9e3267288bb3458d7488f125",
+                  "size": 67778134
                 },
                 {
-                  "digest": "sha256:8a7504cd2818ce40ac76c17886a03dff25ef0aa06ff6125bf0f0c7302cdc6471",
-                  "size": 25633915
+                  "digest": "sha256:3f59c84a786323367a79d4959142649bb24b16c989bbaae7f273550b47325959",
+                  "size": 25634938
                 },
                 {
-                  "digest": "sha256:f32f49ce655a9cf7c1fd4ca1417ddb39a54cedf4b7ff35de20f8009c18dd7a96",
-                  "size": 49310623
+                  "digest": "sha256:aa3e9ef32f73c30e8b065800ee66429992d3bfea6a1fb8224afdd878ab5b994f",
+                  "size": 49317255
                 }
               ]
             }
@@ -5668,57 +5753,57 @@
               "simpleTags": [
                 "debian-13-gcc16-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:809f0d7665f450524c199cfb723d064911d2584315f8de7cee744090d1fe2f61",
-              "baseImageDigest": "library/gcc@sha256:6a251e45411969f95e57f2587563dfba89d449798b80504bcebc7fad6f210200",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:66879499e7ce51c22202e08f4a9651f2fcb49ab290d8258ca38421c7f6fa5463",
+              "baseImageDigest": "library/gcc@sha256:40b2ce7eae4147798093ef78be2b9799e1d0018460db8c8044cfede763344486",
               "osType": "Linux",
               "osVersion": "trixie",
               "architecture": "amd64",
-              "created": "2026-06-01T08:34:23.7487968Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/3467879939ff845bc97ec4ddf2ce772abd729040/src/debian/13/gcc16/amd64/Dockerfile",
+              "created": "2026-06-24T21:00:27.5940631Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/8acd88f6876e255ab30581ea2859449f975c2828/src/debian/13/gcc16/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:240fd6d7da9840ed08e07a077a0f118e47ab31d9ca985c1b64a041d336b6827d",
-                  "size": 172
+                  "digest": "sha256:9cd1383a0bae3eb5866f810d8412cd394a8fa47d4889e5259c431b6f37c7b86e",
+                  "size": 173
                 },
                 {
-                  "digest": "sha256:b5736b33ecd0960881e0ccdbd77f5a2487e60f83e1eef25c2cbbc79f3d9b523f",
-                  "size": 80348399
+                  "digest": "sha256:d2fc8f8488394f515ecc1dff6a6d3a2ef4fb0c1ae777bfb3fef26ca671d1a354",
+                  "size": 80158237
                 },
                 {
-                  "digest": "sha256:ec45150729f4849cd88e1137ffccf05c2d416772e60951d3cfbee646ddda6f3a",
-                  "size": 777643272
+                  "digest": "sha256:624bf9e35f0000d389159151f9a2b9323cce50fe76a5b509564f418043e9eb32",
+                  "size": 765494306
                 },
                 {
-                  "digest": "sha256:44989be9b602bc22778fd45bea3e08c517597310f2ce1d7c2bb7131c38667e29",
-                  "size": 2006
+                  "digest": "sha256:5e986d8807389bf48424fd018efbc8735268a1ec933387f687b20f496c4bec2e",
+                  "size": 2005
                 },
                 {
-                  "digest": "sha256:d666f8f1c556ab0aa09f3777b2d9316ce60e2432e8721d304f58770a5ce012ee",
-                  "size": 10652
+                  "digest": "sha256:0aa529d2064c9131eab22035d0e3c740e4f25d39fdda7e977ed95ab99c1aa0f4",
+                  "size": 10648
                 },
                 {
-                  "digest": "sha256:fb1e29f9c0f6d9589ab4f52b8a9ad609db53f49fdec8a7c174fa9827197daa81",
-                  "size": 176395315
+                  "digest": "sha256:969c9523d2df743a05db102ff20548e7cf62fb6dce080c13377e697cd9f0f43c",
+                  "size": 176395143
                 },
                 {
-                  "digest": "sha256:c21dad1bfb65cbbd65f66ba4f0d57798aa7e619600d4f5c514269a8a2c214153",
-                  "size": 4592049
+                  "digest": "sha256:56fd4b781f2c7ccf31ad00561aba88c460ef9b967c6e4d2a394f5c47419b4c8e",
+                  "size": 4592134
                 },
                 {
-                  "digest": "sha256:8d6d44b254dab2063c4226fc8a0849d5527402d24d3bea80d644a1e4ac3a47e5",
-                  "size": 236176097
+                  "digest": "sha256:0252e6abaf0ff12562710faa97dc617e372a424bf144947f39dcb38700423e9f",
+                  "size": 236248824
                 },
                 {
-                  "digest": "sha256:b53089dca50590292ecc77bf803152a5799650e734717e4b706cb812a02073ba",
-                  "size": 67777732
+                  "digest": "sha256:30d0db852850114cc79598cc8ab1ec19da54691d9e3267288bb3458d7488f125",
+                  "size": 67778134
                 },
                 {
-                  "digest": "sha256:8a7504cd2818ce40ac76c17886a03dff25ef0aa06ff6125bf0f0c7302cdc6471",
-                  "size": 25633915
+                  "digest": "sha256:3f59c84a786323367a79d4959142649bb24b16c989bbaae7f273550b47325959",
+                  "size": 25634938
                 },
                 {
-                  "digest": "sha256:f32f49ce655a9cf7c1fd4ca1417ddb39a54cedf4b7ff35de20f8009c18dd7a96",
-                  "size": 49310623
+                  "digest": "sha256:aa3e9ef32f73c30e8b065800ee66429992d3bfea6a1fb8224afdd878ab5b994f",
+                  "size": 49317255
                 }
               ]
             }
@@ -5770,33 +5855,33 @@
               "simpleTags": [
                 "debian-13-helix-arm32v7"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:7cd2e25705d98e003a2d4f2e10cbf27847f573d9548e06a72062028ed74f43a6",
-              "baseImageDigest": "library/debian@sha256:4ae67669760b807c19f23902a3fd7c121a6a70cf2ae709035674b23e712e4d62",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:cc5720152b9ddb1df305525253e31936794ffff0d440007bb170ec3bf6a5f7ae",
+              "baseImageDigest": "library/debian@sha256:d07d1b51c39f51188e60be9b64e6bf769fa94e187f092bc32b91305cfa34ba5a",
               "osType": "Linux",
               "osVersion": "trixie",
               "architecture": "arm32",
-              "created": "2026-06-01T05:17:15.1706757Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/debian/13/helix/Dockerfile",
+              "created": "2026-06-24T16:52:05.1406006Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/debian/13/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:44962d24e6eade7f68109b35186b868dea839e0cac6799537a2e416b645e740a",
-                  "size": 20014396
+                  "digest": "sha256:dc1682d43f5a48d32d05e4d635b2f02c34ad69d58dae613a03d26aa47ae4c3df",
+                  "size": 20026135
                 },
                 {
-                  "digest": "sha256:8d8f479892808874e38d0bf34edc1a5409d206b40294622547abde0b8efa66bc",
-                  "size": 3533416
+                  "digest": "sha256:250ac3d52c915533aa66d2b34c4544954cbdfb216202e15b49e354dde56b2413",
+                  "size": 3533317
                 },
                 {
-                  "digest": "sha256:63a97b2ad44e823099a6707d4e098a1b2e8b5eb5f7bb29ed1099bf070f3192ac",
-                  "size": 3684
+                  "digest": "sha256:4aa823e8fa8dcc40f0db76c2fb8c5f9e0caad9016185cb88962388869577ddce",
+                  "size": 3682
                 },
                 {
-                  "digest": "sha256:b625df7f5ecb44ee14f94ab14840fcdc5c134105e20527bb9d365a5bbb5f77e2",
-                  "size": 513365141
+                  "digest": "sha256:cbeb10d9085f12833c61b27a8704c20cd989b7704e491ea0c97593c53c08bcb3",
+                  "size": 513407372
                 },
                 {
-                  "digest": "sha256:16329e57da118ecb493828b7b07e7a4228b11fef4bc65ec0fa8d7fc9fac39b62",
-                  "size": 45742031
+                  "digest": "sha256:6ec13525e08787ad79558c5631e8f1a1fa24a87872974d31cec094e902b73822",
+                  "size": 45748717
                 }
               ]
             }
@@ -5809,33 +5894,33 @@
               "simpleTags": [
                 "debian-13-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:32b177a6d41b3f01dc4b2b9b863a1d3051b2660cb7e934dd3991c763b1636af7",
-              "baseImageDigest": "library/debian@sha256:4ae67669760b807c19f23902a3fd7c121a6a70cf2ae709035674b23e712e4d62",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:3d5eec53b199f1269011a6ec3e554c41cfb2eb33821e5944e05a5c9fbf001ef3",
+              "baseImageDigest": "library/debian@sha256:d07d1b51c39f51188e60be9b64e6bf769fa94e187f092bc32b91305cfa34ba5a",
               "osType": "Linux",
               "osVersion": "trixie",
               "architecture": "arm64",
-              "created": "2026-06-01T05:18:57.7952466Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/debian/13/helix/Dockerfile",
+              "created": "2026-06-24T16:54:45.9427564Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/debian/13/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:f3945f6651021341d2057605d3954ca41279e885eceeba853b7d67be093447fb",
-                  "size": 20962366
+                  "digest": "sha256:4d9b2056ce73e76d66cf86d8d209e0627900c91549f1ebabb1ad8f4ff275616d",
+                  "size": 20961408
                 },
                 {
-                  "digest": "sha256:0605cc8bc216dbcad5c8dd7fbc13d19afdae5e45f4efdd22720b5b4939a5a692",
-                  "size": 3533455
+                  "digest": "sha256:ce91b97ea69f6c2eb9c83b400cccc165c1c8786a89054e371f28b13f9159d87d",
+                  "size": 3533158
                 },
                 {
-                  "digest": "sha256:9a58d8b33322df0fbe337c35e89da72fb846f85c995a8f062476b5779c4f63e9",
-                  "size": 3685
+                  "digest": "sha256:12129d14ff6fa460b5e2d86892a0d1e177d30a7a25afa0e49433558446f0f959",
+                  "size": 3681
                 },
                 {
-                  "digest": "sha256:7da5ca7a207545d13bfac7467dc56199589635e367564edd9901e501daec496b",
-                  "size": 554384889
+                  "digest": "sha256:7714d05b39b968a4eacc79aeff75252c66da23d1d0c2f8bd83bdc87d2ffa8d40",
+                  "size": 554422188
                 },
                 {
-                  "digest": "sha256:635135721e54f918d2d81497bc66b71f98aee3b440dd6498218827c56d7d277f",
-                  "size": 49672220
+                  "digest": "sha256:c8a311258fd162f6aa0db134045a19154c81a2244ff9ed7620256c95ae5d6b69",
+                  "size": 49678395
                 }
               ]
             }
@@ -5848,29 +5933,29 @@
               "simpleTags": [
                 "fedora-42-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4bf2b9e1339ad85337d2252587e8a3e4992245d26e3e570473bce7934d2a2024",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:68df174befbd434d7529fe75d8a2ac843fb33d4a02795bb577c622a92010a586",
               "baseImageDigest": "library/fedora@sha256:99e203b80b1c3d8f7e161ec10a68fd02b081ef83a3963553e513c82846b97814",
               "osType": "Linux",
               "osVersion": "fedora42",
               "architecture": "amd64",
-              "created": "2026-06-01T06:19:34.1222909Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/2f061b93f8153e174e411294d6e9cd421dfb968e/src/fedora/42/helix/amd64/Dockerfile",
+              "created": "2026-06-24T18:42:23.1907909Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/fedora/42/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:9200a2c15de712c443f71e43b1be70a3827dc1fa9a1063379934610d9e4461ba",
-                  "size": 20796623
+                  "digest": "sha256:680f51ee972f748768d7780eb1e3b137877d74614fe2632cac5efafafd1f9c19",
+                  "size": 20814845
                 },
                 {
-                  "digest": "sha256:c77263ffc4bd34dfbf9e710ea29e84a3e7fd299cf07676fbb4244839e92e3224",
-                  "size": 3361195
+                  "digest": "sha256:9c7f61244014b58e78feba9f16abb5d7ea1182ddde950c0a824e250d4d5dc582",
+                  "size": 3361141
                 },
                 {
-                  "digest": "sha256:6bcef30a900aa1c8b3b46e8bc615a70307dba778887ac695dc9448466261d0e7",
-                  "size": 43569
+                  "digest": "sha256:b462de180bac6b9838813538a678deb5b8b24324eee01f4a81a6de31216c12d8",
+                  "size": 43578
                 },
                 {
-                  "digest": "sha256:3f0c3deecc1c45e4d06c54710a38369294097885e767a04be3a825fad70450f1",
-                  "size": 296444119
+                  "digest": "sha256:493729cf6b66cf0492ddcfd95e4cfbbb638b88a5db48be103267a759f80176f2",
+                  "size": 296445482
                 },
                 {
                   "digest": "sha256:accf5bbc0c673c47ad630c95ca23849b2f9c9a1064e61093f4c2b7ad79be4f8f",
@@ -5887,21 +5972,21 @@
               "simpleTags": [
                 "fedora-43-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8b1b81947ed2c94a9306a132be14a7f29905c8f64b9c39f084eaf3e9ef21fa89",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:fb476e6522e0298dbe497d56f3aa80b131724e05365aca894e8770c05b36bc11",
               "baseImageDigest": "library/fedora@sha256:762d73ba1c455232b0272c5d445a34f36c4b9f421cbc05ce8102552325b6a222",
               "osType": "Linux",
               "osVersion": "fedora43",
               "architecture": "amd64",
-              "created": "2026-06-01T08:33:18.8679779Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4616ef5dd1cc16c2c932d38b14bac303e1e2d32a/src/fedora/43/amd64/Dockerfile",
+              "created": "2026-06-24T21:11:35.6761548Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/8acd88f6876e255ab30581ea2859449f975c2828/src/fedora/43/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:cd1f0f29a54b3159bdafc266ca45870bfa643d44ada46b8de9f1ed2fba74a8d2",
-                  "size": 79954525
+                  "digest": "sha256:c69932c7b472e9ff0fa4e72972f2ea13ec962854b65b0191fcd5acf49cddd086",
+                  "size": 79765631
                 },
                 {
-                  "digest": "sha256:379f10fdb597030fad59e99d06a8ad27cae081f5d399977d8fb656652c43016d",
-                  "size": 576674820
+                  "digest": "sha256:dc878625450febaeef8f3d8df90dc1ceb7e11f9983a065cd259242649f5c95a9",
+                  "size": 589452302
                 },
                 {
                   "digest": "sha256:1fd43c80f797bf345b2afc94cb5e652a1f917ee52bc5d01191ddba6b8668915b",
@@ -5918,33 +6003,33 @@
               "simpleTags": [
                 "fedora-43-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:681071c3e1327b1cf55dad2bdd7c7cfc73a4bbd34194a3dce91457a71fedd84f",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a33e69b1677488c5d7fa0a63e978e42d244b792efca26b0c06e912b34933ea92",
               "baseImageDigest": "library/fedora@sha256:762d73ba1c455232b0272c5d445a34f36c4b9f421cbc05ce8102552325b6a222",
               "osType": "Linux",
               "osVersion": "fedora43",
               "architecture": "amd64",
-              "created": "2026-06-01T08:33:27.8283336Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/29c0482719d8c1e787440d47c20b325357697b8a/src/fedora/43/helix/amd64/Dockerfile",
+              "created": "2026-06-24T21:06:30.8520458Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/fedora/43/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:eea8d3ace2ec1921e974e81c794a8d1c24372cbe91093d3a605605c1315f8351",
-                  "size": 21494382
+                  "digest": "sha256:228e1a896c00988d2071a94ecac9628a9a7000e8ef971fcd1241163214bd2e9b",
+                  "size": 21494366
                 },
                 {
-                  "digest": "sha256:6e98d46e0bfce1af5a944cba7c3a19449073aec87e54c0e11a69431400cca1c3",
-                  "size": 3538414
+                  "digest": "sha256:b97508e096141f3fbf69a28009d3f7b06eabdbe45634f950da25d76aa5ff29d2",
+                  "size": 3538428
                 },
                 {
-                  "digest": "sha256:8b902c1a6a16c6e2015f66a3610f1d3d0418ccd6b41e7dd0db5a0a687db2f5aa",
-                  "size": 43292
+                  "digest": "sha256:4668995b08b1f53eb57d67dfc2913e04bf394393318b8629645fefa999cce1f8",
+                  "size": 43296
                 },
                 {
-                  "digest": "sha256:3f5f6d056b4cb5f0975169ce04fd162b68226b5eaa9070f636057aa4f6db244f",
-                  "size": 195045428
+                  "digest": "sha256:db17af1cce32235b726f580b0c78e18b2baabdc7e3574207bbb167200dcd4c94",
+                  "size": 207840631
                 },
                 {
-                  "digest": "sha256:2d38f0c0f335c2b650f8835dba70f69acbc385a5376b25c32b3c300bf890114b",
-                  "size": 77258952
+                  "digest": "sha256:3897470226eaed01591a8075e569eee05930716e03f73a939e3fe307a3438047",
+                  "size": 77697950
                 },
                 {
                   "digest": "sha256:1fd43c80f797bf345b2afc94cb5e652a1f917ee52bc5d01191ddba6b8668915b",
@@ -5961,21 +6046,21 @@
               "simpleTags": [
                 "fedora-44-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:157affe600f1bbdd3272948b2bf0c00178c028b84083ac883b76f5dceeb07c61",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:2fd32dca96c421987a06feae2bd0b4fe6d823a41476573b81362937e45bb6243",
               "baseImageDigest": "library/fedora@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898",
               "osType": "Linux",
               "osVersion": "fedora44",
               "architecture": "amd64",
-              "created": "2026-06-01T08:36:59.6815109Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4616ef5dd1cc16c2c932d38b14bac303e1e2d32a/src/fedora/44/amd64/Dockerfile",
+              "created": "2026-06-24T21:05:14.486039Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/8acd88f6876e255ab30581ea2859449f975c2828/src/fedora/44/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:708cd4eb4f57422c9b623bcdbe8f33ffe4a9594f835485f6eb9fdbeaeb75d88a",
-                  "size": 79954489
+                  "digest": "sha256:38a1bb2025596b87ddbb7649713bcc78e53094748e383f7eb745be5dcee18045",
+                  "size": 79765617
                 },
                 {
-                  "digest": "sha256:3521316df5ae53f01358cc49d465b16eb14e8ea2ed3bfb822995904a5dbddcb7",
-                  "size": 578673536
+                  "digest": "sha256:acfb659fea963e9c08f36ffc6c35f0292731388e2831f13ff67f4e74231eb652",
+                  "size": 593495919
                 },
                 {
                   "digest": "sha256:4dd84e24b4ebeafd11df963cf2ee4b8544198650dd964a0f008448a2e2664f2b",
@@ -5992,33 +6077,33 @@
               "simpleTags": [
                 "fedora-44-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:43e56a12d44ddebdd406b54813902fc7d4dbf2e8dd6c501d702eab9222a91a6b",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4096bbf8e5e57083fba6c6b0fad5384575695e6f5067d18a12db3a8b59c49d2f",
               "baseImageDigest": "library/fedora@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898",
               "osType": "Linux",
               "osVersion": "fedora44",
               "architecture": "amd64",
-              "created": "2026-06-01T08:44:19.475213Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/29c0482719d8c1e787440d47c20b325357697b8a/src/fedora/44/helix/amd64/Dockerfile",
+              "created": "2026-06-24T21:06:38.1884089Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/fedora/44/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:27acc8967295164750e7021e0cb9a040001581df8ed9e026bd5404765c9558a9",
-                  "size": 21264957
+                  "digest": "sha256:fb09f59f08a79de843bb82067334447dabb5a4056b7cb60f4db5a00ab26860aa",
+                  "size": 21269079
                 },
                 {
-                  "digest": "sha256:5ecff0a74a305b6bca0c1deaaa96d9704807c053bb3bfb8da55bf4f646626310",
-                  "size": 3309100
+                  "digest": "sha256:ea6aea43ffbf45be5ebb7b82f84f1b424378116362ad3b89cbb1f049b52826ad",
+                  "size": 3309079
                 },
                 {
-                  "digest": "sha256:82af684cafb17c9303d4a9b8fac5dd0f05361991fb5d25a3fe891873a4995421",
-                  "size": 43901
+                  "digest": "sha256:182f6ad06f4246ca72c8733d5269bd804275c7539038507476d2b69fb31c0c36",
+                  "size": 43904
                 },
                 {
-                  "digest": "sha256:f965bb32d8bc6b1b28f04788a289eb9184cd81ed558a7e78d1e97efbea91b07c",
-                  "size": 203686603
+                  "digest": "sha256:43b108a4b0b7d922996ec7dff4786342cc05ed7187fc31be6972f20e882e8176",
+                  "size": 218555929
                 },
                 {
-                  "digest": "sha256:b43702b8350af272027471eeee11a3a6f1d4be49b59132d66c3e7ab3e14a46cc",
-                  "size": 74677796
+                  "digest": "sha256:273cc6a326fa1c6f89239b8b4a35897d7307cddb527b14bdb4e5bc6e457db679",
+                  "size": 76450908
                 },
                 {
                   "digest": "sha256:4dd84e24b4ebeafd11df963cf2ee4b8544198650dd964a0f008448a2e2664f2b",
@@ -6066,33 +6151,37 @@
               "simpleTags": [
                 "fedora-45-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:dcca86340bb350628ce43247923ae8920b258b1afe04b48009ddef1694a2a4ea",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:e3afd4df299a82b3940bc25734dce96b73f7ae6f448c3e73c04dd82c21865eb3",
               "baseImageDigest": "library/fedora@sha256:0c1f63ed8fb818fad16cf6ae091598c410a21d2e1a9adf183beb93189299bfba",
               "osType": "Linux",
               "osVersion": "fedora45",
               "architecture": "amd64",
-              "created": "2026-06-01T08:49:28.6377739Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/29c0482719d8c1e787440d47c20b325357697b8a/src/fedora/45/helix/amd64/Dockerfile",
+              "created": "2026-06-24T21:16:39.3842295Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/fedora/45/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:f8a9d7577307e1683cf1049ded5127a0a581439fd7a6bfb6af907e102b91a18e",
-                  "size": 21359364
+                  "digest": "sha256:8c279c0d939cec7311b66bacd5b958c7c3134c87968d2634415639e076f1a2c8",
+                  "size": 21366034
                 },
                 {
-                  "digest": "sha256:f9d0ebdf03157c7daf5503182647f589fa5f35f88703eea55ccf6c15cdab8661",
-                  "size": 3404608
+                  "digest": "sha256:8280562d68b8dab51167c218c3dd6b88bc418132d9b2cb2e939066113dbff03a",
+                  "size": 3404557
                 },
                 {
-                  "digest": "sha256:c63b5df00a37f1b4599c0c274412eba76c84e1161b74dc19eab4266d2b322765",
-                  "size": 43897
+                  "digest": "sha256:ee2295cf3a02d0f40c41f02e3e4021de6d1285631f47978c4e6978ccca68a490",
+                  "size": 43901
                 },
                 {
-                  "digest": "sha256:ebeee501430204d2cedf1afdbbe226ec21bd824ddbb75d2bdd80a29feb668e1f",
-                  "size": 204645304
+                  "digest": "sha256:7d3f80d2ad8ed75be3fefe67b699583240dd4bda6242b6ef71adaa4bd2857824",
+                  "size": 174635630
                 },
                 {
-                  "digest": "sha256:2432b90e159bbf251ab5cbdf11b9d9481cb14729c7c159fa457f6a255f7ab05a",
-                  "size": 44895145
+                  "digest": "sha256:97a921eef243c486baacc40b831b4d5c134b94875399435816b14c51911e01db",
+                  "size": 138033356
+                },
+                {
+                  "digest": "sha256:4d28716d5969033cb8d805ebaa289a8d3831220075dda2fc8bc03f12e03d27b5",
+                  "size": 44896535
                 },
                 {
                   "digest": "sha256:f5df7f8b763e11a327a7dd55ef7f51f13067cb907030a71bb1d75cd820d20108",
@@ -6140,33 +6229,37 @@
               "simpleTags": [
                 "fedora-rawhide-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:aa1974c1cef800d53d3c7bab7bce88c091ac747b3b6b10ab05504705eed34ab4",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:91e317c75d79e7e542271e6c03be2d0c6deeff34a52ab8ddb2da35b23dd73d58",
               "baseImageDigest": "library/fedora@sha256:0c1f63ed8fb818fad16cf6ae091598c410a21d2e1a9adf183beb93189299bfba",
               "osType": "Linux",
               "osVersion": "fedora-rawhide",
               "architecture": "amd64",
-              "created": "2026-06-01T06:33:11.7370275Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/29c0482719d8c1e787440d47c20b325357697b8a/src/fedora/rawhide/helix/amd64/Dockerfile",
+              "created": "2026-06-24T20:12:52.7056124Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/fedora/rawhide/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:617e5bea3ffa7fa529ca2e84fb2096e461bdf108511f0f6d37fcb2cb80f7efb4",
-                  "size": 21358615
+                  "digest": "sha256:38e36516560ef50215a2ba31d552751a9377b72995a3b1754319f2652e41c9dd",
+                  "size": 21365703
                 },
                 {
-                  "digest": "sha256:b382d0782cc4b6f763bd1e0dc0868ca7d9c69eb6b53ee6df8a528975b5279d4b",
-                  "size": 3404618
+                  "digest": "sha256:29465a14afd90588561376b64d20edefe5590b32ad7896e54617a1f6ccd80c46",
+                  "size": 3404536
                 },
                 {
-                  "digest": "sha256:d1876a1883c51fc82929167689f1d3a9f029b9ca7ba9eda02a8091fbc758eb41",
-                  "size": 43897
+                  "digest": "sha256:2d069d2daea1e91ee28f8e864ab7e04d3879e76ea4ad6d749c3dfa5a3fbe7589",
+                  "size": 43906
                 },
                 {
-                  "digest": "sha256:21239fdc866d4aeb80aee6d130599e755890e15f79df9ef6f2ff2a10944cb358",
-                  "size": 204642819
+                  "digest": "sha256:dc929c22c7b65c7c910f485a58820f76c9b8f8dc4904f2c4e756ab5d64dfb8d0",
+                  "size": 174624198
                 },
                 {
-                  "digest": "sha256:1eb316c5fe3df1e109253e51e2cca8db52a9b8d7e2a6c9894e329e8f4a3952b8",
-                  "size": 44895124
+                  "digest": "sha256:3408911ac5825e13d31dc46fcc35c187e3ee4badb0348c6194b8dbc4ee649d98",
+                  "size": 138034318
+                },
+                {
+                  "digest": "sha256:cfe15a31d582f44e03d965994e47c3f820606059f0b7542d4203b70d6f76ef54",
+                  "size": 44896164
                 },
                 {
                   "digest": "sha256:f5df7f8b763e11a327a7dd55ef7f51f13067cb907030a71bb1d75cd820d20108",
@@ -6183,45 +6276,57 @@
               "simpleTags": [
                 "nanoserver-1809-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b37663ac0c14e420084a5d64fa20bd6e5d820fc4569653d6c5c2de1b7374b465",
-              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:8cfbc152747c948cc595b081d9e351b6968737eb9ace62d2fe7a47b7c4bf5e0d",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:cc1824ed636b6b8750af5a6e00fb5ef6e2232eeccf766b063d600dde16d2496b",
+              "baseImageDigest": "mcr.microsoft.com/windows/nanoserver@sha256:8282c8697d0ee8df810ecf84a6afecf01c9551555bcf1c495c93b51264990fd9",
               "osType": "Windows",
               "osVersion": "nanoserver-1809",
               "architecture": "amd64",
-              "created": "2026-06-01T05:23:09.0279446Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cf634bbfb902f5f7a88b520f3aa589bc4a2a2eb5/src/nanoserver/1809/helix/amd64/Dockerfile",
+              "created": "2026-06-24T16:56:32.6852903Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/nanoserver/1809/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:a14b2ce2c4944d0b6c3461aafbd6d7d42048784def599e22b80c0cb1a4785d4e",
-                  "size": 1271
-                },
-                {
-                  "digest": "sha256:81e962c028facad4c3ea52a50488d583a1ba6df8164f1e8cceed51e99e7c2cfa",
-                  "size": 175191
-                },
-                {
-                  "digest": "sha256:eff48defbe75d7cf6a30a2d12e0adfebef066d6eef17eeeecd9185004ff73d3e",
-                  "size": 73842
-                },
-                {
-                  "digest": "sha256:69733f879b4eab3975f6f55f957d38f39730f0803d12fe68fe970bebcea5c6db",
-                  "size": 32720994
-                },
-                {
-                  "digest": "sha256:3e79f1f85f6e6d6222f1f596603df8dee0c843efe0237ea0e161785a721d7c81",
-                  "size": 16798737
-                },
-                {
-                  "digest": "sha256:c3a283df826a952fb430b2d2050e1c323cd699052e225735fc79c551f853d31b",
-                  "size": 118329008
-                },
-                {
-                  "digest": "sha256:4ef643f6625bf1a4a361264d97bacbc9c6d58ddc92965179ae8c9013931767a4",
+                  "digest": "sha256:e649ba3c2554d75e5885196202d0d9e20efb35924eaa7135cb3b620a3b5c17ff",
                   "size": 1039
                 },
                 {
-                  "digest": "sha256:160ec44fc8bbb3af4bc6be53278d26045c9c9dc52d7a37a34e4ffc06e45c92ce",
-                  "size": 108926344
+                  "digest": "sha256:39bdd07fa7d78d8043dfaa0d6f5d3ad313f2774ca7864c32fe63347b0e65291e",
+                  "size": 1249
+                },
+                {
+                  "digest": "sha256:397b25b10e5876ba42c8f97206a5580c63437f42005c79c29493b640c46e0e41",
+                  "size": 174234
+                },
+                {
+                  "digest": "sha256:ae96db2361a65c877b7dd8656d42328ca582a61c146dd733b5b5848f478d0d41",
+                  "size": 71185
+                },
+                {
+                  "digest": "sha256:2779f052ff0e18fc0a3398eb8ca76225d8176e84a0526e2f0d4c4abd166a6046",
+                  "size": 30066603
+                },
+                {
+                  "digest": "sha256:f568798cfb4fce4280a8b413026e3b66d78f6369318e1b776af50354be2692f8",
+                  "size": 16798485
+                },
+                {
+                  "digest": "sha256:eb3060f73319d6cef9c9e8e66ad3c2d6384a9ca013bbc0f72f4fe08f1be62b5f",
+                  "size": 118076950
+                },
+                {
+                  "digest": "sha256:97932990dab7e6553e5bc3318d8728964dcacc3d4a0c7c8faff94be78c6539f9",
+                  "size": 1037
+                },
+                {
+                  "digest": "sha256:79ff4aef81747ddaa0b4d2dc10231f0dbdb41c25b67c6227a91dc065e159f374",
+                  "size": 1029
+                },
+                {
+                  "digest": "sha256:8b9c6ebc88c5f04a8a8a9dd9c18c8415b352b45699f76f83579c4c46371166b0",
+                  "size": 1040
+                },
+                {
+                  "digest": "sha256:43d446ce8b59cde0787aab3b5342dad243498a2758e34a9ce6826fbcc26cd193",
+                  "size": 108956093
                 }
               ]
             }
@@ -6587,41 +6692,41 @@
               "simpleTags": [
                 "ubuntu-22.04-helix-arm32v7"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6be2ccb181b5b5c34016e5966abc45e6c9ad2515f697dc3417e4b41a0359b37a",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:f7054b7d5262af3ffbb794eddc1e9e3331cdbd6adbb0be788d7f139c1aad5c48",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:edea8504b829dd5bcbe2c9d0c6e9d71004eb13214ffa7413628903a495b55c9c",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:2fb95c39cd913ced24e2aa85ca52081be176265a3058faed2fbd0d7e26f68205",
               "osType": "Linux",
               "osVersion": "jammy",
               "architecture": "arm32",
-              "created": "2026-06-01T05:17:15.5430625Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/ubuntu/22.04/helix/Dockerfile",
+              "created": "2026-06-24T16:52:54.2972592Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/ubuntu/22.04/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:8a9aca8aba07cf8d28034cb7b3d6be7f463fa85f87a2d21575c9ea157fa4cc3a",
-                  "size": 37202259
+                  "digest": "sha256:b9d9e037a2d5e9d5b3d61469a08a9a3b1d9182d90612b7ecd709b92418db0fc4",
+                  "size": 39026442
                 },
                 {
                   "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
                   "size": 32
                 },
                 {
-                  "digest": "sha256:5157aa3a386c0304ba05251eac082f73b34cb110e141e9f169319ea817f1ef1b",
-                  "size": 4546
+                  "digest": "sha256:e58a2922551df83b40567f2acb4eb6b7cb4323b8e3b6f85fb6804e6f0883e22e",
+                  "size": 4542
                 },
                 {
-                  "digest": "sha256:478045e33af7bc6ebe815d5d9ef77a390b698f01cb53db45cacd423a71796969",
-                  "size": 4833757
+                  "digest": "sha256:0fa1d319eadb93436c12fcc12a60992b96fd75841b89c46cc74a7d2b4f645e24",
+                  "size": 4833752
                 },
                 {
-                  "digest": "sha256:91e2f85929c99d267788f4b2c03ed16de48d9a90976209ec3a90ef6b9f037687",
-                  "size": 151
+                  "digest": "sha256:a92305bd08fd56c15a4b84e77ab02890cb026f527bb6fc64712f303b7ad5828e",
+                  "size": 150
                 },
                 {
-                  "digest": "sha256:af767535dfda2c8edb7b05a8bbc04fca67fc863a2b71be9bf72568bd77a81bfd",
-                  "size": 552720339
+                  "digest": "sha256:0735e307442249ea66bd9bbb42cfdececd0cb323b86f736d2f7735b3f0aefb0f",
+                  "size": 554759555
                 },
                 {
-                  "digest": "sha256:422dc0f0ec960f769d890f368bdf0a0ba195325ef487f5b07a4d06efaa7b2c41",
-                  "size": 26841796
+                  "digest": "sha256:380defa675d2dc4368853c5952af9b78cbffd143abd495c7450416b079f6eded",
+                  "size": 26843408
                 }
               ]
             }
@@ -6634,41 +6739,41 @@
               "simpleTags": [
                 "ubuntu-22.04-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:5dcacd6d5d1bd25df9bc466a2309fdfad709886a7590638b0f54d2ece7034c60",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:f7054b7d5262af3ffbb794eddc1e9e3331cdbd6adbb0be788d7f139c1aad5c48",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:4619327e97b925d075ebe49ec0de4ac7568c1cf4c02b13912cf87fdac074dc50",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:2fb95c39cd913ced24e2aa85ca52081be176265a3058faed2fbd0d7e26f68205",
               "osType": "Linux",
               "osVersion": "jammy",
               "architecture": "arm64",
-              "created": "2026-06-01T05:17:10.8075528Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/ubuntu/22.04/helix/Dockerfile",
+              "created": "2026-06-24T16:54:29.0194433Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/ubuntu/22.04/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:aed0a6b0590318da0a01441eedcf700e6dbcd77d0240d009c7becb077c5e0d20",
-                  "size": 34613630
+                  "digest": "sha256:2734ab5a6d5fd067b94ced5afe5c6f3f54623c4f412f4fe531ae37052a3e40ae",
+                  "size": 33763092
                 },
                 {
                   "digest": "sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1",
                   "size": 32
                 },
                 {
-                  "digest": "sha256:91b8e1468f5187968805ed0daced9f26296d666383fcb3bb3191fc77d9f9ff03",
-                  "size": 4558
+                  "digest": "sha256:8830dbe3b8a7b363c6c6683e596fa35f81189ccda0433e2b032c03310b21d2c3",
+                  "size": 4565
                 },
                 {
-                  "digest": "sha256:e15061061da43da26d5b2c3a53aebff5b673aa2178fbe6845824df745d381bfb",
-                  "size": 4871745
+                  "digest": "sha256:96bbad73be2681cee2b8553c4b2fa8ab453d6817e85e00552b93275d9e618658",
+                  "size": 4871512
                 },
                 {
-                  "digest": "sha256:48ef23d00fa15afba29a432f8a69b65459b123b5115bce6dbd840980742fdf4f",
-                  "size": 151
+                  "digest": "sha256:860a5e7589cae1ee7392f914ff43d1edf279589e3d922c1719d61bd059730a79",
+                  "size": 150
                 },
                 {
-                  "digest": "sha256:e3715a4da0a5261c735dd5a79f819ab7ffd95daa4e635f2313dc896682164d85",
-                  "size": 577018810
+                  "digest": "sha256:9d3bfc8d509087e5c354668cecffc12f489541716e5baef1a6515d9be086a720",
+                  "size": 579229986
                 },
                 {
-                  "digest": "sha256:99267111abcc4caf5e9b6f06fd8b9ca7ae7bff04ce06b24ca352c6007daaa73e",
-                  "size": 27606623
+                  "digest": "sha256:63c4878b3a401f70392301f0a6964b7ebd16110facf31bad5c887ceefc5ab2e5",
+                  "size": 27608286
                 }
               ]
             }
@@ -7010,49 +7115,49 @@
                 "ubuntu-24.04-arm64",
                 "ubuntu-24.04-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:151a85c112b12a3c0a388492a697b7864cc1c493640d1830be9022fb049e885f",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:8c10ecc59261c77dd866fa8587f1b9cbf172ad8f1253f0af96eaae0fa390c132",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:930fe4bbf7c0ff72f2583ffee9be7bd4726e1d23556ec5ff01b73492c16024a1",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648",
               "osType": "Linux",
               "osVersion": "noble",
               "architecture": "arm64",
-              "created": "2026-06-01T05:18:38.9182841Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4616ef5dd1cc16c2c932d38b14bac303e1e2d32a/src/ubuntu/24.04/Dockerfile",
+              "created": "2026-06-24T16:55:18.7966684Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/8acd88f6876e255ab30581ea2859449f975c2828/src/ubuntu/24.04/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:3a89b0349de4ba42bde353c94786b12f36b6d8bb17c5fa75c1fee71880c3d91e",
-                  "size": 48654549
+                  "digest": "sha256:e6de8c0a7c8a96b1f883e6e009595d080642343985bb84d9d0e980eaf2b2be42",
+                  "size": 48640186
                 },
                 {
-                  "digest": "sha256:0899a7265cf24214f9bf69054a01a991471c1ad8eafad142f4d952b6f49d823f",
-                  "size": 75670078
+                  "digest": "sha256:f7d890f34064ee97bd2e13dca0b64d5c976e1a3183c969228111224233e6ca51",
+                  "size": 75507203
                 },
                 {
-                  "digest": "sha256:b6b83ed232bffccffd2bb9e11d3c9160b4440dbd308535da99dc2d1143dd26a4",
-                  "size": 1484062
+                  "digest": "sha256:5a340d0735440628ad5881d171f75fd8b98b54e5b11d734b76ac906d9c71b6f4",
+                  "size": 1483832
                 },
                 {
-                  "digest": "sha256:bb3dc2611c5aa448f401e0b5999237a7a0e01dbac72e0bde1fc071bd8d17d4d1",
-                  "size": 26159712
+                  "digest": "sha256:c130b4eaf777e7bc85e094bf9c5c6c685d43f7f7f554582941a0e95199e98645",
+                  "size": 26159083
                 },
                 {
-                  "digest": "sha256:dd2cad96379753f49d361f6390d9aee4a7d9d94a15d250f0096165b9afedc4e8",
-                  "size": 122720154
+                  "digest": "sha256:36e6f4278a0ee9820e733c6aa38b60cb867fb1b623487270cc711c2b87800915",
+                  "size": 119438198
                 },
                 {
-                  "digest": "sha256:85d7b5b86dc1c7c7235a3ffeb9b269bb29f7d6597ad605f97d070f0ee3eca2de",
-                  "size": 866606
+                  "digest": "sha256:1eda28f5588d2240e6f57d5947de36a41fb1d0c8d6fd239b5a2424f28dca0d33",
+                  "size": 866602
                 },
                 {
-                  "digest": "sha256:cfad00d45587155e20b5f01d7404547e8772dc51e325d9d2b65ea78d6a991e4f",
-                  "size": 24920530
+                  "digest": "sha256:25dd59c96f1ce8924ecd7a722d5bbbf5fcbe01b9711f564c1364d50de17a533c",
+                  "size": 27319892
                 },
                 {
-                  "digest": "sha256:ae82756bfd40be90e7d68673757517be57faa21788875adffc939c28eb68d999",
-                  "size": 382750185
+                  "digest": "sha256:1c189901526c105b6d1a2a07914ab28d170f75dfe6258041d0fd303ea70f142b",
+                  "size": 382726392
                 },
                 {
-                  "digest": "sha256:fff3795b437199a0b714aadba6fb2c251d7da853c3e257d3fed1d2c8d0f05158",
-                  "size": 28876406
+                  "digest": "sha256:4b987da45db4d6278590ab89840c7167ea397df222f3ee4cdb77c3e15694b1a9",
+                  "size": 28884180
                 }
               ]
             }
@@ -7151,41 +7256,41 @@
               "simpleTags": [
                 "ubuntu-24.04-helix-arm32v7"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1abc45b0bd5e87132b1f3e26d3c6e5397acf87e6f19d262f331b258573962557",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:8c10ecc59261c77dd866fa8587f1b9cbf172ad8f1253f0af96eaae0fa390c132",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:975ac16650e33037a9fb6e7a229f19e7b0987f0e1a59075ddf20194f378a6ad9",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648",
               "osType": "Linux",
               "osVersion": "noble",
               "architecture": "arm32",
-              "created": "2026-06-01T05:17:59.4389202Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/ubuntu/24.04/helix/Dockerfile",
+              "created": "2026-06-24T16:53:16.2324593Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/ubuntu/24.04/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:9eb11060e8a66084064413a2681f2de3e8dd0831b4fae99dbe7c0a5b11022063",
-                  "size": 20661957
+                  "digest": "sha256:38abcaf1cc4e512c6cc46e66b0dd2950d964b4960739eb75403044278cd39e75",
+                  "size": 20665487
                 },
                 {
-                  "digest": "sha256:0e018cdecca7052f04263eaaedb271e16e654f782299f0e90b358cca0a15c187",
-                  "size": 4200637
+                  "digest": "sha256:e0dc03582ec15b15f7aa9b53164fe4ca746732001a4798fbe9c4c11e6e0b219c",
+                  "size": 4200840
                 },
                 {
-                  "digest": "sha256:d915a1cd3935a8717ff838d9c1b969016f1794b42032bdbd29190b17fdb90ac5",
-                  "size": 3853
+                  "digest": "sha256:854e24d30612b2a102cb168ac3205acafccccf8956f05ddd077aa1b10b34ec29",
+                  "size": 3848
                 },
                 {
-                  "digest": "sha256:42a8ddc55b00864d398a2d01290ad8f92d2ff0d0e5d6cd543e512c3f5bbfb9d4",
+                  "digest": "sha256:ff7820ab09ccca8b3aabbb8f0af93cd00d69dd3153fe2f7eb5f2528da7013e70",
                   "size": 1567
                 },
                 {
-                  "digest": "sha256:765a492f54419212e7be278fa8d75e3a509dbba736993111d0a841f4347da65a",
-                  "size": 7057969
+                  "digest": "sha256:4fd2d8be5df93d313911611f6963be8a07ae0d5260b07cf9fbc25f051035c6d1",
+                  "size": 7058833
                 },
                 {
-                  "digest": "sha256:5ba7f3abbd6ac6e3123591ac317f4152418ccc27bff6d3c8f1d68ff7cc9d36fd",
-                  "size": 506575469
+                  "digest": "sha256:38479370f52ca4dd39cedc24ed76f125fa4e8e5e4d97a7dc07743b4ef35f4ba1",
+                  "size": 508700984
                 },
                 {
-                  "digest": "sha256:a2dede8d0e9ca179460cb274dab10c5c4b741cf1544b130df872809a4467e3e4",
-                  "size": 26859709
+                  "digest": "sha256:67abbeb92f85087f969de6f6864f7b5cc172fa05098a68931182f6e5b4d2d8c6",
+                  "size": 26862593
                 }
               ]
             }
@@ -7198,41 +7303,41 @@
               "simpleTags": [
                 "ubuntu-24.04-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:430323ab0bb6d285f00438fe80680fb75ab6fa27f6ab35ad89a28e9441eb4efb",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:8c10ecc59261c77dd866fa8587f1b9cbf172ad8f1253f0af96eaae0fa390c132",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:daf6966d534cac446ce8774091c0080b733addcde1ef86234fb75a80c1607a8d",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:22a8228e1e48cbe7e0e0f2056e752ffb8a35950cda150a4e5e16417200bec648",
               "osType": "Linux",
               "osVersion": "noble",
               "architecture": "arm64",
-              "created": "2026-06-01T05:18:42.4451458Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/ubuntu/24.04/helix/Dockerfile",
+              "created": "2026-06-24T16:55:17.8282554Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/ubuntu/24.04/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:d2521eaa8e23a2ef053d3c2a59bb5f2eb67dd191c676e0497f68f88e2abfabfc",
-                  "size": 21597470
+                  "digest": "sha256:9eb59b636d0dad349dc58d2a4008cd06fe3ac36237b37c587277e49ed32bb861",
+                  "size": 21604440
                 },
                 {
-                  "digest": "sha256:c8636ca4d09fe68947e385ae9abd3107a38df71657ca27a6f037641dc05d5973",
-                  "size": 4200697
+                  "digest": "sha256:f1974c7421b6097229e8f5a63f4fef6a58104094b662b07c7dffd726eecd905a",
+                  "size": 4200619
                 },
                 {
-                  "digest": "sha256:c2d58d2d0cce8f8bc9c8ac88efed5737c89d7ec07095f25ca2ec08d6613508a5",
-                  "size": 3849
+                  "digest": "sha256:0d606a5c1a175032556e66103b50f3313aab55e3c842b17aae09b3f226a89bea",
+                  "size": 3840
                 },
                 {
-                  "digest": "sha256:bf7cf7881fd62449218a6679e7cf8245457447dda7465f313b949ecd35361cff",
-                  "size": 1569
+                  "digest": "sha256:841ee237977c9bbbdeec68fb39b008c0f386a5b1a7e638c151ca11b12d33b3cd",
+                  "size": 1568
                 },
                 {
-                  "digest": "sha256:bda61133ed91c73420d6e3254b3f4be16d4df69a9ed8bf0ca99ae294aa1fe80e",
-                  "size": 7140898
+                  "digest": "sha256:7b6265d719e0c2b8abf7a7b29edde07257166c4a34a03dbb394d89f3ea738667",
+                  "size": 7142325
                 },
                 {
-                  "digest": "sha256:f74f8fd2e0d964186e66ee08901af8ed9cabc082879c8f65f5d1234a156c3446",
-                  "size": 530789076
+                  "digest": "sha256:7aafa3cf4ea7747ae9a8123c8545eba3f02ffb31f9a90f69fc444bc42d90efd6",
+                  "size": 533155867
                 },
                 {
-                  "digest": "sha256:fff3795b437199a0b714aadba6fb2c251d7da853c3e257d3fed1d2c8d0f05158",
-                  "size": 28876406
+                  "digest": "sha256:4b987da45db4d6278590ab89840c7167ea397df222f3ee4cdb77c3e15694b1a9",
+                  "size": 28884180
                 }
               ]
             }
@@ -7380,53 +7485,53 @@
               "simpleTags": [
                 "ubuntu-26.04-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9fe0e26d2a5e7762356ca808327f62be3d588ab8550582ab79ccb9f68e091025",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:7ad0926092b4e45abc5acf33c5cdc9a6de52d5b0e12ed87dd82e5c79a8167f9f",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:c88fef1362fd8854bf8f97a07bb2f074ed8df29cb264dddb6d069aaca3c759ec",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:215ce47dc5c697ba3bcda7367ac1f6448d039306017d3c6a539dcefd2911efdb",
               "osType": "Linux",
               "osVersion": "resolute",
               "architecture": "arm64",
-              "created": "2026-06-01T05:18:15.749014Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/4616ef5dd1cc16c2c932d38b14bac303e1e2d32a/src/ubuntu/26.04/Dockerfile",
+              "created": "2026-06-24T16:54:57.4225762Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/8acd88f6876e255ab30581ea2859449f975c2828/src/ubuntu/26.04/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:c12a2af006379a4b97aa6ede1d7150f556b97e40599c1d72269a88f918f86ddf",
-                  "size": 48632991
+                  "digest": "sha256:c0142651ff59ed8b16601dc854bcd439fa17569510245a11d3c11d9ad8f511d3",
+                  "size": 48618201
                 },
                 {
-                  "digest": "sha256:5e46f35ca60ad79e944c87f0c023f6ffe128aa7ead6e8a750e6088a28e2369eb",
-                  "size": 75670077
+                  "digest": "sha256:0992f590d57820ac3d2f383db75a5a4feee00f5f722120ebba1df01f4f094e9f",
+                  "size": 75507168
                 },
                 {
-                  "digest": "sha256:0ed23785b48dd51c45be7efb6d971f8dab6b3843cb0b51eb09ad93b70d2ad296",
-                  "size": 1528263
+                  "digest": "sha256:2b34c5eef16a547ed4591c486e4dccb01f92aafdbe6c6fa1fff296b705f66f75",
+                  "size": 1528223
                 },
                 {
-                  "digest": "sha256:d1b563dc99302fee1c8bafa215f6d84d844c5f67190f86532285656bc490cb14",
-                  "size": 65875057
+                  "digest": "sha256:e38f209989f2dff816080980be538f560d4239074273280f993b09941ebba2cc",
+                  "size": 65996947
                 },
                 {
-                  "digest": "sha256:88957fbab2e09a2e2e846c42aa99288fac9137ed61bb902a3dbfa395c95db053",
-                  "size": 122761656
+                  "digest": "sha256:c1dfd7d84f3119cc926df0e2dd68ed57b5639a8be8e61993501c4d44cae19b4d",
+                  "size": 119478894
                 },
                 {
-                  "digest": "sha256:507a51f5e0e2c1df079eb38c6b48c8384071374ec7b99342dd2448ceec2184a2",
-                  "size": 868618
+                  "digest": "sha256:2302895e6826354ab097f5b57f2cdd0b1eae6172b844918ba39b9a69e028287b",
+                  "size": 868621
                 },
                 {
-                  "digest": "sha256:3907bcd9eb71c3a58d6a14810100b09504dd554ae19ee08599e14286e35468b0",
-                  "size": 28008011
+                  "digest": "sha256:72eacb40212437ae7fc749fd5be683548848455f1f96267553a27aeadda7e9e5",
+                  "size": 30424334
                 },
                 {
-                  "digest": "sha256:daf1e6bd4601d3ae074f4997db80706886060a057dfd81200289f113b78ee4f2",
-                  "size": 361503586
+                  "digest": "sha256:760363ab4fab50962589eb9b959d83e152200e8396aa8759da3e0ad4ad9e493f",
+                  "size": 361517334
                 },
                 {
-                  "digest": "sha256:4a7720058461eb4ae40ed203b9874ab3248bd34ffb9948193e99245229fdbd6f",
-                  "size": 390
+                  "digest": "sha256:c9dda33820b52cf93fd5ff3808c770af252cf0565784b42e52e3dd74e2ebf5b2",
+                  "size": 385
                 },
                 {
-                  "digest": "sha256:2113f8d7eb32748b14581824c1b94cea9ed9a08456312a2e94eddd522d01b927",
-                  "size": 40728955
+                  "digest": "sha256:c572f291b2a0cc05a1d523f3dda4d3f1992c3e480debf2e1bc9278aeab115625",
+                  "size": 40709186
                 }
               ]
             }
@@ -7490,45 +7595,45 @@
               "simpleTags": [
                 "ubuntu-26.04-helix-arm32v7"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:d844037ecb212233e9a64d410cc2db2d932bfbec7411d28b2a8e034c17eef50c",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:7ad0926092b4e45abc5acf33c5cdc9a6de52d5b0e12ed87dd82e5c79a8167f9f",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:95d429789f8c074a08153cb88ba3033c7ff068e98f57a46361f464910499eeec",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:215ce47dc5c697ba3bcda7367ac1f6448d039306017d3c6a539dcefd2911efdb",
               "osType": "Linux",
               "osVersion": "resolute",
               "architecture": "arm32",
-              "created": "2026-06-01T05:17:23.763459Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/ubuntu/26.04/helix/Dockerfile",
+              "created": "2026-06-24T16:52:19.0815213Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/ubuntu/26.04/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:98ff183c2e8bd761834c23ddcef33b0c0ab6d1bbe69fbb4764f6d3fa48a67101",
-                  "size": 20712095
+                  "digest": "sha256:c1d95dc01b782c79a2eb5ec7f89a8afd07f84ab6f26d390abef2f0b963ae3a4a",
+                  "size": 20731492
                 },
                 {
-                  "digest": "sha256:f73f536a47cb9c2f3433288f82d00746b3759ea703486e3a7aa565f07bf910f9",
-                  "size": 3702901
+                  "digest": "sha256:3c6dfcaa0907105f61857777e0e03f0d9617e849f35f08c492d39e149d02d6dc",
+                  "size": 3702746
                 },
                 {
-                  "digest": "sha256:91678aaaf5878c4dd88916f1395d4ce4eb7e478f3af15b5dae7e30bc4aabd721",
+                  "digest": "sha256:878531ea13c8208953b2128d24052fbd6b5283e1ce5d13e6aeb9093d0c2c2473",
                   "size": 3857
                 },
                 {
-                  "digest": "sha256:a555398275da45b5e3f5c2525679e265da3d69a58709a6d7834d91b104382c6b",
-                  "size": 1578
+                  "digest": "sha256:62296312ea5ed6f95e645fe83d8e435fc12304ecb41140cdbad4dfaf329d2f26",
+                  "size": 1581
                 },
                 {
-                  "digest": "sha256:4f8374dcc0e536450ec352a4de04e8cc3b8fb6c7db3d642648aef385ace9e901",
-                  "size": 4488557
+                  "digest": "sha256:2db8ca84c2edb0c99411a775d20481b03531f1de2abe858d2c78d77c09484dc6",
+                  "size": 4488827
                 },
                 {
-                  "digest": "sha256:336f2c4438cee9e6f9ceab6d42972a4b75507276a8a6e74614eec04814cba90b",
-                  "size": 529829714
+                  "digest": "sha256:02f476295dc72e6e47aa245996d27fa8fac4eaadab00ce60c2f67264bf034524",
+                  "size": 532114309
                 },
                 {
-                  "digest": "sha256:6e1e6d15d19b2a80e7f768ac0a91bdb2925087c53f3f94473451db1b255204d2",
+                  "digest": "sha256:c279c504cbdcf584210eab38c9b6180e5f540e26a0d226b9601877512d72bbf5",
                   "size": 388
                 },
                 {
-                  "digest": "sha256:9c6f78f81026c2f39f141ed672d14a3efb8ee8ae4d02c08dbd7d751ffa3c5038",
-                  "size": 38720288
+                  "digest": "sha256:3afcfc6322f1b6ea07a2fb9b031f643f9af38c2bf4625ad357d711767538dbf8",
+                  "size": 38703143
                 }
               ]
             }
@@ -7541,45 +7646,45 @@
               "simpleTags": [
                 "ubuntu-26.04-helix-arm64v8"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:2a0400a4274972efa528f4447831ee25bc9f1c412868fde9152379ebcc895e42",
-              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:7ad0926092b4e45abc5acf33c5cdc9a6de52d5b0e12ed87dd82e5c79a8167f9f",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:763221aafc767cb16b388c7c68d018c6e8953d0500957b699b6a196cb618b684",
+              "baseImageDigest": "ubuntu.azurecr.io/ubuntu@sha256:215ce47dc5c697ba3bcda7367ac1f6448d039306017d3c6a539dcefd2911efdb",
               "osType": "Linux",
               "osVersion": "resolute",
               "architecture": "arm64",
-              "created": "2026-06-01T05:18:48.8659862Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/d4b3976f199611f26eeba17ac01731d0744af96f/src/ubuntu/26.04/helix/Dockerfile",
+              "created": "2026-06-24T16:54:53.5896095Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/ubuntu/26.04/helix/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:e083aac883d4fa11fe7183eca51b1facfa9068c2868d9b4b5557a38985b9b4a8",
-                  "size": 21652774
+                  "digest": "sha256:9ee4762cf76a1004b186b2e0952f4d1826a62d25d67c9a82be9a0ef838fd9167",
+                  "size": 21653480
                 },
                 {
-                  "digest": "sha256:67df5a1320a5c81d373230c56ad419ff5fe2d2a8baf907bceae9377afd7861ac",
-                  "size": 3702538
+                  "digest": "sha256:147bb8fb47eb2354d63154a2629a831a932ea5782fa021164852661d7fbb82cd",
+                  "size": 3702635
                 },
                 {
-                  "digest": "sha256:830942828948d5bcd4ff8d64b777dc89869952737689819267c7983b3e2cd167",
-                  "size": 3862
+                  "digest": "sha256:97f20e1141a203a7baee71aca952e7ddc747099d44c36f2fb92fc3efe1516a44",
+                  "size": 3864
                 },
                 {
-                  "digest": "sha256:ec7bbeb358ee5a951b952dac13db05905a22faf01c0997dfb6d6354b18a7dedd",
-                  "size": 1582
+                  "digest": "sha256:2124fbcf8e8cfad9f61ff4ffc82984c37d066970b5dd280ae453db2f478c3042",
+                  "size": 1583
                 },
                 {
-                  "digest": "sha256:070638f8b8372b62a3688f52a4bcc36a627f4c705f7e2983bdc43ffd6758ee29",
-                  "size": 4522165
+                  "digest": "sha256:1785f2336b88cd86b1dd088640f583f47dfdfae2b71f857b2ce0105525e68c03",
+                  "size": 4521952
                 },
                 {
-                  "digest": "sha256:e8b7a36c550f50f4ce297dcdd7d9dfe2824d63d945e5e75a4374ee300e8d75db",
-                  "size": 573030066
+                  "digest": "sha256:9df205a05a345b13103c5b0e7c9be83f8fcfce18ee3f7ce2bc6cb06b58d2a5ce",
+                  "size": 575531322
                 },
                 {
-                  "digest": "sha256:4a7720058461eb4ae40ed203b9874ab3248bd34ffb9948193e99245229fdbd6f",
-                  "size": 390
+                  "digest": "sha256:c9dda33820b52cf93fd5ff3808c770af252cf0565784b42e52e3dd74e2ebf5b2",
+                  "size": 385
                 },
                 {
-                  "digest": "sha256:2113f8d7eb32748b14581824c1b94cea9ed9a08456312a2e94eddd522d01b927",
-                  "size": 40728955
+                  "digest": "sha256:c572f291b2a0cc05a1d523f3dda4d3f1992c3e480debf2e1bc9278aeab115625",
+                  "size": 40709186
                 }
               ]
             }
@@ -7672,41 +7777,53 @@
               "simpleTags": [
                 "windowsservercore-ltsc2019-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:a451fee134e89af6ec3913b17c2a47f5ef55e98ea5eacac1723591898493933a",
-              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:cd96c9b4873aba2f63716934ed5e535ec21c8d3dc32d29d9bc778be28f19cbfa",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:675c5f21174adf4d0cc5ba4b8457e3418966f5251d005d5b1b841b8caabd286e",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:59d374d44d844cef8de438d60fac13c22e1841f06e28c665d734822b878f5d55",
               "osType": "Windows",
               "osVersion": "windowsservercore-ltsc2019",
               "architecture": "amd64",
-              "created": "2026-06-01T05:23:42.9550616Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cf634bbfb902f5f7a88b520f3aa589bc4a2a2eb5/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile",
+              "created": "2026-06-24T16:56:39.6323466Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/windowsservercore/ltsc2019/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:938382c7e86b9692e094ceadbb180de16bb730e5569a300bca5c9ee5b31587e4",
-                  "size": 1443
+                  "digest": "sha256:8476078369616bb7791dd23d268103af22514feeb6dbf0757018eff912aa0b85",
+                  "size": 1304
                 },
                 {
-                  "digest": "sha256:27a0e39f747abad95bfa149860046438e91d89992a682f60202eeb2d1efdc79a",
-                  "size": 336476
+                  "digest": "sha256:dce4a79392d81fd2dc036ff1baf1d6a0728b57ee52b8a4d3d6ec9af5d3d22800",
+                  "size": 1475
                 },
                 {
-                  "digest": "sha256:26c3da4679b5a21138837243a88a4d97a86d60acb68759491db4cd7912e67e87",
-                  "size": 391790
+                  "digest": "sha256:c7992ae922f45e67affb8f9d1c152689e63dda10a02fab907fe860e4434227cb",
+                  "size": 350830
                 },
                 {
-                  "digest": "sha256:1cd28bd7da7fa9bf17bcbcefdcf1f892b8be8eb63b73452df0744c32ad4abed9",
-                  "size": 32719452
+                  "digest": "sha256:4059728f9992b64ffd1bf92eeadd25ebe481ce2162122345aeddcc138d9ae1f6",
+                  "size": 393435
                 },
                 {
-                  "digest": "sha256:5cf1ac60b679a6bb48843ff965e2e8838d2869370f98f71dfc79cd947682a6f1",
-                  "size": 16798467
+                  "digest": "sha256:d62a2c44a68d0f96f74781d4503f5b3e8a94b6eb177c6fb722bad101d16a708f",
+                  "size": 30066417
                 },
                 {
-                  "digest": "sha256:f899daeca57f6b86ac73016a9f617b83f656b93c6370d7e5a2adda52c816ced4",
-                  "size": 1292
+                  "digest": "sha256:60194549700b60b802217c85a6881ceee93a2287a3f0ee119ed5b1531f3ea2df",
+                  "size": 16798591
                 },
                 {
-                  "digest": "sha256:c84bbd81535e2b3e542dfc9aa52c58307c381e5480a7e4cd3235954d1570f306",
-                  "size": 581788157
+                  "digest": "sha256:f14afd92b2bff4ebc52d36256dc6bd0b21bf132874fa38e97eb9fc7fb6711c29",
+                  "size": 1291
+                },
+                {
+                  "digest": "sha256:4b4ab7e066c32b57d2237bd2942aab68db96c0af6390ac85aada53e5773b641f",
+                  "size": 1324
+                },
+                {
+                  "digest": "sha256:457f9fed16a04eac5c1a2e9bea3bd48636514855b0bf743ad851c8df1670c629",
+                  "size": 1299
+                },
+                {
+                  "digest": "sha256:f2bd6c530059937c9dc085ba6c3bb240ebbc6734d70c033c0b1bcf22813289c4",
+                  "size": 597697945
                 },
                 {
                   "digest": "sha256:14438130d31b6d796622524183cad5b87bc21e40555a933b4a2356bcc736b772",
@@ -7723,145 +7840,53 @@
               "simpleTags": [
                 "windowsservercore-ltsc2022-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b0feafb71d664eafa0f3d180e3a36a3587e466c92e35af6321469884c978dc21",
-              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:86da395cfd2b35dbfc2e9d08719550c51b0570c394bff8f92622a19234766185",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6bf81d9073f70e9256ced18ad32a8ab68de7dcda70ae52f784283a77336c8e2b",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:a23b350061d76236e2c427e32175a2decfe3214200eee4ae9ee9cd9e98f26bf0",
               "osType": "Windows",
               "osVersion": "windowsservercore-ltsc2022",
               "architecture": "amd64",
-              "created": "2026-06-01T05:24:51.2943852Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cf634bbfb902f5f7a88b520f3aa589bc4a2a2eb5/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile",
+              "created": "2026-06-24T16:57:42.0441613Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/windowsservercore/ltsc2022/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:480db4b3a60a1b7e58fe3c4a1dd6ba8644562058962ca9a29c2e4e2532d67be4",
-                  "size": 1449
+                  "digest": "sha256:d7f9e7a075fb21d36dc59eed58cfcf8da9b44c87421754fa7091b3d7b84bc0e2",
+                  "size": 1294
                 },
                 {
-                  "digest": "sha256:00dc732d14cc49f29acbd7718eb0b0fd04d4f40af340fd38de5d1dd86d77eae3",
-                  "size": 339863
+                  "digest": "sha256:6492f580990f5d06467dd2968b2b7b226161a150a29c97b975843c60bb05bf6b",
+                  "size": 1447
                 },
                 {
-                  "digest": "sha256:d1da42e4bca3d356e5796caa051e581315832ccf7d21db664c2ef0863ad9dc00",
-                  "size": 417178
+                  "digest": "sha256:03e9c0557c38872862371a749a1cb3991207475c283d8a3798f37ac04e03a66e",
+                  "size": 318285
                 },
                 {
-                  "digest": "sha256:f5d36e2ac452a387c55d222fe7daa98aafedc7fbf8de1adc7e1364a9a7eb3e20",
-                  "size": 32720113
+                  "digest": "sha256:6b3852bee56623ae1104129048a8ebc25d605827d0247c45fd7259660ac23c5e",
+                  "size": 401543
                 },
                 {
-                  "digest": "sha256:30b909a1a50e086d612f788e0a43a2dea2b32878af6f71cc74b4d0db36b6c20d",
-                  "size": 16798802
+                  "digest": "sha256:0431dd39fc71f7595d8b988b0ab4b44375867916046fbe5c8223f256fd353748",
+                  "size": 30067527
                 },
                 {
-                  "digest": "sha256:bb5f93e82261f4f15cd2208414c2940b84308d2f2a0fef26585c1ffea0804de9",
+                  "digest": "sha256:560b2c5094e43711f71da6ec54390b7b7ab4bb16be4deaa9a36821362aacd6ef",
+                  "size": 16798823
+                },
+                {
+                  "digest": "sha256:45bcadfa51a38db92448977438203237c3f88deed20cc5941662162962153ceb",
+                  "size": 1293
+                },
+                {
+                  "digest": "sha256:63f984e94db0eeb7b9c4dbaf4094b46f05c3fcb72b86e15e38e9224a3df40473",
+                  "size": 1291
+                },
+                {
+                  "digest": "sha256:855182312d2bdc5e91bad8f7de966b6eb6a48362b986587a64b54c024388100c",
                   "size": 1298
                 },
                 {
-                  "digest": "sha256:857865ad3eca4da109d969134a9cab7225d9de49597914ae325d43661900f513",
-                  "size": 633401492
-                },
-                {
-                  "digest": "sha256:3cc21a1b754848d23f00aa65cb94ec34c9a5dc6028b3aada42039c824738d02f",
-                  "size": 1489019076
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile",
-              "simpleTags": [
-                "windowsservercore-ltsc2022-helix-webassembly-net8",
-                "windowsservercore-ltsc2022-helix-webassembly-net8-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1eca0534c90b10559f4045fe7050fa38f799ce991bb1fa09ceed1f453418ab4f",
-              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b0feafb71d664eafa0f3d180e3a36a3587e466c92e35af6321469884c978dc21",
-              "osType": "Windows",
-              "osVersion": "windowsservercore-ltsc2022",
-              "architecture": "amd64",
-              "created": "2026-06-01T05:34:59.2551674Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/13bb625f484ea769094f1f4833991471eae50cd1/src/windowsservercore/ltsc2022/helix/webassembly-net8/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:c968baf5af2cb4bf8f842da9cbba040824f416bcbd74d1c291c6b805973bcc30",
-                  "size": 295608
-                },
-                {
-                  "digest": "sha256:7df1284e70f767852def8c4422a7a14cdcfcf62952c1b6579b5afbb5b63e521e",
-                  "size": 1289
-                },
-                {
-                  "digest": "sha256:6768403264bc75d2650bddc585be70bc20d4448d31989130051da8aba93a29fc",
-                  "size": 549707
-                },
-                {
-                  "digest": "sha256:11ecb09bec8224babe29bcce22d03a032c36213144d4535911cd288d96c03c19",
-                  "size": 37624110
-                },
-                {
-                  "digest": "sha256:9fc4997f1e84e17bc50c2438067580b0623f9fe6cabfe031e4bfce907c55127f",
-                  "size": 17227774
-                },
-                {
-                  "digest": "sha256:0cbe1956b6108b27eaaa955699703c43654fccbc3d13560a627b567edd28c0ad",
-                  "size": 1918
-                },
-                {
-                  "digest": "sha256:4b8afdda847e9c7e8ed212176e7787d6c6bbc68abde3b9b1672c075d6031010c",
-                  "size": 563983995
-                },
-                {
-                  "digest": "sha256:e51634fe6a4ed60626da78712e9e7cc5e31da71665b2b14d98e97c4a78f9975e",
-                  "size": 43129403
-                },
-                {
-                  "digest": "sha256:835c5d4a89f94420baa11b25d317a141ddaf33dd226df057a1abcea7966f9117",
-                  "size": 2722675
-                },
-                {
-                  "digest": "sha256:05f0c931ab1740f0bc6d7e22fda449d609563990045071bd6148dd708e1334c0",
-                  "size": 1292
-                },
-                {
-                  "digest": "sha256:95e00a3f80114a169c0ffad4f357448eebda582d1761565333c0c3de02c43ef2",
-                  "size": 1289
-                },
-                {
-                  "digest": "sha256:8dd2a63592e0fe66c82663fadf6f235505995b69cb35becd9a7d272885266fc8",
-                  "size": 1289
-                },
-                {
-                  "digest": "sha256:b668fb53df83a0a61a3e82d111e1106db05bac43c87c819a76c86b153ba02ade",
-                  "size": 1297
-                },
-                {
-                  "digest": "sha256:480db4b3a60a1b7e58fe3c4a1dd6ba8644562058962ca9a29c2e4e2532d67be4",
-                  "size": 1449
-                },
-                {
-                  "digest": "sha256:00dc732d14cc49f29acbd7718eb0b0fd04d4f40af340fd38de5d1dd86d77eae3",
-                  "size": 339863
-                },
-                {
-                  "digest": "sha256:d1da42e4bca3d356e5796caa051e581315832ccf7d21db664c2ef0863ad9dc00",
-                  "size": 417178
-                },
-                {
-                  "digest": "sha256:f5d36e2ac452a387c55d222fe7daa98aafedc7fbf8de1adc7e1364a9a7eb3e20",
-                  "size": 32720113
-                },
-                {
-                  "digest": "sha256:30b909a1a50e086d612f788e0a43a2dea2b32878af6f71cc74b4d0db36b6c20d",
-                  "size": 16798802
-                },
-                {
-                  "digest": "sha256:bb5f93e82261f4f15cd2208414c2940b84308d2f2a0fef26585c1ffea0804de9",
-                  "size": 1298
-                },
-                {
-                  "digest": "sha256:857865ad3eca4da109d969134a9cab7225d9de49597914ae325d43661900f513",
-                  "size": 633401492
+                  "digest": "sha256:6897a04901ec162be0eabd7eb636b5ac50d6e37c880f1db618610f2d777b1ce6",
+                  "size": 643106423
                 },
                 {
                   "digest": "sha256:3cc21a1b754848d23f00aa65cb94ec34c9a5dc6028b3aada42039c824738d02f",
@@ -7879,97 +7904,101 @@
                 "windowsservercore-ltsc2022-helix-webassembly",
                 "windowsservercore-ltsc2022-helix-webassembly-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8e4f47735cd1ace47f522d4c317426c4fe567f88340f93d63940660c3edcef77",
-              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:b0feafb71d664eafa0f3d180e3a36a3587e466c92e35af6321469884c978dc21",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:8143d3fc7490769ba64cdc7526866db3ba36c932963a513e999d6790f74ef838",
+              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:6bf81d9073f70e9256ced18ad32a8ab68de7dcda70ae52f784283a77336c8e2b",
               "osType": "Windows",
               "osVersion": "windowsservercore-ltsc2022",
               "architecture": "amd64",
-              "created": "2026-06-01T05:27:41.7216554Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/aa85f0dcc3b3d6757c80dc8c2a6f38c290b372cc/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile",
+              "created": "2026-06-24T17:00:04.5313862Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09f312cd5a1a92ae4058f78e933a16c67cce6606/src/windowsservercore/ltsc2022/helix/webassembly/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:188c3ae52c1bebd2275f3aceeb28f33523e868492fdab17feb66c2521c87e1d8",
-                  "size": 14880638
+                  "digest": "sha256:88ea6d4f3d1765b2aa7c741817f09fcfd03af32b0b5d5f465882ba447a8aa177",
+                  "size": 14884882
                 },
                 {
-                  "digest": "sha256:269066f5d6ee5b8a9b115657677206e50fca51a6c06e83f9139f5a1f3638d916",
+                  "digest": "sha256:3f0e78e6b68bf71726e545a64742b8dfa2fcd29904be7361313e8112714957d1",
+                  "size": 1297
+                },
+                {
+                  "digest": "sha256:e240cee1ca1544729eca9b14c25662d3ccb77dcc42ca7dc782304f3e9b45f9d4",
+                  "size": 309592
+                },
+                {
+                  "digest": "sha256:a50cf6aa860e2eae4e2eb9bdd8363cac597aa78851729f865c66ec5ea714e84e",
+                  "size": 294996
+                },
+                {
+                  "digest": "sha256:f899e2eb137c46922f7e4f7ece9420a994f25b7f2d51ec2c2728d619d5628aeb",
+                  "size": 1292
+                },
+                {
+                  "digest": "sha256:5b684bfd372721ab89f452b196e039a917b6ce9ed96f87d493e8b99205364ae1",
+                  "size": 549698
+                },
+                {
+                  "digest": "sha256:8408db691214615e7d54139cbbbed1b8b6b247a8056a008cf3f9ce9aa8c3427f",
+                  "size": 37639961
+                },
+                {
+                  "digest": "sha256:37ea0fd8aed8524499b6c10ff422ec0ea39a7305c55f46693c1f6f8d030bb0e8",
+                  "size": 17448338
+                },
+                {
+                  "digest": "sha256:fdcf93a1fc5b823d495e891b22897eb83315f95e3051cc549c424d0e7e34d270",
+                  "size": 1904
+                },
+                {
+                  "digest": "sha256:6284cdd8c88ab31024070eefa56b8be6425d44547431285450e74fdae8f284d1",
+                  "size": 27767232
+                },
+                {
+                  "digest": "sha256:bed7850461b10c262415cf578ed9c4af20107cd7499b1e300729d26f760733a1",
+                  "size": 1340
+                },
+                {
+                  "digest": "sha256:f686597aade7675b96982390f100895876de034ef9b6b0ab37921bca5f8145a2",
+                  "size": 1297
+                },
+                {
+                  "digest": "sha256:d7f9e7a075fb21d36dc59eed58cfcf8da9b44c87421754fa7091b3d7b84bc0e2",
                   "size": 1294
                 },
                 {
-                  "digest": "sha256:853c296f3a43e1592cb71244920b9355666d22b253283d986159b4b1fcffe875",
-                  "size": 318186
+                  "digest": "sha256:6492f580990f5d06467dd2968b2b7b226161a150a29c97b975843c60bb05bf6b",
+                  "size": 1447
                 },
                 {
-                  "digest": "sha256:f791d07cc1a2cf04657f811d5bc96c959aa090c32d7b839fb14e33696d60f159",
-                  "size": 300365
+                  "digest": "sha256:03e9c0557c38872862371a749a1cb3991207475c283d8a3798f37ac04e03a66e",
+                  "size": 318285
                 },
                 {
-                  "digest": "sha256:a5abaabb211f3024d9e377d03dfb2a01527ae3aa7dfa08cfa12c0b3f8b0a8a96",
+                  "digest": "sha256:6b3852bee56623ae1104129048a8ebc25d605827d0247c45fd7259660ac23c5e",
+                  "size": 401543
+                },
+                {
+                  "digest": "sha256:0431dd39fc71f7595d8b988b0ab4b44375867916046fbe5c8223f256fd353748",
+                  "size": 30067527
+                },
+                {
+                  "digest": "sha256:560b2c5094e43711f71da6ec54390b7b7ab4bb16be4deaa9a36821362aacd6ef",
+                  "size": 16798823
+                },
+                {
+                  "digest": "sha256:45bcadfa51a38db92448977438203237c3f88deed20cc5941662162962153ceb",
                   "size": 1293
                 },
                 {
-                  "digest": "sha256:283f902c62cef2f84a2626c6708b05ae3c8ad74ef7bb83de1b74194e7fb6a270",
-                  "size": 549702
+                  "digest": "sha256:63f984e94db0eeb7b9c4dbaf4094b46f05c3fcb72b86e15e38e9224a3df40473",
+                  "size": 1291
                 },
                 {
-                  "digest": "sha256:0f50ea53dd66ee2abe7a35f1f8c11279200222a66d4b643533fb72570afb06da",
-                  "size": 37624165
-                },
-                {
-                  "digest": "sha256:ec8176b0bb4f042f52082e8d25a1e342a522b27e04f91df53aef1080907fa0f7",
-                  "size": 17227764
-                },
-                {
-                  "digest": "sha256:e41fdcf88758aad55c1f38aa759e2ae31070979886f675725b65979c2b993953",
-                  "size": 1920
-                },
-                {
-                  "digest": "sha256:cfd21a135976d13992379f7b62e0251580495ca20f98b60aa5bc5683dc142b9f",
-                  "size": 27767436
-                },
-                {
-                  "digest": "sha256:7ca45a0037c331a458ec0889194708712d777ce46e61f4d08bf4f798134c6050",
-                  "size": 2722710
-                },
-                {
-                  "digest": "sha256:20f6c7d96cea5eaa89ce01e38002275376da17460f81bba1644e0235707d2346",
-                  "size": 1300
-                },
-                {
-                  "digest": "sha256:c8527640a0f61976fd8f76ee3ce4fcffbc6abdb8c8cfaedf719480cd706fa75b",
-                  "size": 1297
-                },
-                {
-                  "digest": "sha256:b668fb53df83a0a61a3e82d111e1106db05bac43c87c819a76c86b153ba02ade",
-                  "size": 1297
-                },
-                {
-                  "digest": "sha256:480db4b3a60a1b7e58fe3c4a1dd6ba8644562058962ca9a29c2e4e2532d67be4",
-                  "size": 1449
-                },
-                {
-                  "digest": "sha256:00dc732d14cc49f29acbd7718eb0b0fd04d4f40af340fd38de5d1dd86d77eae3",
-                  "size": 339863
-                },
-                {
-                  "digest": "sha256:d1da42e4bca3d356e5796caa051e581315832ccf7d21db664c2ef0863ad9dc00",
-                  "size": 417178
-                },
-                {
-                  "digest": "sha256:f5d36e2ac452a387c55d222fe7daa98aafedc7fbf8de1adc7e1364a9a7eb3e20",
-                  "size": 32720113
-                },
-                {
-                  "digest": "sha256:30b909a1a50e086d612f788e0a43a2dea2b32878af6f71cc74b4d0db36b6c20d",
-                  "size": 16798802
-                },
-                {
-                  "digest": "sha256:bb5f93e82261f4f15cd2208414c2940b84308d2f2a0fef26585c1ffea0804de9",
+                  "digest": "sha256:855182312d2bdc5e91bad8f7de966b6eb6a48362b986587a64b54c024388100c",
                   "size": 1298
                 },
                 {
-                  "digest": "sha256:857865ad3eca4da109d969134a9cab7225d9de49597914ae325d43661900f513",
-                  "size": 633401492
+                  "digest": "sha256:6897a04901ec162be0eabd7eb636b5ac50d6e37c880f1db618610f2d777b1ce6",
+                  "size": 643106423
                 },
                 {
                   "digest": "sha256:3cc21a1b754848d23f00aa65cb94ec34c9a5dc6028b3aada42039c824738d02f",
@@ -7986,144 +8015,53 @@
               "simpleTags": [
                 "windowsservercore-ltsc2025-helix-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1ccf55d7b87f89080bc41fb89618acb1580412541094a4137b81e7a5f45019a6",
-              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:b066ad35b01f928ef9ea7d8551e3bd8835749e7479e107beaa2655bebbcb6408",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9209e1ec7f3980075d7c0bcfea105b3eb5744bf0cee7dff6e591e9129514b0da",
+              "baseImageDigest": "mcr.microsoft.com/windows/servercore@sha256:b96a2794665fc1d9ebb068b4434827f0f712ad10b67ffba964911a366e7a8e2d",
               "osType": "Windows",
               "osVersion": "windowsservercore-ltsc2025",
               "architecture": "amd64",
-              "created": "2026-06-01T05:26:09.8734816Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/cf634bbfb902f5f7a88b520f3aa589bc4a2a2eb5/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile",
+              "created": "2026-06-24T17:03:24.0701757Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/268fe29b6ed8e993e5a5154ea533bf8c70b1a924/src/windowsservercore/ltsc2025/helix/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:5af0baa0fdcca9567e339b56127be41e652856846b160138c685c4e27036ab51",
-                  "size": 1417
+                  "digest": "sha256:07fcd93ff5a280c6bde23e7a5cb346a003bb302fef9ab0a07ab2ad3df275888c",
+                  "size": 1264
                 },
                 {
-                  "digest": "sha256:a3679ded79517249b18f80bc44fe8cb8204ceab70d17b596b50cd0810cd9ad04",
-                  "size": 390596
+                  "digest": "sha256:7e91a9d9fbdabb6672f42533c60db0d8258ac785cf92061893ed4e8d35ca5de8",
+                  "size": 1420
                 },
                 {
-                  "digest": "sha256:9cdef805b20c28c3403b20a856bad9ab302d936f9a77113e0567a16c4234dc68",
-                  "size": 333354
+                  "digest": "sha256:e809d8ce4a9578891dad48ecd52e32f0a3cfcbd12c10e3a7126406542963f2df",
+                  "size": 383490
                 },
                 {
-                  "digest": "sha256:17dfab5bc679bd7560e48b18774bfdffd126becb41ab6dbd84540fd3d0d3b914",
-                  "size": 32743330
+                  "digest": "sha256:e9d10a0e28a6692ebe82896abff479ba26e3032487e606968cbf54f3513385b4",
+                  "size": 302994
                 },
                 {
-                  "digest": "sha256:72753bfa69f6f4744f41c114ad8b155afd15164e08a2f3dfdaf5d5e13eb7ed80",
-                  "size": 16806009
+                  "digest": "sha256:747dabbd0a77aa8eb103fc6c56187ddce7a88f0684afb02a382dd7a65cb073b6",
+                  "size": 30093675
                 },
                 {
-                  "digest": "sha256:b1197ed30a7abf7f106fd0eb1401c854548df4b57fa5766e48511ee313f70658",
-                  "size": 1296
+                  "digest": "sha256:abcc52c531d1318f1f8a7bfed85906423a9bb214cecc6876fb1c8a86e539e704",
+                  "size": 16806578
                 },
                 {
-                  "digest": "sha256:f787ad06f38db673c3d304f21c09a82ff9a1ced32062515ea52fdb0383457b24",
-                  "size": 682882530
+                  "digest": "sha256:e16654068ddec1785d754d650f1a75190695451faa9fe2564f88ec9f6306f976",
+                  "size": 1264
                 },
                 {
-                  "digest": "sha256:0938cf51b672b81c9804d1d5f0c57031c931f41b279270e84820c63642d6a3bd",
-                  "size": 1523059351
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "platforms": [
-            {
-              "dockerfile": "src/windowsservercore/ltsc2025/helix/webassembly-net8/amd64/Dockerfile",
-              "simpleTags": [
-                "windowsservercore-ltsc2025-helix-webassembly-net8-amd64"
-              ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:629de7b2ae2fc23cba9623282de194c8107463c43e66790bf4314289b57c9498",
-              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1ccf55d7b87f89080bc41fb89618acb1580412541094a4137b81e7a5f45019a6",
-              "osType": "Windows",
-              "osVersion": "windowsservercore-ltsc2025",
-              "architecture": "amd64",
-              "created": "2026-06-01T05:37:13.3613037Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/13bb625f484ea769094f1f4833991471eae50cd1/src/windowsservercore/ltsc2025/helix/webassembly-net8/amd64/Dockerfile",
-              "layers": [
-                {
-                  "digest": "sha256:76ed173cd0f7c6e5fd80850ff521c5377a145e0a707da5f6ca0f637aabbebc6d",
-                  "size": 262873
+                  "digest": "sha256:d058d76192fe54cbbaaa0624eb39db881e6bec863cc1fd19e5b7a863dd70fa65",
+                  "size": 1287
                 },
                 {
-                  "digest": "sha256:d214e7e2a2a5af56f859ca80bfa0308f09ac57993665f55eac1af343840c4109",
-                  "size": 1301
-                },
-                {
-                  "digest": "sha256:95ddeece40037cd721c4fa375947db7d2b1524f1717e43e437ae66dd65c636d4",
-                  "size": 549656
-                },
-                {
-                  "digest": "sha256:facc074393eed7ee31ee3bef07ab89dbf0ce755400ef1710eb0d358f78f53cd0",
-                  "size": 37633594
-                },
-                {
-                  "digest": "sha256:98e53129968bab55682987702286dfbb215d89b8740dd6a055d0a360da8b473b",
-                  "size": 17227633
-                },
-                {
-                  "digest": "sha256:6f240b1ee4afdaa25b6568b30bb09a9d21776effd466ca2ae80b66956404eea0",
-                  "size": 2024
-                },
-                {
-                  "digest": "sha256:cf93ad6d902a9acc65d58344e4c1b199801be4eba1ae44305163812ee72559b1",
-                  "size": 564016505
-                },
-                {
-                  "digest": "sha256:fc2765d8bd203ae6907a03eacc971ea977018b29210f216a28c3517c86604cf9",
-                  "size": 43130254
-                },
-                {
-                  "digest": "sha256:88feed22afa6300e37f1ac62596d311fd431bbc095ff293fd6e152a843ce9be2",
-                  "size": 2705740
-                },
-                {
-                  "digest": "sha256:46d0aa636dcb7fb255815621740d116e4dba6d2123cd721c98e64c4a1048320d",
+                  "digest": "sha256:e3d350e72ebb5403b50df7cc840bb2c1058d662e431999614d3aeafadb6a28fd",
                   "size": 1290
                 },
                 {
-                  "digest": "sha256:21d09b0c526d0cc04cee70585a58d3de3ed631f8ebfa88f8257fb4e40b87519a",
-                  "size": 1286
-                },
-                {
-                  "digest": "sha256:be3db7ecd42342bfb16633068659b45aeabad9cf89b6cc7644fddc07697d0cdb",
-                  "size": 1269
-                },
-                {
-                  "digest": "sha256:0408dd366a930cfb11f6e9d6ae1a1ab1362edae7d9a9372aa16ed8fdefc6d8d0",
-                  "size": 1262
-                },
-                {
-                  "digest": "sha256:5af0baa0fdcca9567e339b56127be41e652856846b160138c685c4e27036ab51",
-                  "size": 1417
-                },
-                {
-                  "digest": "sha256:a3679ded79517249b18f80bc44fe8cb8204ceab70d17b596b50cd0810cd9ad04",
-                  "size": 390596
-                },
-                {
-                  "digest": "sha256:9cdef805b20c28c3403b20a856bad9ab302d936f9a77113e0567a16c4234dc68",
-                  "size": 333354
-                },
-                {
-                  "digest": "sha256:17dfab5bc679bd7560e48b18774bfdffd126becb41ab6dbd84540fd3d0d3b914",
-                  "size": 32743330
-                },
-                {
-                  "digest": "sha256:72753bfa69f6f4744f41c114ad8b155afd15164e08a2f3dfdaf5d5e13eb7ed80",
-                  "size": 16806009
-                },
-                {
-                  "digest": "sha256:b1197ed30a7abf7f106fd0eb1401c854548df4b57fa5766e48511ee313f70658",
-                  "size": 1296
-                },
-                {
-                  "digest": "sha256:f787ad06f38db673c3d304f21c09a82ff9a1ced32062515ea52fdb0383457b24",
-                  "size": 682882530
+                  "digest": "sha256:2ee71d57b2226db82d002abc39a97b7dd144f007db435566364a0285bf115b83",
+                  "size": 756083682
                 },
                 {
                   "digest": "sha256:0938cf51b672b81c9804d1d5f0c57031c931f41b279270e84820c63642d6a3bd",
@@ -8140,97 +8078,101 @@
               "simpleTags": [
                 "windowsservercore-ltsc2025-helix-webassembly-amd64"
               ],
-              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:72fc18c4b0585933cf3696aa0c5995af74b21909e2832aa7d260e08bb7778fb1",
-              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:1ccf55d7b87f89080bc41fb89618acb1580412541094a4137b81e7a5f45019a6",
+              "digest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:57861fa777455c4d8aaae1fea5f623c43276ba342caf451dafe38becdaf62a15",
+              "baseImageDigest": "mcr.microsoft.com/dotnet-buildtools/prereqs@sha256:9209e1ec7f3980075d7c0bcfea105b3eb5744bf0cee7dff6e591e9129514b0da",
               "osType": "Windows",
               "osVersion": "windowsservercore-ltsc2025",
               "architecture": "amd64",
-              "created": "2026-06-01T05:29:32.8748291Z",
-              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/13bb625f484ea769094f1f4833991471eae50cd1/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile",
+              "created": "2026-06-24T17:06:40.7281036Z",
+              "commitUrl": "https://github.com/dotnet/dotnet-buildtools-prereqs-docker/blob/09f312cd5a1a92ae4058f78e933a16c67cce6606/src/windowsservercore/ltsc2025/helix/webassembly/amd64/Dockerfile",
               "layers": [
                 {
-                  "digest": "sha256:50a6a8dfb10e146c43013fd3c4dae7ab9847fc15a4cb334366ba5564876172b5",
-                  "size": 14964223
+                  "digest": "sha256:c083bed7856cda43c9baeba133f0429b5b3df223a69ae03121185dc5a77c01a4",
+                  "size": 14934222
                 },
                 {
-                  "digest": "sha256:fb98b779568be29a8ce9660ed276c103d8f45d75f3c5c2e7c3b1657d9ae19c60",
-                  "size": 1320
+                  "digest": "sha256:af42b54207288189ba3830c0582f16bb546f5868c689aeea2a92ed69b135541d",
+                  "size": 1294
                 },
                 {
-                  "digest": "sha256:1e30954f10cdc77c8ca5c3d3f0cfa403cc098281f2d4693b5ed5150ca6c07473",
-                  "size": 323917
+                  "digest": "sha256:c278301e1bab0b22d0d096351db689e2850a82feb7725d8080b5029a858cf2e5",
+                  "size": 280624
                 },
                 {
-                  "digest": "sha256:8807de06239e16c297e47abedbd7b2bc10c43b037319e78f28ae21eeb51949b7",
-                  "size": 316015
+                  "digest": "sha256:8d77eb03b848077b9e8a34375f1732b3297d9965facc0f4d6ba6d066f26bc95c",
+                  "size": 353919
                 },
                 {
-                  "digest": "sha256:34d3955a27bc34dc8c5b8080c3555cc90bb3db3a6905220d3160c53baf6ea31a",
-                  "size": 1286
+                  "digest": "sha256:c0526b8fd25f0afc2ac59794c6b65cdcf744cb3cf284bca65f90430c27deb51d",
+                  "size": 1317
                 },
                 {
-                  "digest": "sha256:6874aff02ef71d3347f2e5842fdb93cdac938a07cac91221e61a95c72a3463c8",
-                  "size": 549733
+                  "digest": "sha256:468555cc752d28c7568ee3fb2a5617cd4d63cc9498a6162db292ce785616cd74",
+                  "size": 549711
                 },
                 {
-                  "digest": "sha256:a68d81df414c04aa1c53e276d294b9b2dfe3a116ae3063db08b310f2e85380d3",
-                  "size": 37634820
+                  "digest": "sha256:4763f9816805f0b5645099c451b6113d51c9947bfe4623d04abb6c8ab2f49a50",
+                  "size": 37650176
                 },
                 {
-                  "digest": "sha256:8da128fa103d41c9dddd9d21070353c040338333adeaec736806537ffa23acb7",
-                  "size": 17227692
+                  "digest": "sha256:8728d88898ad36b3c214a848d3ad98839bf70cab9441448e556fbabb38b8b2c8",
+                  "size": 17448436
                 },
                 {
-                  "digest": "sha256:f369c6bf27e71f4b3fde8a4f7b0cff32d8161ce6ec758ed23a66586424fe369e",
-                  "size": 2025
+                  "digest": "sha256:e2f75cb410ae0b528c4a6bf989e76d6d23151db46cbb487deb741728bdcde86e",
+                  "size": 2064
                 },
                 {
-                  "digest": "sha256:53e8ad94738ff3d542f8916b37af88114ff3e818f8518524fd5bcab6c1d9dc1b",
-                  "size": 43130143
+                  "digest": "sha256:b41c0269d529598bae186108dd87a26f72334ff69124e56f3e12398a92f45503",
+                  "size": 43129817
                 },
                 {
-                  "digest": "sha256:4a2ee41e8dfbce13d76d06d6846c12e9a34a2e4ebc47331669bc8d165a6db631",
-                  "size": 2705538
+                  "digest": "sha256:b631680de38c8af06a6a554d02a072fc4f68b0bd7d9beb01cd78e935d2c89e94",
+                  "size": 1291
                 },
                 {
-                  "digest": "sha256:6935b902ddbb80339718a2c42d990162acec2a3e521adcbe220817140542b670",
-                  "size": 1267
+                  "digest": "sha256:fb19d73bd20719c0c4dbfd180a80e6ba2f784641da22d359f00587d57907c771",
+                  "size": 1265
                 },
                 {
-                  "digest": "sha256:be3db7ecd42342bfb16633068659b45aeabad9cf89b6cc7644fddc07697d0cdb",
-                  "size": 1269
+                  "digest": "sha256:07fcd93ff5a280c6bde23e7a5cb346a003bb302fef9ab0a07ab2ad3df275888c",
+                  "size": 1264
                 },
                 {
-                  "digest": "sha256:0408dd366a930cfb11f6e9d6ae1a1ab1362edae7d9a9372aa16ed8fdefc6d8d0",
-                  "size": 1262
+                  "digest": "sha256:7e91a9d9fbdabb6672f42533c60db0d8258ac785cf92061893ed4e8d35ca5de8",
+                  "size": 1420
                 },
                 {
-                  "digest": "sha256:5af0baa0fdcca9567e339b56127be41e652856846b160138c685c4e27036ab51",
-                  "size": 1417
+                  "digest": "sha256:e809d8ce4a9578891dad48ecd52e32f0a3cfcbd12c10e3a7126406542963f2df",
+                  "size": 383490
                 },
                 {
-                  "digest": "sha256:a3679ded79517249b18f80bc44fe8cb8204ceab70d17b596b50cd0810cd9ad04",
-                  "size": 390596
+                  "digest": "sha256:e9d10a0e28a6692ebe82896abff479ba26e3032487e606968cbf54f3513385b4",
+                  "size": 302994
                 },
                 {
-                  "digest": "sha256:9cdef805b20c28c3403b20a856bad9ab302d936f9a77113e0567a16c4234dc68",
-                  "size": 333354
+                  "digest": "sha256:747dabbd0a77aa8eb103fc6c56187ddce7a88f0684afb02a382dd7a65cb073b6",
+                  "size": 30093675
                 },
                 {
-                  "digest": "sha256:17dfab5bc679bd7560e48b18774bfdffd126becb41ab6dbd84540fd3d0d3b914",
-                  "size": 32743330
+                  "digest": "sha256:abcc52c531d1318f1f8a7bfed85906423a9bb214cecc6876fb1c8a86e539e704",
+                  "size": 16806578
                 },
                 {
-                  "digest": "sha256:72753bfa69f6f4744f41c114ad8b155afd15164e08a2f3dfdaf5d5e13eb7ed80",
-                  "size": 16806009
+                  "digest": "sha256:e16654068ddec1785d754d650f1a75190695451faa9fe2564f88ec9f6306f976",
+                  "size": 1264
                 },
                 {
-                  "digest": "sha256:b1197ed30a7abf7f106fd0eb1401c854548df4b57fa5766e48511ee313f70658",
-                  "size": 1296
+                  "digest": "sha256:d058d76192fe54cbbaaa0624eb39db881e6bec863cc1fd19e5b7a863dd70fa65",
+                  "size": 1287
                 },
                 {
-                  "digest": "sha256:f787ad06f38db673c3d304f21c09a82ff9a1ced32062515ea52fdb0383457b24",
-                  "size": 682882530
+                  "digest": "sha256:e3d350e72ebb5403b50df7cc840bb2c1058d662e431999614d3aeafadb6a28fd",
+                  "size": 1290
+                },
+                {
+                  "digest": "sha256:2ee71d57b2226db82d002abc39a97b7dd144f007db435566364a0285bf115b83",
+                  "size": 756083682
                 },
                 {
                   "digest": "sha256:0938cf51b672b81c9804d1d5f0c57031c931f41b279270e84820c63642d6a3bd",


### PR DESCRIPTION
Based on https://dev.azure.com/dnceng/internal/_build/results?buildId=3007306&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=729bd3d3-63cd-5b66-6efd-ae98d0926964&l=120 which somehow got pushed but the branch didn't update to it